### PR TITLE
Add route groups and application-level middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,10 @@ make clean              # clean build artifacts + corral cache
 
 ### Public API
 
-Users interact with four types:
+Users interact with five types:
 
-- **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.). `serve()` consumes the Application, freezes routes into an immutable router, and starts listening.
+- **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.), `group()` for route groups, `add_middleware()` for app-level middleware. `serve()` consumes the Application, freezes routes into an immutable router, and starts listening.
+- **`RouteGroup`** (`class iso`): Groups routes under a shared prefix and optional middleware. Supports nesting via `group()`. Consumed by `Application.group()` or outer `RouteGroup.group()`.
 - **`Handler`** (`interface val`): Request handler. Receives `Context ref`, calls `ctx.respond()` to send a response. Partial (`?`) — errors without responding produce 500.
 - **`Middleware`** (`interface val`): Two-phase processor. `before` (partial) runs before the handler; `after` (not partial) runs after, in reverse order.
 - **`Context`** (`class ref`): Request context with route params, body, data map, and respond methods.
@@ -47,6 +48,7 @@ Users interact with four types:
 - **Build/lookup separation**: Mutable `_BuildNode ref` trees for construction, frozen into immutable `_TreeNode val` trees for lookup. Params built bottom-up as `val` arrays to avoid ref-to-val boundary issues in recover blocks.
 - **Static priority**: Static children checked before param child during lookup.
 - **Trailing slash normalization**: `/users/` and `/users` match the same route.
+- **Flatten at registration time**: Route groups are flattened when consumed by `group()`. Prefixes are joined and middleware arrays are concatenated at that point, so the router sees only flat routes with fully resolved paths and middleware chains.
 
 ## File Layout
 
@@ -59,6 +61,8 @@ hobby/
   handler.pony            - Handler interface (public)
   middleware.pony          - Middleware interface (public)
   application.pony        - Application class (public)
+  route_group.pony        - RouteGroup class (public)
+  _flatten.pony           - Path joining + middleware concatenation (internal)
   _connection.pony        - Connection actor (internal)
   _listener.pony          - Listener actor (internal)
   _router.pony            - Router + radix tree (internal)
@@ -68,6 +72,7 @@ hobby/
   _mort.pony              - _Unreachable primitive (internal)
   _test.pony              - Test runner
   _test_router.pony       - Router property-based + example tests
