### PR TITLE
Add automatic HEAD request support

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -26,3 +26,52 @@ hobby.ServeFiles(root where chunk_threshold = 256)
 
 Content-Type is detected from file extensions. Path traversal is prevented by Pony's `FilePath.from()` capability system. HTTP/1.0 clients requesting files above the chunk threshold receive 505 HTTP Version Not Supported rather than having the entire file loaded into memory. Directory requests return 404 — there is no automatic index file lookup (e.g., requesting `/static/` does not serve `/static/index.html`).
 
+## Add automatic HEAD request support
+
+HEAD requests are handled automatically per RFC 7231 §4.3.2. The framework suppresses response bodies while preserving headers (including `Content-Length`). No changes are needed in handlers for non-streaming responses.
+
+When no explicit HEAD route is registered, HEAD requests automatically fall back to the matching GET handler. Explicit HEAD routes (registered via `Application.head()`) take precedence.
+
+For streaming handlers, `start_streaming()` returns `BodyNotNeeded` instead of starting a stream:
+
+```pony
+match ctx.start_streaming(stallion.StatusOK)?
+| let sender: hobby.StreamSender tag =>
+  MyProducer(sender)
+| stallion.ChunkedNotSupported =>
+  ctx.respond(stallion.StatusOK, "Upgrade to HTTP/1.1.")
+| hobby.BodyNotNeeded => None
+end
+```
+
+Existing handlers that don't match on `BodyNotNeeded` work correctly — in a statement-position match, unmatched cases silently fall through. Only handlers that assign the match result need updating.
+
+`ServeFiles` is optimized for HEAD: it responds with `Content-Type` and `Content-Length` headers (from file stat) without reading the file, regardless of file size.
+
+## Change `start_streaming()` return type
+
+`Context.start_streaming()` now returns `(StreamSender tag | ChunkedNotSupported | BodyNotNeeded)` instead of `(StreamSender tag | ChunkedNotSupported)`.
+
+Before:
+
+```pony
+match ctx.start_streaming(stallion.StatusOK)?
+| let sender: hobby.StreamSender tag =>
+  MyProducer(sender)
+| stallion.ChunkedNotSupported =>
+  ctx.respond(stallion.StatusOK, "Fallback response.")
+end
+```
+
+After:
+
+```pony
+match ctx.start_streaming(stallion.StatusOK)?
+| let sender: hobby.StreamSender tag =>
+  MyProducer(sender)
+| stallion.ChunkedNotSupported =>
+  ctx.respond(stallion.StatusOK, "Fallback response.")
+| hobby.BodyNotNeeded => None
+end
+```
+

--- a/docs/middleware-guide.md
+++ b/docs/middleware-guide.md
@@ -152,7 +152,7 @@ The framework handles errors differently depending on where they occur and wheth
 
 **Handler errors without responding**: same as middleware — the framework sends 500.
 
-**`before`/handler errors after starting a stream**: the framework sends the terminal chunk to close the chunked response, preventing a hung connection. The `after` phases still run as normal. Note that `ctx.start_streaming()` is itself partial — it errors if a response has already been sent (programmer error). It also returns `(StreamSender tag | ChunkedNotSupported)`, so handlers can fall back to `ctx.respond()` when the client doesn't support chunked encoding.
+**`before`/handler errors after starting a stream**: the framework sends the terminal chunk to close the chunked response, preventing a hung connection. The `after` phases still run as normal. Note that `ctx.start_streaming()` is itself partial — it errors if a response has already been sent (programmer error). It also returns `(StreamSender tag | ChunkedNotSupported | BodyNotNeeded)`, so handlers can fall back to `ctx.respond()` when the client doesn't support chunked encoding, or skip streaming for HEAD requests.
 
 **`after` is not partial**: `after` cannot raise errors. If your `after` logic might fail (e.g., writing to a log file), handle the failure internally. This is a design choice — `after` is for cleanup and post-processing, and it must always complete.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,4 +20,4 @@ Serves static files from a `public/` directory using the built-in `ServeFiles` h
 
 ## [streaming](streaming/)
 
