### PR TITLE
Upgrade Stallion from 0.3.0 to 0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ The `ssl` option is required — Stallion transitively depends on the `ssl` pack
 
 ## Dependencies
 
-- **Stallion** (0.3.0): HTTP/1.x server built on lori. Provides `HTTPServerActor`, `HTTPServer`, `Responder`, `ResponseBuilder`, `Request`, `ServerConfig`, `Status`, `Method`, `Headers`, `StartChunkedResponseResult`, `StreamingStarted`, `AlreadyResponded`, `ChunkedNotSupported`.
+- **Stallion** (0.4.0): HTTP/1.x server built on lori. Provides `HTTPServerActor`, `HTTPServer`, `Responder`, `ResponseBuilder`, `Request`, `ServerConfig`, `Status`, `Method`, `Headers`, `StartChunkedResponseResult`, `StreamingStarted`, `AlreadyResponded`, `ChunkedNotSupported`.
 - **lori** (transitive via Stallion): TCP layer. Provides `TCPListenerActor`, `TCPListener`, `TCPConnectionActor`, `TCPConnection`, auth types.
 - **uri** (transitive via Stallion): URI parsing. Used to read `request.uri.path`.
 - **ssl** (transitive via Stallion): SSL/TLS support. Requires an SSL version flag at build time (`ssl=3.0.x`, `ssl=1.1.x`, or `ssl=libressl`).

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/stallion.git",
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   ]
 }

--- a/hobby/_test_integration.pony
+++ b/hobby/_test_integration.pony
@@ -74,7 +74,7 @@ actor \nodoc\ _TestClient is (lori.TCPConnectionActor & lori.ClientLifecycleEven
 
   fun ref _on_closed() => None
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("connection failed")
     _listener.dispose()
     _h.complete(false)
@@ -610,7 +610,7 @@ actor \nodoc\ _TestHeadClient is (lori.TCPConnectionActor & lori.ClientLifecycle
 
   fun ref _on_closed() => None
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("connection failed")
     _listener.dispose()
     _h.complete(false)

--- a/hobby/_test_serve_files.pony
+++ b/hobby/_test_serve_files.pony
@@ -503,7 +503,7 @@ actor \nodoc\ _TestNoCacheControlClient is (lori.TCPConnectionActor & lori.Clien
 
   fun ref _on_closed() => None
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("connection failed")
     _listener.dispose()
     _h.complete(false)


### PR DESCRIPTION
Stallion 0.4.0 upgrades lori from 0.9.0 to 0.10.0, which changes the `_on_connection_failure` callback signature on `ClientLifecycleEventReceiver` to include a `ConnectionFailureReason` parameter. Only hobby's test clients implement this interface directly, so the fix is limited to test code — hobby's public API is unchanged.