+  _test_route_group.pony  - Route group unit + property tests
   _test_integration.pony  - HTTP round-trip integration tests
 ```
 

--- a/docs/middleware-guide.md
+++ b/docs/middleware-guide.md
@@ -200,4 +200,4 @@ The `recover val ... end` block is necessary because array literals are `ref` by
 
 When a route has multiple middleware, they execute in array order during the forward phase and reverse order during the `after` phase. Order matters — put auth checks before permission checks, and logging outermost if you want it to run regardless.
 
-Middleware is per-route, not global. There is currently no built-in mechanism for applying middleware to all routes at once. To share middleware across routes, define the array once and pass it to each route registration.
+Middleware can also be applied at the group or application level. `RouteGroup` attaches middleware to all routes in the group, and `Application.add_middleware()` applies middleware to every route in the application. The execution order is: application middleware first, then group middleware, then per-route middleware. See the [route-groups example](../examples/route-groups/main.pony) for a complete demonstration.

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,7 @@ Starts an HTTP server with two routes: a static greeting at `/` and a parameteri
 ## [middleware](middleware/)
 
 Starts an HTTP server with public and protected routes. Demonstrates two middleware patterns: an auth middleware that short-circuits with 401 in the `before` phase when a token is missing, and a logging middleware that records requests in the `after` phase. Also shows the typed accessor convention for inter-middleware communication — `AuthData.user()` extracts domain types (`AuthenticatedUser` or `NotAuthenticated`) from the context data map, avoiding raw string-key lookups.
+
+## [route-groups](route-groups/)
+
+Starts an HTTP server with grouped routes sharing prefixes and middleware. Demonstrates application-level middleware (logging on every route), a `/api` group with auth middleware, and a nested `/api/admin` group that adds admin middleware on top. Shows the complete middleware composition order: application middleware runs first, then group middleware, then per-route middleware.

--- a/examples/route-groups/main.pony
+++ b/examples/route-groups/main.pony
@@ -1,0 +1,102 @@
+// in your code this `use` statement would be:
+// use hobby = "hobby"
+use hobby = "../../hobby"
+use stallion = "stallion"
+use lori = "lori"
+
+actor Main
+  """
+  Route groups example.
+
+  Demonstrates route grouping with shared prefixes and middleware:
+  - Application-level middleware (logging) runs on every route.
+  - A `/api` group with auth middleware protects its routes.
+  - A nested `/api/admin` group adds admin middleware on top of auth.
+  - Routes registered directly on the Application have no group middleware.
+
+  Routes:
+  - GET /              -> public, app middleware only
+  - GET /health        -> public, app middleware only
+  - GET /api/users     -> auth middleware
+  - GET /api/users/:id -> auth middleware
+  - GET /api/admin/dashboard -> auth + admin middleware
+
+  Try it:
+    curl http://localhost:8080/
+    curl http://localhost:8080/health
+    curl http://localhost:8080/api/users                         # 401
+    curl -H "Authorization: Bearer secret" http://localhost:8080/api/users
+    curl -H "Authorization: Bearer secret" http://localhost:8080/api/users/42
+    curl -H "Authorization: Bearer secret" http://localhost:8080/api/admin/dashboard
+  """
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+
+    let log_mw: Array[hobby.Middleware val] val =
+      recover val [as hobby.Middleware val: LogMiddleware(env.out)] end
+    let auth_mw: Array[hobby.Middleware val] val =
+      recover val [as hobby.Middleware val: AuthMiddleware] end
+    let admin_mw: Array[hobby.Middleware val] val =
+      recover val [as hobby.Middleware val: AdminMiddleware] end
+
+    hobby.Application
+      .>add_middleware(log_mw)
+      .>get("/", HelloHandler)
+      .>get("/health", HealthHandler)
+      .>group(
+        hobby.RouteGroup("/api" where middleware = auth_mw)
+          .>get("/users", UsersHandler)
+          .>get("/users/:id", UserHandler)
+          .>group(
+            hobby.RouteGroup("/admin" where middleware = admin_mw)
+              .>get("/dashboard", DashboardHandler)))
+      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+
+// --- Handlers ---
+
+primitive HelloHandler is hobby.Handler
+  fun apply(ctx: hobby.Context ref) =>
+    ctx.respond(stallion.StatusOK, "Hello from Hobby!")
+
+primitive HealthHandler is hobby.Handler
+  fun apply(ctx: hobby.Context ref) =>
+    ctx.respond(stallion.StatusOK, "OK")
+
+primitive UsersHandler is hobby.Handler
+  fun apply(ctx: hobby.Context ref) =>
+    ctx.respond(stallion.StatusOK, "User list")
+
+class val UserHandler is hobby.Handler
+  fun apply(ctx: hobby.Context ref) ? =>
+    let id = ctx.param("id")?
+    ctx.respond(stallion.StatusOK, "User " + id)
+
+primitive DashboardHandler is hobby.Handler
+  fun apply(ctx: hobby.Context ref) =>
+    ctx.respond(stallion.StatusOK, "Admin dashboard")
+
+// --- Middleware ---
+
+class val AuthMiddleware is hobby.Middleware
+  """Rejects requests without an Authorization header."""
+  fun before(ctx: hobby.Context ref) =>
+    match ctx.request.headers.get("authorization")
+    | let _: String => None
+    else
+      ctx.respond(stallion.StatusUnauthorized, "Unauthorized")
+    end
+
+primitive AdminMiddleware is hobby.Middleware
+  """Placeholder admin check — always passes."""
+  fun before(ctx: hobby.Context ref) => None
+
+class val LogMiddleware is hobby.Middleware
+  """Logs the request method and path after handling."""
+  let _out: OutStream
+  new val create(out: OutStream) => _out = out
+
+  fun before(ctx: hobby.Context ref) => None
+
+  fun after(ctx: hobby.Context ref) =>
+    _out.print(
+      ctx.request.method.string() + " " + ctx.request.uri.path)

--- a/hobby/_flatten.pony
+++ b/hobby/_flatten.pony
@@ -1,0 +1,65 @@
+primitive _JoinPath
+  """
+  Join a group prefix with a route path.
+
+  Strips any trailing slash from the prefix, then concatenates with the route
+  path (which always starts with `/`). If the prefix is empty, returns the
+  route path unchanged.
+
+  Examples: `("/api/", "/users")` -> `"/api/users"`,
+  `("/", "/health")` -> `"/health"`, `("", "/health")` -> `"/health"`.
+  """
+  fun apply(prefix: String, path: String): String =>
+    if prefix.size() == 0 then
+      return path
+    end
+    let trimmed = _TrimTrailingSlash(prefix)
+    if trimmed.size() == 0 then
+      // Prefix was just "/", return path as-is
+      path
+    else
+      trimmed + path
+    end
+
+primitive _TrimTrailingSlash
+  """Strip trailing slash from a string (unconditionally)."""
+  fun apply(s: String): String =>
+    try
+      if (s.size() > 0) and (s(s.size() - 1)? == '/') then
+        return s.trim(0, s.size() - 1)
+      end
+    else
+      _Unreachable()
+    end
+    s
+
+primitive _ConcatMiddleware
+  """
+  Concatenate two optional middleware arrays.
+
+  Returns a combined array with outer middleware first, then inner middleware.
+  When one side is `None`, returns the other directly (no allocation).
+  When both are `None`, returns `None`.
+  """
+  fun apply(
+    outer: (Array[Middleware val] val | None),
+    inner: (Array[Middleware val] val | None))
+    : (Array[Middleware val] val | None)
+  =>
+    match (outer, inner)
+    | (let o: Array[Middleware val] val, let i: Array[Middleware val] val) =>
+      recover val
+        let combined = Array[Middleware val](o.size() + i.size())
+        for mw in o.values() do
+          combined.push(mw)
+        end
+        for mw in i.values() do
+          combined.push(mw)
+        end
+        combined
+      end
+    | (let o: Array[Middleware val] val, None) => o
+    | (None, let i: Array[Middleware val] val) => i
+    else
+      None
+    end

--- a/hobby/_route_definition.pony
+++ b/hobby/_route_definition.pony
@@ -2,10 +2,11 @@ use stallion = "stallion"
 
 class val _RouteDefinition
   """
-  A route registration captured by `Application` before the router is built.
+  A route registration captured during route setup.
 
   Stores the HTTP method, path pattern, handler, and optional middleware chain.
-  `Application.serve()` iterates these definitions to populate the router.
+  Created by `Application` and `RouteGroup` route methods, then iterated by
+  `Application.serve()` to populate the router.
   """
   let method: stallion.Method
   let path: String

--- a/hobby/_test.pony
+++ b/hobby/_test.pony
@@ -6,4 +6,5 @@ actor \nodoc\ Main is TestList
 
   fun tag tests(test: PonyTest) =>
     _TestRouterList.tests(test)
+    _TestRouteGroupList.tests(test)
     _TestIntegrationList.tests(test)

--- a/hobby/_test_route_group.pony
+++ b/hobby/_test_route_group.pony
@@ -1,0 +1,465 @@
+use "pony_test"
+use "pony_check"
+use "collections"
+use stallion = "stallion"
+
+primitive \nodoc\ _TestRouteGroupList
+  fun tests(test: PonyTest) =>
+    // Property tests
+    test(Property1UnitTest[
+      (String, String)](_PropertyGroupPrefixMatches))
+    test(Property1UnitTest[
+      (USize, USize)](_PropertyGroupMiddlewarePreserved))
+    test(Property1UnitTest[
+      (String, String, String)](_PropertyNestedGroupPrefixOrder))
+    test(Property1UnitTest[
+      (String, String)](_PropertyGroupFlattenEquivalence))
+    // Example tests
+    test(_TestJoinPath)
+    test(_TestConcatMiddleware)
+    test(_TestNestedGroups)
+    test(_TestEmptyGroup)
+    test(_TestGroupNoMiddleware)
+    test(_TestAppMiddleware)
+    test(_TestAppMiddlewareAccumulation)
+    test(_TestAppMiddlewareWithGroups)
+    test(_TestMultipleGroupsOnApplication)
+
+// --- Test middleware ---
+
+primitive \nodoc\ _NoOpMiddleware is Middleware
+  fun before(ctx: Context ref) => None
+
+class \nodoc\ val _MarkerMiddleware is Middleware
+  let label: String
+  new val create(label': String) => label = label'
+  fun before(ctx: Context ref) => None
+
+// --- Generators ---
+
+primitive \nodoc\ _GenSegment
+  """Generate a single path segment: lowercase letters, length 1-10."""
+  fun apply(): Generator[String] =>
+    Generators.ascii(1, 10 where range = ASCIILetters)
+
+// --- Property tests ---
+
+class \nodoc\ iso _PropertyGroupPrefixMatches is
+  Property1[(String, String)]
+  """A route registered via a group matches at the joined path."""
+  fun name(): String => "route-group/property/prefix matches"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](_GenSegment(), _GenSegment())
+
+  fun property(sample: (String, String), h: PropertyHelper) =>
+    (let prefix_seg, let route_seg) = sample
+    let prefix: String val = "/" + prefix_seg
+    let path: String val = "/" + route_seg
+    let joined = _JoinPath(prefix, path)
+
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, joined, _NoOpHandler, None)
+    let router = builder.build()
+    match router.lookup(stallion.GET, joined)
+    | let _: _RouteMatch => None
+    else
+      h.fail("expected match at " + joined)
+    end
+
+class \nodoc\ iso _PropertyGroupMiddlewarePreserved is
+  Property1[(USize, USize)]
+  """Concatenated middleware has size = sum of input sizes."""
+  fun name(): String => "route-group/property/middleware preserved"
+
+  fun gen(): Generator[(USize, USize)] =>
+    Generators.zip2[USize, USize](
+      Generators.usize(0, 5),
+      Generators.usize(0, 5))
+
+  fun property(sample: (USize, USize), h: PropertyHelper) =>
+    (let group_count, let route_count) = sample
+    let group_mw: (Array[Middleware val] val | None) =
+      if group_count > 0 then
+        recover val
+          let a = Array[Middleware val](group_count)
+          var i: USize = 0
+          while i < group_count do
+            a.push(_NoOpMiddleware)
+            i = i + 1
+          end
+          a
+        end
+      else
+        None
+      end
+    let route_mw: (Array[Middleware val] val | None) =
+      if route_count > 0 then
+        recover val
+          let a = Array[Middleware val](route_count)
+          var i: USize = 0
+          while i < route_count do
+            a.push(_NoOpMiddleware)
+            i = i + 1
+          end
+          a
+        end
+      else
+        None
+      end
+    let result = _ConcatMiddleware(group_mw, route_mw)
+    let expected = group_count + route_count
+    match result
+    | let a: Array[Middleware val] val =>
+      h.assert_eq[USize](expected, a.size())
+    else
+      h.assert_eq[USize](0, expected)
+    end
+
+class \nodoc\ iso _PropertyNestedGroupPrefixOrder is
+  Property1[(String, String, String)]
+  """Nested group paths join as outer + inner + route."""
+  fun name(): String => "route-group/property/nested prefix order"
+
+  fun gen(): Generator[(String, String, String)] =>
+    Generators.zip3[String, String, String](
+      _GenSegment(), _GenSegment(), _GenSegment())
+
+  fun property(sample: (String, String, String), h: PropertyHelper) =>
+    (let outer_seg, let inner_seg, let route_seg) = sample
+    let joined: String val =
+      "/" + outer_seg + "/" + inner_seg + "/" + route_seg
+
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, joined, _NoOpHandler, None)
+    let router = builder.build()
+    match router.lookup(stallion.GET, joined)
+    | let _: _RouteMatch => None
+    else
+      h.fail("expected match at " + joined)
+    end
+
+class \nodoc\ iso _PropertyGroupFlattenEquivalence is
+  Property1[(String, String)]
+  """Flattened group route matches the same as a manually built route."""
+  fun name(): String => "route-group/property/flatten equivalence"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](_GenSegment(), _GenSegment())
+
+  fun property(sample: (String, String), h: PropertyHelper) =>
+    (let prefix_seg, let route_seg) = sample
+    let prefix: String val = "/" + prefix_seg
+    let path: String val = "/" + route_seg
+    let joined = _JoinPath(prefix, path)
+
+    // Build via JoinPath + RouterBuilder
+    let builder1 = _RouterBuilder
+    builder1.add(stallion.GET, joined, _NoOpHandler, None)
+    let router1 = builder1.build()
+
+    // Build via manual string concatenation
+    let manual: String val = prefix + path
+    let builder2 = _RouterBuilder
+    builder2.add(stallion.GET, manual, _NoOpHandler, None)
+    let router2 = builder2.build()
+
+    let r1_matches = router1.lookup(stallion.GET, joined) isnt None
+    let r2_matches = router2.lookup(stallion.GET, joined) isnt None
+    h.assert_eq[Bool](r1_matches, r2_matches)
+
+// --- Example-based tests ---
+
+class \nodoc\ iso _TestJoinPath is UnitTest
+  """_JoinPath handles various prefix/path combinations."""
+  fun name(): String => "route-group/join path"
+
+  fun apply(h: TestHelper) =>
+    // Normal case
+    h.assert_eq[String]("/api/users", _JoinPath("/api", "/users"))
+    // Trailing slash on prefix
+    h.assert_eq[String]("/api/users", _JoinPath("/api/", "/users"))
+    // Root prefix
+    h.assert_eq[String]("/health", _JoinPath("/", "/health"))
+    // Empty prefix
+    h.assert_eq[String]("/health", _JoinPath("", "/health"))
+    // Root group with root route
+    h.assert_eq[String]("/", _JoinPath("/", "/"))
+    // Multi-segment prefix
+    h.assert_eq[String]("/api/v1/users",
+      _JoinPath("/api/v1", "/users"))
+    // Multi-segment prefix with trailing slash
+    h.assert_eq[String]("/api/v1/users",
+      _JoinPath("/api/v1/", "/users"))
+
+class \nodoc\ iso _TestConcatMiddleware is UnitTest
+  """_ConcatMiddleware combines middleware arrays correctly."""
+  fun name(): String => "route-group/concat middleware"
+
+  fun apply(h: TestHelper) =>
+    let mw1 = _MarkerMiddleware("a")
+    let mw2 = _MarkerMiddleware("b")
+    let outer: Array[Middleware val] val =
+      recover val [as Middleware val: mw1] end
+    let inner: Array[Middleware val] val =
+      recover val [as Middleware val: mw2] end
+
+    // Both non-None
+    match _ConcatMiddleware(outer, inner)
+    | let a: Array[Middleware val] val =>
+      h.assert_eq[USize](2, a.size())
+      try
+        h.assert_is[Middleware](mw1, a(0)?)
+        h.assert_is[Middleware](mw2, a(1)?)
+      else
+        h.fail("middleware identity mismatch")
+      end
+    else
+      h.fail("expected combined array")
+    end
+
+    // Outer only
+    match _ConcatMiddleware(outer, None)
+    | let a: Array[Middleware val] val =>
+      h.assert_eq[USize](1, a.size())
+    else
+      h.fail("expected outer array")
+    end
+
+    // Inner only
+    match _ConcatMiddleware(None, inner)
+    | let a: Array[Middleware val] val =>
+      h.assert_eq[USize](1, a.size())
+    else
+      h.fail("expected inner array")
+    end
+
+    // Both None
+    match _ConcatMiddleware(None, None)
+    | let _: Array[Middleware val] val =>
+      h.fail("expected None")
+    end
+
+class \nodoc\ iso _TestNestedGroups is UnitTest
+  """Two levels of nesting produce correct path and middleware order."""
+  fun name(): String => "route-group/nested groups"
+
+  fun apply(h: TestHelper) =>
+    let outer_mw = _MarkerMiddleware("outer")
+    let inner_mw = _MarkerMiddleware("inner")
+    let route_mw = _MarkerMiddleware("route")
+
+    let outer_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: outer_mw] end
+    let inner_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: inner_mw] end
+    let route_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: route_mw] end
+
+    // Build inner group
+    let inner = RouteGroup("/admin" where middleware = inner_mw_arr)
+    inner.get("/dashboard", _NoOpHandler where middleware = route_mw_arr)
+
+    // Build outer group and nest inner
+    let outer = RouteGroup("/api" where middleware = outer_mw_arr)
+    outer.group(consume inner)
+
+    // Flatten into target (consume iso to ref for box method call)
+    let target = Array[_RouteDefinition]
+    let outer_ref: RouteGroup ref = consume outer
+    outer_ref._flatten_into(target)
+
+    h.assert_eq[USize](1, target.size())
+    try
+      let r = target(0)?
+      h.assert_eq[String]("/api/admin/dashboard", r.path)
+      match r.middleware
+      | let mw: Array[Middleware val] val =>
+        h.assert_eq[USize](3, mw.size())
+        h.assert_is[Middleware](outer_mw, mw(0)?)
+        h.assert_is[Middleware](inner_mw, mw(1)?)
+        h.assert_is[Middleware](route_mw, mw(2)?)
+      else
+        h.fail("expected middleware array")
+      end
+    else
+      h.fail("expected one route")
+    end
+
+class \nodoc\ iso _TestEmptyGroup is UnitTest
+  """An empty group flattens zero routes."""
+  fun name(): String => "route-group/empty group"
+
+  fun apply(h: TestHelper) =>
+    let g = RouteGroup("/api")
+    let target = Array[_RouteDefinition]
+    let g_ref: RouteGroup ref = consume g
+    g_ref._flatten_into(target)
+    h.assert_eq[USize](0, target.size())
+
+class \nodoc\ iso _TestGroupNoMiddleware is UnitTest
+  """A group with prefix only preserves route middleware unchanged."""
+  fun name(): String => "route-group/no middleware"
+
+  fun apply(h: TestHelper) =>
+    let route_mw = _MarkerMiddleware("route")
+    let route_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: route_mw] end
+
+    let g = RouteGroup("/api")
+    g.get("/users", _NoOpHandler where middleware = route_mw_arr)
+
+    let target = Array[_RouteDefinition]
+    let g_ref: RouteGroup ref = consume g
+    g_ref._flatten_into(target)
+
+    h.assert_eq[USize](1, target.size())
+    try
+      let r = target(0)?
+      h.assert_eq[String]("/api/users", r.path)
+      match r.middleware
+      | let mw: Array[Middleware val] val =>
+        h.assert_eq[USize](1, mw.size())
+        h.assert_is[Middleware](route_mw, mw(0)?)
+      else
+        h.fail("expected middleware array")
+      end
+    else
+      h.fail("expected one route")
+    end
+
+class \nodoc\ iso _TestAppMiddleware is UnitTest
+  """Application middleware is prepended to every route's middleware."""
+  fun name(): String => "route-group/app middleware"
+
+  fun apply(h: TestHelper) =>
+    let app_mw = _MarkerMiddleware("app")
+    let route_mw = _MarkerMiddleware("route")
+
+    let app_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: app_mw] end
+    let route_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: route_mw] end
+
+    // Simulate what serve() does: ConcatMiddleware(app_mw, route_mw)
+    match _ConcatMiddleware(app_mw_arr, route_mw_arr)
+    | let combined: Array[Middleware val] val =>
+      h.assert_eq[USize](2, combined.size())
+      try
+        h.assert_is[Middleware](app_mw, combined(0)?)
+        h.assert_is[Middleware](route_mw, combined(1)?)
+      else
+        h.fail("middleware identity mismatch")
+      end
+    else
+      h.fail("expected combined array")
+    end
+
+    // Route with no middleware gets app middleware only
+    match _ConcatMiddleware(app_mw_arr, None)
+    | let combined: Array[Middleware val] val =>
+      h.assert_eq[USize](1, combined.size())
+      try
+        h.assert_is[Middleware](app_mw, combined(0)?)
+      else
+        h.fail("middleware identity mismatch")
+      end
+    else
+      h.fail("expected app middleware array")
+    end
+
+class \nodoc\ iso _TestAppMiddlewareAccumulation is UnitTest
+  """Multiple middleware() calls accumulate in order."""
+  fun name(): String => "route-group/app middleware accumulation"
+
+  fun apply(h: TestHelper) =>
+    let mw1 = _MarkerMiddleware("first")
+    let mw2 = _MarkerMiddleware("second")
+
+    let arr1: Array[Middleware val] val =
+      recover val [as Middleware val: mw1] end
+    let arr2: Array[Middleware val] val =
+      recover val [as Middleware val: mw2] end
+
+    // Simulate accumulation: push both into a single array, then build val
+    let accumulated: Array[Middleware val] iso =
+      recover iso Array[Middleware val] end
+    for m in arr1.values() do
+      accumulated.push(m)
+    end
+    for m in arr2.values() do
+      accumulated.push(m)
+    end
+    let result: Array[Middleware val] val = consume accumulated
+
+    h.assert_eq[USize](2, result.size())
+    try
+      h.assert_is[Middleware](mw1, result(0)?)
+      h.assert_is[Middleware](mw2, result(1)?)
+    else
+      h.fail("middleware order mismatch")
+    end
+
+class \nodoc\ iso _TestAppMiddlewareWithGroups is UnitTest
+  """App middleware + group middleware + route middleware in correct order."""
+  fun name(): String => "route-group/app middleware with groups"
+
+  fun apply(h: TestHelper) =>
+    let app_mw = _MarkerMiddleware("app")
+    let group_mw = _MarkerMiddleware("group")
+    let route_mw = _MarkerMiddleware("route")
+
+    let app_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: app_mw] end
+    let group_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: group_mw] end
+    let route_mw_arr: Array[Middleware val] val =
+      recover val [as Middleware val: route_mw] end
+
+    // Group flattening: concat group_mw + route_mw
+    let group_combined = _ConcatMiddleware(group_mw_arr, route_mw_arr)
+
+    // App serve: concat app_mw + group_combined
+    match _ConcatMiddleware(app_mw_arr, group_combined)
+    | let combined: Array[Middleware val] val =>
+      h.assert_eq[USize](3, combined.size())
+      try
+        h.assert_is[Middleware](app_mw, combined(0)?)
+        h.assert_is[Middleware](group_mw, combined(1)?)
+        h.assert_is[Middleware](route_mw, combined(2)?)
+      else
+        h.fail("middleware order mismatch")
+      end
+    else
+      h.fail("expected combined array")
+    end
+
+class \nodoc\ iso _TestMultipleGroupsOnApplication is UnitTest
+  """Two separate groups flatten independently into application routes."""
+  fun name(): String => "route-group/multiple groups on application"
+
+  fun apply(h: TestHelper) =>
+    let h1 = _TestMarkerHandler("api")
+    let h2 = _TestMarkerHandler("admin")
+
+    let g1 = RouteGroup("/api")
+    g1.get("/users", h1)
+
+    let g2 = RouteGroup("/admin")
+    g2.get("/dashboard", h2)
+
+    let target = Array[_RouteDefinition]
+    let g1_ref: RouteGroup ref = consume g1
+    g1_ref._flatten_into(target)
+    let g2_ref: RouteGroup ref = consume g2
+    g2_ref._flatten_into(target)
+
+    h.assert_eq[USize](2, target.size())
+    try
+      h.assert_eq[String]("/api/users", target(0)?.path)
+      h.assert_is[Handler](h1, target(0)?.handler)
+      h.assert_eq[String]("/admin/dashboard", target(1)?.path)
+      h.assert_is[Handler](h2, target(1)?.handler)
+    else
+      h.fail("expected two routes")
+    end

--- a/hobby/application.pony
+++ b/hobby/application.pony
@@ -6,7 +6,7 @@ class iso Application
   The public API for the Hobby web framework.
 
   Register routes via `.>` method chaining (`get`, `post`, etc.), then call
-  `serve()` to freeze the routes and start listening for connections.
+  `serve()` to freeze the routes and start listening.
 
   ```pony
   use hobby = "hobby"
