### PR TITLE
Buffer pipelined requests during streaming responses

### DIFF
--- a/.release-notes/buffer-pipelined-requests-during-streaming-responses.md
+++ b/.release-notes/buffer-pipelined-requests-during-streaming-responses.md
@@ -1,0 +1,5 @@
+## Buffer pipelined requests during streaming responses
+
+When a client sends pipelined HTTP requests while a streaming response is in progress, the second request's handler could overwrite the connection's streaming state. This caused the first stream's chunks to be sent through the wrong responder and the second stream's chunks to be silently dropped.
+
+Pipelined requests are now buffered during an active streaming response and processed after the stream finishes.


### PR DESCRIPTION
When a pipelined HTTP request arrives during an active streaming response, `_Connection` now buffers it instead of processing immediately. Without this, the second handler could overwrite `_streaming_responder`, causing the first producer's chunks to hit the wrong responder and the second producer's chunks to be silently dropped.

The fix extracts request processing into `_process_request`, adds a `_pending_requests` buffer checked on entry, and drains the buffer in `finish()` after the stream completes. If a drained request starts its own stream, draining stops and resumes when that stream finishes. Zero overhead when there's no pipelining during streaming.

Closes #13