-Streaming responses with chunked transfer encoding. A handler starts a stream and passes the sender to a producer actor that sends chunks asynchronously. Also demonstrates falling back to a non-streaming response when the client doesn't support chunked encoding (`ChunkedNotSupported`).
+Streaming responses with chunked transfer encoding. A handler starts a stream and passes the sender to a producer actor that sends chunks asynchronously. Also demonstrates falling back to a non-streaming response when the client doesn't support chunked encoding (`ChunkedNotSupported`) and handling HEAD requests via `BodyNotNeeded`.

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -12,9 +12,13 @@ actor Main
   - GET /        -> static page explaining the /stream endpoint
   - GET /stream  -> chunked streaming response with 5 numbered chunks
 
+  HEAD requests are handled automatically — `start_streaming()` returns
+  `BodyNotNeeded` and the handler skips starting a producer.
+
   Try it:
     curl http://localhost:8080/
     curl http://localhost:8080/stream
+    curl --head http://localhost:8080/stream
   """
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
@@ -36,6 +40,7 @@ primitive StreamHandler is hobby.Handler
     | stallion.ChunkedNotSupported =>
       ctx.respond(stallion.StatusOK,
         "Chunked encoding not supported — upgrade to HTTP/1.1.")
+    | hobby.BodyNotNeeded => None
     end
 
 actor ChunkProducer

--- a/hobby/_response_mode.pony
+++ b/hobby/_response_mode.pony
@@ -1,0 +1,93 @@
+use stallion = "stallion"
+
+interface val _ResponseMode
+  """
+  Strategy for building HTTP responses, separating HEAD from standard behavior.
+
+  Standard mode builds full responses with bodies. Head mode builds
+  headers-only responses, suppressing bodies while preserving Content-Length.
+  """
+  fun respond(responder: stallion.Responder, status: stallion.Status,
+    body': ByteSeq, body_size: USize)
+
+  fun respond_with_headers(responder: stallion.Responder,
+    status: stallion.Status, headers: stallion.Headers val, body': ByteSeq)
+
+  fun start_streaming(responder: stallion.Responder, status: stallion.Status,
+    headers: (stallion.Headers val | None), conn: _Connection tag)
+    : (StreamSender tag | stallion.ChunkedNotSupported | BodyNotNeeded) ?
+
+primitive _StandardResponseMode is _ResponseMode
+  fun respond(responder: stallion.Responder, status: stallion.Status,
+    body': ByteSeq, body_size: USize)
+  =>
+    let response = stallion.ResponseBuilder(status)
+      .add_header("Content-Length", body_size.string())
+      .finish_headers()
+      .add_chunk(body')
+      .build()
+    responder.respond(response)
+
+  fun respond_with_headers(responder: stallion.Responder,
+    status: stallion.Status, headers: stallion.Headers val, body': ByteSeq)
+  =>
+    let builder = stallion.ResponseBuilder(status)
+    for (name, value) in headers.values() do
+      builder.add_header(name, value)
+    end
+    let response = builder
+      .finish_headers()
+      .add_chunk(body')
+      .build()
+    responder.respond(response)
+
+  fun start_streaming(responder: stallion.Responder, status: stallion.Status,
+    headers: (stallion.Headers val | None), conn: _Connection tag)
+    : (StreamSender tag | stallion.ChunkedNotSupported | BodyNotNeeded) ?
+  =>
+    match responder.start_chunked_response(status, headers)
+    | stallion.StreamingStarted => conn
+    | stallion.ChunkedNotSupported => stallion.ChunkedNotSupported
+    | stallion.AlreadyResponded => error
+    end
+
+primitive _HeadResponseMode is _ResponseMode
+  fun respond(responder: stallion.Responder, status: stallion.Status,
+    body': ByteSeq, body_size: USize)
+  =>
+    let response = stallion.ResponseBuilder(status)
+      .add_header("Content-Length", body_size.string())
+      .finish_headers()
+      .build()
+    responder.respond(response)
+
+  fun respond_with_headers(responder: stallion.Responder,
+    status: stallion.Status, headers: stallion.Headers val, body': ByteSeq)
+  =>
+    let builder = stallion.ResponseBuilder(status)
+    for (name, value) in headers.values() do
+      builder.add_header(name, value)
+    end
+    let response = builder
+      .finish_headers()
+      .build()
+    responder.respond(response)
+
+  fun start_streaming(responder: stallion.Responder, status: stallion.Status,
+    headers: (stallion.Headers val | None), conn: _Connection tag)
+    : (StreamSender tag | stallion.ChunkedNotSupported | BodyNotNeeded)
+  =>
+    // Build a headers-only response without going through
+    // start_chunked_response(), which would inject Transfer-Encoding: chunked.
+    let builder = stallion.ResponseBuilder(status)
+    match headers
+    | let h: stallion.Headers val =>
+      for (name, value) in h.values() do
+        builder.add_header(name, value)
+      end
+    end
+    let response = builder
+      .finish_headers()
+      .build()
+    responder.respond(response)
+    BodyNotNeeded

--- a/hobby/body_not_needed.pony
+++ b/hobby/body_not_needed.pony
@@ -1,0 +1,7 @@
+primitive BodyNotNeeded
+  """
+  Returned by `Context.start_streaming()` when the request is HEAD.
+
+  The framework has already sent a headers-only response. The handler should
+  not start a producer — there is no stream to write to.
+  """

--- a/hobby/handler.pony
+++ b/hobby/handler.pony
@@ -9,9 +9,9 @@ interface val Handler
   Call `ctx.respond()` or `ctx.respond_with_headers()` to send a complete
   response, or `ctx.start_streaming()` to begin a chunked streaming response.
   `start_streaming()` is partial — it errors if a response has already been
-  sent, and returns `(StreamSender tag | ChunkedNotSupported)` so handlers
-  can fall back to a non-streaming response when the client doesn't support
-  chunked encoding.
+  sent, and returns `(StreamSender tag | ChunkedNotSupported | BodyNotNeeded)`
+  so handlers can fall back to a non-streaming response when the client doesn't
+  support chunked encoding, or skip streaming entirely for HEAD requests.
 
   If the handler returns without responding, the framework sends 500 Internal
   Server Error. The `?` allows genuine errors to propagate — if the handler

--- a/hobby/stream_sender.pony
+++ b/hobby/stream_sender.pony
@@ -4,7 +4,8 @@ interface tag StreamSender
 
   Returned by `Context.start_streaming()` on success. `start_streaming()` may
   also return `ChunkedNotSupported` when the client doesn't support chunked
-  encoding — callers should `match` on the result before using the sender.
+  encoding, or `BodyNotNeeded` for HEAD requests — callers should `match` on
+  the result before using the sender.
 
   Pass this to a producer actor that sends chunks asynchronously via
   `send_chunk()` and signals completion with `finish()`. Both methods are


### PR DESCRIPTION
HEAD requests are handled automatically per RFC 7231 §4.3.2. The framework suppresses response bodies while preserving headers (including `Content-Length`). No changes needed in handlers for non-streaming responses.

When no explicit HEAD route is registered, HEAD requests fall back to the matching GET handler. Explicit HEAD routes (via `Application.head()`) take precedence.

For streaming handlers, `start_streaming()` returns the new `BodyNotNeeded` primitive instead of starting a chunked stream. The return type changes from `(StreamSender tag | ChunkedNotSupported)` to `(StreamSender tag | ChunkedNotSupported | BodyNotNeeded)` — this is a breaking change for handlers that assign the match result, but existing statement-position matches work unchanged.

`ServeFiles` is optimized for HEAD: responds with `Content-Type` and `Content-Length` headers from file stat without reading the file.

Design: #18