@@ -29,9 +29,11 @@ class iso Application
   the routes.
   """
   embed _routes: Array[_RouteDefinition]
+  embed _app_middleware: Array[Middleware val]
 
   new iso create() =>
     _routes = Array[_RouteDefinition]
+    _app_middleware = Array[Middleware val]
 
   fun ref get(path: String, handler: Handler,
     middleware: (Array[Middleware val] val | None) = None)
@@ -81,6 +83,28 @@ class iso Application
     """Register a route with an arbitrary HTTP method."""
     _routes.push(_RouteDefinition(method, path, handler, middleware))
 
+  fun ref add_middleware(middleware: Array[Middleware val] val) =>
+    """
+    Add application-level middleware that runs before every route's middleware.
+
+    Can be called multiple times — middleware accumulates in registration order.
+    Application middleware runs before group middleware, which runs before
+    per-route middleware.
+    """
+    for m in middleware.values() do
+      _app_middleware.push(m)
+    end
+
+  fun ref group(g: RouteGroup iso) =>
+    """
+    Consume a route group, flattening its routes into this application.
+
+    The group's prefix and middleware are applied to each of its routes. The
+    group is consumed — no further registration on it is possible.
+    """
+    let g_ref: RouteGroup ref = consume g
+    g_ref._flatten_into(_routes)
+
   fun iso serve(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
     out: OutStream)
   =>
@@ -91,9 +115,24 @@ class iso Application
     after this call.
     """
     let self: Application ref = consume this
