### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/examples/middleware/main.pony
+++ b/examples/middleware/main.pony
@@ -64,7 +64,7 @@ primitive AuthData
   Typed accessor for auth middleware context data.
 
   Middleware authors provide accessor primitives like this to give handlers
-  type-safe access to context data via `match \exhaustive\`, avoiding raw string-key
+  type-safe access to context data via `match`, avoiding raw string-key
   lookups and `as` casts.
   """
   fun user(ctx: hobby.Context box): AuthenticatedUser ? =>

--- a/hobby/_etag.pony
+++ b/hobby/_etag.pony
@@ -1,6 +1,6 @@
 primitive _ETag
   """
-  Compute and match \exhaustive\ weak ETags from file metadata.
+  Compute and match weak ETags from file metadata.
 
   ETags use the weak format `W/"<inode>-<size>-<mtime_secs>"`, matching the
   approach used by nginx and Apache. No file content hashing — computing a

--- a/hobby/context.pony
+++ b/hobby/context.pony
@@ -105,8 +105,8 @@ class ref Context
     the handler can fall back to `ctx.respond()` for a non-streaming response.
 
     When `BodyNotNeeded` is returned, `is_handled()` is `true` — the handler
-    should not start a producer. Existing handlers that don't match \exhaustive\ on
-    `BodyNotNeeded` work correctly: in a statement-position match \exhaustive\, unmatched
+    should not start a producer. Existing handlers that don't match on
+    `BodyNotNeeded` work correctly: in a statement-position match, unmatched
     cases silently fall through, so the handler does nothing (which is correct
     for HEAD).
 
@@ -174,7 +174,7 @@ class ref Context
     Retrieve a value from the context data map.
 
     Errors if the key does not exist. Middleware authors should provide typed
-    accessor primitives that wrap this method with `match \exhaustive\` to recover domain
+    accessor primitives that wrap this method with `match` to recover domain
     types.
     """
     _data(key)?

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -35,13 +35,13 @@ class val GreetHandler is hobby.Handler
 
 Routes use a radix tree with two kinds of dynamic segments:
 
-- **Named parameters** (`:name`): match \exhaustive\ a single path segment.
+- **Named parameters** (`:name`): match a single path segment.
   `/users/:id` matches `/users/42` but not `/users/42/posts`.
-- **Wildcard parameters** (`*name`): match \exhaustive\ everything from that point forward,
+- **Wildcard parameters** (`*name`): match everything from that point forward,
   must be the last segment. `/files/*path` matches `/files/css/style.css`.
 
 Static routes have priority over parameter routes at the same position.
-Trailing slashes are normalized — `/users/` and `/users` match \exhaustive\ the same route.
+Trailing slashes are normalized — `/users/` and `/users` match the same route.
 
 ## Middleware
 
@@ -105,7 +105,7 @@ in registration order.
 
 Middleware communicates with handlers through `ctx.set()` / `ctx.get()`.
 The data map stores `Any val` values. Middleware authors should provide typed
-accessor primitives that use `match \exhaustive\` to recover domain types, following the
+accessor primitives that use `match` to recover domain types, following the
 convention demonstrated in the middleware example.
 
 ## Streaming Responses
@@ -116,7 +116,7 @@ on the result:
 ```pony
 primitive StreamHandler is hobby.Handler
   fun apply(ctx: hobby.Context ref) ? =>
-    match \exhaustive\ ctx.start_streaming(stallion.StatusOK)?
+    match ctx.start_streaming(stallion.StatusOK)?
     | let sender: hobby.StreamSender tag =>
       MyProducer(sender)
     | stallion.ChunkedNotSupported =>
@@ -141,8 +141,8 @@ actor MyProducer
 sent. It returns `(StreamSender tag | ChunkedNotSupported | BodyNotNeeded)`
 so handlers can fall back to a non-streaming response when the client doesn't
 support chunked encoding (e.g., HTTP/1.0), or skip streaming entirely for
-HEAD requests (`BodyNotNeeded`). Existing handlers that don't match \exhaustive\ on
-`BodyNotNeeded` work correctly — in a statement-position match \exhaustive\, unmatched
+HEAD requests (`BodyNotNeeded`). Existing handlers that don't match on
+`BodyNotNeeded` work correctly — in a statement-position match, unmatched
 cases silently fall through. If the handler errors after a successful
 `start_streaming()`, the framework automatically terminates the chunked
 response to prevent a hung connection.

--- a/hobby/stream_sender.pony
+++ b/hobby/stream_sender.pony
@@ -4,7 +4,7 @@ interface tag StreamSender
 
   Returned by `Context.start_streaming()` on success. `start_streaming()` may
   also return `ChunkedNotSupported` when the client doesn't support chunked
-  encoding, or `BodyNotNeeded` for HEAD requests — callers should `match \exhaustive\` on
+  encoding, or `BodyNotNeeded` for HEAD requests — callers should `match` on
   the result before using the sender.
 
   Pass this to a producer actor that sends chunks asynchronously via


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.