### PR TITLE
Bind examples to 0.0.0.0 instead of localhost

### DIFF
--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -8,7 +8,7 @@ actor Main
   """
   Hello world example.
 
-  Starts an HTTP server on localhost:8080 with two routes:
+  Starts an HTTP server on 0.0.0.0:8080 with two routes:
   - GET /         -> "Hello from Hobby!"
   - GET /greet/:name -> "Hello, <name>!"
 
@@ -21,7 +21,7 @@ actor Main
     hobby.Application
       .>get("/", HelloHandler)
       .>get("/greet/:name", GreetHandler)
-      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
 
 primitive HelloHandler is hobby.Handler
   fun apply(ctx: hobby.Context ref) =>

--- a/examples/middleware/main.pony
+++ b/examples/middleware/main.pony
@@ -34,7 +34,7 @@ actor Main
       .>get("/", HelloHandler)
       .>get("/dashboard", DashboardHandler where middleware = auth_mw)
       .>get("/health", HealthHandler where middleware = log_mw)
-      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
 
 // --- Handlers ---
 

--- a/examples/route-groups/main.pony
+++ b/examples/route-groups/main.pony
@@ -50,7 +50,7 @@ actor Main
           .>group(
             hobby.RouteGroup("/admin" where middleware = admin_mw)
               .>get("/dashboard", DashboardHandler)))
-      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
 
 // --- Handlers ---
 

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -8,7 +8,7 @@ actor Main
   """
   Streaming response example.
 
-  Starts an HTTP server on localhost:8080 with two routes:
+  Starts an HTTP server on 0.0.0.0:8080 with two routes:
   - GET /        -> static page explaining the /stream endpoint
   - GET /stream  -> chunked streaming response with 5 numbered chunks
 
@@ -21,7 +21,7 @@ actor Main
     hobby.Application
       .>get("/", IndexHandler)
       .>get("/stream", StreamHandler)
-      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
 
 primitive IndexHandler is hobby.Handler
   fun apply(ctx: hobby.Context ref) =>


### PR DESCRIPTION
On systems where "localhost" resolves to ::1 first (common on modern Linux including WSL2), the examples only listen on IPv6. Using 0.0.0.0 binds to all interfaces, which is more useful for example programs and works consistently across platforms.

Changes all four examples (hello, middleware, route-groups, streaming) from `"localhost"` to `"0.0.0.0"` in their `ServerConfig` calls. Docstring curl commands still reference `localhost` since that's what users will type.