+
+    // Build app-level middleware as a val array (or None if empty)
+    let app_mw: (Array[Middleware val] val | None) =
+      if self._app_middleware.size() > 0 then
+        let mw_iso: Array[Middleware val] iso =
+          recover iso Array[Middleware val] end
+        for m in self._app_middleware.values() do
+          mw_iso.push(m)
+        end
+        consume mw_iso
+      else
+        None
+      end
+
     let builder = _RouterBuilder
     for r in self._routes.values() do
-      builder.add(r.method, r.path, r.handler, r.middleware)
+      let combined_mw = _ConcatMiddleware(app_mw, r.middleware)
+      builder.add(r.method, r.path, r.handler, combined_mw)
     end
     let router: _Router val = builder.build()
     _Listener(auth, config, router, out)

--- a/hobby/route_group.pony
+++ b/hobby/route_group.pony
@@ -1,0 +1,107 @@
+use stallion = "stallion"
+
+class iso RouteGroup
+  """
+  A group of routes sharing a common path prefix and optional middleware.
+
+  Route groups let you factor out repeated prefixes and middleware instead of
+  attaching them to every route individually. Groups can be nested — inner
+  groups inherit the outer group's prefix and middleware, with the outer
+  middleware running first.
+
+  ```pony
+  let api = hobby.RouteGroup("/api" where middleware = auth_mw)
+  api.>get("/users", UsersHandler)
+  api.>get("/users/:id", UserHandler)
+  app.>group(consume api)
+  ```
+
+  Route methods are `fun ref` — automatic receiver recovery allows calling
+  them on an `iso` receiver since all arguments are `val`. Use `.>` to chain
+  route calls. Pass the group to `Application.group()` or an outer
+  `RouteGroup.group()` when done — this consumes the group and flattens its
+  routes.
+  """
+  let _prefix: String
+  let _middleware: (Array[Middleware val] val | None)
+  embed _routes: Array[_RouteDefinition]
+
+  new iso create(prefix: String,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """
+    Create a route group with a path prefix and optional middleware.
+
+    The prefix is prepended to every route path in the group. Middleware, if
+    provided, runs before each route's own middleware.
+    """
+    _prefix = prefix
+    _middleware = middleware
+    _routes = Array[_RouteDefinition]
+
+  fun ref get(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a GET route."""
+    _routes.push(_RouteDefinition(stallion.GET, path, handler, middleware))
+
+  fun ref post(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a POST route."""
+    _routes.push(_RouteDefinition(stallion.POST, path, handler, middleware))
+
+  fun ref put(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a PUT route."""
+    _routes.push(_RouteDefinition(stallion.PUT, path, handler, middleware))
+
+  fun ref delete(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a DELETE route."""
+    _routes.push(_RouteDefinition(stallion.DELETE, path, handler, middleware))
+
+  fun ref patch(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a PATCH route."""
+    _routes.push(_RouteDefinition(stallion.PATCH, path, handler, middleware))
+
+  fun ref head(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a HEAD route."""
+    _routes.push(_RouteDefinition(stallion.HEAD, path, handler, middleware))
+
+  fun ref options(path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register an OPTIONS route."""
+    _routes.push(_RouteDefinition(stallion.OPTIONS, path, handler, middleware))
+
+  fun ref route(method: stallion.Method, path: String, handler: Handler,
+    middleware: (Array[Middleware val] val | None) = None)
+  =>
+    """Register a route with an arbitrary HTTP method."""
+    _routes.push(_RouteDefinition(method, path, handler, middleware))
+
+  fun ref group(inner: RouteGroup iso) =>
+    """
+    Consume a nested route group, flattening its routes into this group.
+
+    The inner group's prefix is appended to this group's prefix, and the inner
+    group's middleware is appended after this group's middleware. The inner
+    group is consumed — no further registration on it is possible.
+    """
+    let inner_ref: RouteGroup ref = consume inner
+    inner_ref._flatten_into(_routes)
+
+  fun box _flatten_into(target: Array[_RouteDefinition] ref) =>
+    for r in _routes.values() do
+      let joined_path = _JoinPath(_prefix, r.path)
+      let combined_mw = _ConcatMiddleware(_middleware, r.middleware)
+      target.push(_RouteDefinition(r.method, joined_path, r.handler,
+        combined_mw))
+    end


### PR DESCRIPTION
Route groups let users express shared middleware and path prefixes once for a set of routes, rather than repeating them on every registration call.

- `RouteGroup` groups routes under a shared path prefix and optional middleware. Groups can be nested — inner groups inherit the outer group's prefix and middleware.
- `Application.add_middleware()` applies middleware to every route in the application, running before group and per-route middleware.
- Groups flatten at registration time. The router, chain runner, and connection actor are unchanged.
- The method is named `add_middleware()` rather than `middleware()` because Pony doesn't allow a method name to collide with a parameter name in the same class, and the existing route methods already use `middleware` as a named parameter.

Design: #7