### PR TITLE
Add streaming response support

### DIFF
--- a/.release-notes/add-streaming-response-support.md
+++ b/.release-notes/add-streaming-response-support.md
@@ -1,0 +1,12 @@
+## Add streaming response support
+
+Handlers can now send chunked HTTP responses by calling `ctx.start_streaming()`:
+
+```pony
+primitive StreamHandler is Handler
+  fun apply(ctx: Context ref) =>
+    let sender = ctx.start_streaming(stallion.StatusOK)
+    MyProducer(sender)
+```
+
+`start_streaming()` returns a `StreamSender tag` — pass it to a producer actor that calls `send_chunk()` to send data and `finish()` to close the stream. If the handler errors after starting a stream, the framework automatically sends the terminal chunk to prevent a hung connection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Users interact with five types:
 - **`Handler`** (`interface val`): Request handler. Receives `Context ref`, calls `ctx.respond()` to send a response. Partial (`?`) — errors without responding produce 500.
 - **`Middleware`** (`interface val`): Two-phase processor. `before` (partial) runs before the handler; `after` (not partial) runs after, in reverse order.
 - **`Context`** (`class ref`): Request context with route params, body, data map, and respond methods.
+- **`StreamSender`** (`interface tag`): Streaming response sender. Returned by `Context.start_streaming()`. Receives `send_chunk()` and `finish()` behavior calls from producer actors.
 
 ### Internal layers
 
@@ -49,6 +50,8 @@ Users interact with five types:
 - **Static priority**: Static children checked before param child during lookup.
 - **Trailing slash normalization**: `/users/` and `/users` match the same route.
 - **Flatten at registration time**: Route groups are flattened when consumed by `group()`. Prefixes are joined and middleware arrays are concatenated at that point, so the router sees only flat routes with fully resolved paths and middleware chains.
+- **StreamSender is _Connection**: `_Connection` structurally matches `StreamSender` by having `send_chunk` and `finish` behaviors. No wrapper actor. Users interact through `StreamSender tag`; `_Connection` is package-private.
+- **Streaming error cleanup**: `_ChainRunner` detects handler error + streaming mode and calls `_finish_streaming()` to terminate abandoned streams.
 
 ## File Layout
 
@@ -59,6 +62,7 @@ hobby/
   hobby.pony              - Package docstring
   context.pony            - Context class (public)
   handler.pony            - Handler interface (public)
+  stream_sender.pony      - StreamSender interface (public)
   middleware.pony          - Middleware interface (public)
   application.pony        - Application class (public)
   route_group.pony        - RouteGroup class (public)

--- a/docs/middleware-guide.md
+++ b/docs/middleware-guide.md
@@ -152,9 +152,11 @@ The framework handles errors differently depending on where they occur and wheth
 
 **Handler errors without responding**: same as middleware — the framework sends 500.
 
+**`before`/handler errors after starting a stream**: the framework sends the terminal chunk to close the chunked response, preventing a hung connection. The `after` phases still run as normal.
+
 **`after` is not partial**: `after` cannot raise errors. If your `after` logic might fail (e.g., writing to a log file), handle the failure internally. This is a design choice — `after` is for cleanup and post-processing, and it must always complete.
 
-The general rule: if `error` happens at any point and no response has been sent yet, the framework sends 500. If a response was already sent, the error is absorbed and the chain continues to `after` phases.
+The general rule: if `error` happens at any point and no response has been sent yet, the framework sends 500. If a response was already sent, the error is absorbed and the chain continues to `after` phases. If a streaming response was started, the framework terminates the stream with the terminal chunk.
 
 ## Using `after` for Post-Processing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,7 @@ Starts an HTTP server with public and protected routes. Demonstrates two middlew
 ## [route-groups](route-groups/)
 
 Starts an HTTP server with grouped routes sharing prefixes and middleware. Demonstrates application-level middleware (logging on every route), a `/api` group with auth middleware, and a nested `/api/admin` group that adds admin middleware on top. Shows the complete middleware composition order: application middleware runs first, then group middleware, then per-route middleware.
+
+## [streaming](streaming/)
+
+Streaming responses with chunked transfer encoding. A handler starts a stream and passes the sender to a producer actor that sends chunks asynchronously.

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -14,6 +14,9 @@ actor _Connection is stallion.HTTPServerActor
   let _router: _Router val
   var _body: Array[U8] iso = recover iso Array[U8] end
   var _has_body: Bool = false
