### PR TITLE
Rename build-examples make target to examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ make ssl=3.0.x          # build tests + examples (release, OpenSSL 3.x)
 make test ssl=3.0.x     # same as above
 make ssl=libressl       # use LibreSSL (CI uses this)
 make config=debug       # debug build (combine with ssl=...)
-make build-examples ssl=3.0.x  # examples only
+make examples ssl=3.0.x # examples only
 make clean              # clean build artifacts + corral cache
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -maxdepth 0 -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)
 EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 
-test: unit-tests integration-tests build-examples
+test: unit-tests integration-tests examples
 
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
@@ -54,7 +54,7 @@ $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
 
-build-examples: $(EXAMPLES_BINARIES)
+examples: $(EXAMPLES_BINARIES)
 
 $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
@@ -79,4 +79,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all build-examples clean integration-tests TAGS test unit-tests
+.PHONY: all examples clean integration-tests TAGS test unit-tests


### PR DESCRIPTION
Shorter, more natural target name.