+  // Single-field: only one streaming response per connection at a time.
+  // Pipelined requests during streaming could overwrite this (hobby#13).
+  var _streaming_responder: (stallion.Responder | None) = None
 
   new create(auth: lori.TCPServerAuth, fd: U32,
     config: stallion.ServerConfig, router: _Router val)
@@ -22,6 +25,18 @@ actor _Connection is stallion.HTTPServerActor
     _http = stallion.HTTPServer(auth, fd, this, config)
 
   fun ref _http_connection(): stallion.HTTPServer => _http
+
+  be send_chunk(data: ByteSeq) =>
+    match _streaming_responder
+    | let r: stallion.Responder => r.send_chunk(data)
+    end
+
+  be finish() =>
+    match _streaming_responder
+    | let r: stallion.Responder =>
+      r.finish_response()
+      _streaming_responder = None
+    end
 
   fun ref on_body_chunk(data: Array[U8] val) =>
     _has_body = true
@@ -41,8 +56,11 @@ actor _Connection is stallion.HTTPServerActor
     let path = request'.uri.path
     match _router.lookup(request'.method, path)
     | let m: _RouteMatch =>
-      let ctx = Context(request', responder, m.params, body)
+      let ctx = Context(request', responder, m.params, body, this)
       _ChainRunner(ctx, m.handler, m.middleware)
+      if ctx.is_streaming() then
+        _streaming_responder = responder
+      end
     else
       let response = stallion.ResponseBuilder(stallion.StatusNotFound)
         .add_header("Content-Length", "9")

--- a/hobby/handler.pony
+++ b/hobby/handler.pony
@@ -6,9 +6,12 @@ interface val Handler
   requests. They receive `ref` access to the `Context` because they execute
   synchronously inside the connection actor's behavior.
 
-  Call `ctx.respond()` or `ctx.respond_with_headers()` to send a response. If
-  the handler returns without responding, the framework sends 500 Internal
+  Call `ctx.respond()` or `ctx.respond_with_headers()` to send a complete
+  response, or `ctx.start_streaming()` to begin a chunked streaming response.
+  If the handler returns without responding, the framework sends 500 Internal
   Server Error. The `?` allows genuine errors to propagate — if the handler
-  errors without having called `respond`, the framework also sends 500.
+  errors without having called `respond`, the framework also sends 500. If the
+  handler errors after calling `start_streaming()`, the framework sends the
+  terminal chunk to close the stream instead of sending 500.
   """
   fun apply(ctx: Context ref) ?

--- a/hobby/middleware.pony
+++ b/hobby/middleware.pony
@@ -9,7 +9,9 @@ interface val Middleware
   authentication, input validation, or request transformation. To short-circuit
   the chain (e.g., reject with 401), call `ctx.respond()` — the framework stops
   the forward phase and skips to after phases. The `?` allows genuine errors to
-  propagate; if `before` errors without responding, the framework sends 500.
+  propagate; if `before` errors without responding, the framework sends 500. If
+  `before` errors after calling `ctx.start_streaming()`, the framework sends the
+  terminal chunk to close the stream instead of sending 500.
 
   **`after`** runs during the reverse phase, after the handler (or after any
   middleware that short-circuited). It always runs for every middleware whose

--- a/hobby/stream_sender.pony
+++ b/hobby/stream_sender.pony
@@ -1,0 +1,14 @@
+interface tag StreamSender
+  """
+  Send response chunks and signal completion.
+
+  Returned by `Context.start_streaming()`. Pass this to a producer actor
+  that sends chunks asynchronously via `send_chunk()` and signals completion
+  with `finish()`. Both methods are behaviors — they execute asynchronously
+  in the connection actor's message queue.
+
+  The sender silently drops chunks after `finish()` is called or if the
+  underlying connection closes.
+  """
+  be send_chunk(data: ByteSeq)
+  be finish()


### PR DESCRIPTION
Handlers can now send chunked HTTP responses by calling `ctx.start_streaming()`, which returns a `StreamSender tag`. Pass it to a producer actor that calls `send_chunk()` to send data and `finish()` to close the stream.

`_Connection` structurally matches `StreamSender` by having `send_chunk` and `finish` behaviors — no wrapper actor needed. `_ChainRunner` detects handler/middleware errors after streaming starts and sends the terminal chunk to prevent hung connections.

Implements Section 1 of the [streaming design](https://github.com/ponylang/hobby/discussions/8). Known limitations deferred to separate issues:
- #12: `start_streaming()` silently ignores HTTP/1.0 and already-responded cases
- #13: Pipelined requests during streaming aren't buffered yet