### PR TITLE
Add signed cookie support

### DIFF
--- a/.release-notes/add-signed-cookies.md
+++ b/.release-notes/add-signed-cookies.md
@@ -1,0 +1,21 @@
+## Add signed cookie support
+
+Hobby now includes `CookieSigningKey` and `SignedCookie` for HMAC-SHA256 cookie signing. The value stays readable, but any tampering invalidates the signature.
+
+```pony
+use hobby = "hobby"
+
+// Generate a random 32-byte key at startup
+let key = hobby.CookieSigningKey.generate()?
+
+// Sign a value for storage in a cookie
+let signed = hobby.SignedCookie.sign(key, "user=alice")
+
+// Verify and extract the original value
+match \exhaustive\ hobby.SignedCookie.verify(key, signed)
+| let value: String => // "user=alice"
+| let err: hobby.SignedCookieError => // tampered or wrong key
+end
+```
+
+You can also wrap an existing key with `CookieSigningKey(key_bytes)?` — the key must be at least 32 bytes. Verification returns a `SignedCookieError` union (`MalformedSignedValue` or `InvalidSignature`) for exhaustive matching.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ The `ssl` option is required — Stallion transitively depends on the `ssl` pack
 - **Stallion** (0.5.2): HTTP/1.x server built on lori. Provides `HTTPServerActor`, `HTTPServer`, `Responder`, `ResponseBuilder`, `Request`, `ServerConfig`, `Status`, `Method`, `Headers`, `Header`, `StartChunkedResponseResult`, `StreamingStarted`, `AlreadyResponded`, `ChunkedNotSupported`. Also provides cookie support (`RequestCookie`, `RequestCookies`, `ParseCookies`, `SetCookie`, `SetCookieBuilder`, `SetCookieBuildError`, `SameSite`/`SameSiteStrict`/`SameSiteLax`/`SameSiteNone`) and content negotiation (`MediaType`, `NoAcceptableType`, `ContentNegotiationResult`, `ContentNegotiation`).
 - **lori** (transitive via Stallion): TCP layer. Provides `TCPListenerActor`, `TCPListener`, `TCPConnectionActor`, `TCPConnection`, auth types.
 - **uri** (transitive via Stallion): URI parsing. Used to read `request.uri.path`.
-- **ssl** (transitive via Stallion): SSL/TLS support. Requires an SSL version flag at build time (`ssl=3.0.x`, `ssl=1.1.x`, or `ssl=libressl`).
+- **ssl** (2.0.1): SSL/TLS and cryptography. Also available transitively via Stallion. Direct dependency for signed cookie code — provides `ssl/crypto` subpackage (`HmacSha256`, `ConstantTimeCompare`, `RandBytes`). Requires an SSL version flag at build time (`ssl=3.0.x`, `ssl=1.1.x`, or `ssl=libressl`).
 
 ## Architecture
 
@@ -48,6 +48,11 @@ Users interact with these types:
 - **`BodyNotNeeded`** (`primitive`): Returned by `RequestHandler.start_streaming()` for HEAD requests.
 - **`ContentTypes`** (`class val`): File extension to MIME content type mapping. Ships with 17 common defaults. Chain `.add()` calls to add or override mappings.
 - **`ServeFiles`** (`class val`): Built-in handler factory for serving static files. Structurally matches `HandlerFactory`. Small files served inline; large files streamed via `_ServeFilesHandler` actor. Includes caching headers and conditional request support per RFC 7232.
+- **`CookieSigningKey`** (`class val`): HMAC-SHA256 signing key for use with `SignedCookie`. 32-byte minimum. `create` wraps existing key bytes, `generate` creates a random key. `_bytes()` is package-private.
+- **`SignedCookie`** (`primitive`): Signs and verifies cookie values using HMAC-SHA256. `sign` produces `value.base64url(hmac)` format. `verify` returns the original value or a `SignedCookieError`.
+- **`SignedCookieError`** (type alias): `(MalformedSignedValue | InvalidSignature)`. Error union for `SignedCookie.verify`.
+- **`MalformedSignedValue`** (`primitive`): Structurally invalid signed value (missing separator or invalid base64).
+- **`InvalidSignature`** (`primitive`): Signature did not match (tampered or wrong key).
 
 ### Internal layers
 
@@ -101,6 +106,9 @@ hobby/
   route_group.pony            - RouteGroup class (public)
   serve_files.pony            - ServeFiles handler factory (public)
   content_types.pony          - ContentTypes class + defaults (public)
+  cookie_signing_key.pony     - CookieSigningKey class (public)
+  signed_cookie.pony          - SignedCookie primitive (public)
+  signed_cookie_error.pony    - SignedCookieError union type (public)
   _connection_protocol.pony   - Connection protocol trait (internal)
   _buffered_response.pony     - Response buffer for after-middleware (internal)
   _run_before_middleware.pony  - Before-phase execution (internal)
@@ -127,6 +135,7 @@ hobby/
   _test_request_handler.pony   - RequestHandler unit tests with mock connection
   _test_integration.pony       - HTTP round-trip integration tests
   _test_serve_files.pony       - ServeFiles integration tests
+  _test_signed_cookie.pony     - Signed cookie unit + property tests
 ```
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ hobby is beta quality software that will change frequently. Expect breaking chan
 * `use "hobby"` to include this package
 * `corral run -- ponyc` to compile your application
 
+Note: The ssl transitive dependency requires a C SSL library to be installed. Please see the ssl installation instructions for more information.
+
 ## Usage
 
 ```pony

--- a/corral.json
+++ b/corral.json
@@ -14,6 +14,10 @@
     {
       "locator": "github.com/ponylang/stallion.git",
       "version": "0.5.2"
+    },
+    {
+      "locator": "github.com/ponylang/ssl.git",
+      "version": "2.0.1"
     }
   ]
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,10 @@ Demonstrates actor-based handlers that do async work before responding. A `SlowS
 
 Starts an HTTP server with public and protected routes. Demonstrates two middleware patterns: an auth middleware that short-circuits with 401 in the `before` phase when a token is missing, and a logging middleware that records requests in the `after` phase. Also shows the typed accessor pattern for inter-middleware communication — `handler.get[AuthenticatedUser]()` extracts domain types from the data map.
 
+## [signed-cookie](signed-cookie/)
+
+Signs and verifies cookie values using HMAC-SHA256 to prevent tampering. A visit counter cookie is signed on each response and verified on each request using `CookieSigningKey` and `SignedCookie`. Demonstrates key generation, the sign/verify round-trip, and integration with Stallion's `SetCookieBuilder` for secure cookie attributes.
+
 ## [route-groups](route-groups/)
 
 Starts an HTTP server with grouped routes sharing prefixes and middleware. Demonstrates application-level middleware (logging on every route), a `/api` group with auth middleware, and a nested `/api/admin` group that adds admin middleware on top. Shows the complete middleware composition order: application middleware runs first, then group middleware, then per-route middleware.

--- a/examples/signed-cookie/main.pony
+++ b/examples/signed-cookie/main.pony
@@ -1,0 +1,86 @@
+// in your code this `use` statement would be:
+// use hobby = "hobby"
+use hobby = "../../hobby"
+use stallion = "stallion"
+use lori = "lori"
+
+actor Main
+  """
+  Signed cookie example.
+
+  Demonstrates signing and verifying cookie values using HMAC-SHA256 to
+  prevent tampering. A visit counter cookie is signed on each response and
+  verified on each request -- any modification to the value or the signature
+  is detected and the count resets.
+
+  Routes:
+  - GET /       -> increments and displays a signed visit counter
+  - GET /clear  -> clears the visit counter cookie
+
+  Try it:
+    curl -c cookies.txt -b cookies.txt http://localhost:8080/
+    curl -c cookies.txt -b cookies.txt http://localhost:8080/
+    curl -c cookies.txt -b cookies.txt http://localhost:8080/clear
+    curl -c cookies.txt -b cookies.txt http://localhost:8080/
+  """
+  new create(env: Env) =>
+    let key =
+      try hobby.CookieSigningKey.generate()?
+      else env.err.print("Failed to generate signing key"); return
+      end
+    let auth = lori.TCPListenAuth(env.root)
+    hobby.Application
+      .>get("/", {(ctx)(key) =>
+        let handler = hobby.RequestHandler(consume ctx)
+        // Read and verify the signed visit count from the cookie
+        let count: U64 =
+          match handler.request().cookies.get("visits")
+          | let raw: String =>
+            match \exhaustive\ hobby.SignedCookie.verify(key, raw)
+            | let value: String =>
+              try value.u64()? else 0 end
+            | let _: hobby.SignedCookieError => 0
+            end
+          else
+            0
+          end
+        let new_count: String val = (count + 1).string()
+        let signed = hobby.SignedCookie.sign(key, new_count)
+        // Build response headers with the signed cookie.
+        // Secure=false for localhost testing; use the default (true) in
+        // production.
+        let headers: stallion.Headers val =
+          recover val
+            let h = stallion.Headers
+            match stallion.SetCookieBuilder("visits", signed)
+              .with_path("/")
+              .with_secure(false)
+              .build()
+            | let sc: stallion.SetCookie val =>
+              h.add("Set-Cookie", sc.header_value())
+            end
+            h
+          end
+        handler.respond_with_headers(stallion.StatusOK, headers,
+          "Visit #" + new_count)
+      } val)
+      .>get("/clear", {(ctx) =>
+        let handler = hobby.RequestHandler(consume ctx)
+        // Clear the cookie by setting Max-Age=0
+        let headers: stallion.Headers val =
+          recover val
+            let h = stallion.Headers
+            match stallion.SetCookieBuilder("visits", "")
+              .with_path("/")
+              .with_max_age(0)
+              .with_secure(false)
+              .build()
+            | let sc: stallion.SetCookie val =>
+              h.add("Set-Cookie", sc.header_value())
+            end
+            h
+          end
+        handler.respond_with_headers(stallion.StatusOK, headers,
+          "Visit counter cleared.")
+      } val)
+      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)

--- a/hobby/_test.pony
+++ b/hobby/_test.pony
@@ -13,3 +13,4 @@ actor \nodoc\ Main is TestList
     _TestRequestHandlerList.tests(test)
     _TestIntegrationList.tests(test)
     _TestServeFilesList.tests(test)
+    _TestSignedCookieList.tests(test)

--- a/hobby/_test_signed_cookie.pony
+++ b/hobby/_test_signed_cookie.pony
@@ -1,0 +1,428 @@
+use "pony_test"
+use "pony_check"
+use crypto = "ssl/crypto"
+
+primitive \nodoc\ _TestSignedCookieList
+  fun tests(test: PonyTest) =>
+    test(_TestSignedCookieRoundTrip)
+    test(_TestSignedCookieTamperedValue)
+    test(_TestSignedCookieTamperedSig)
+    test(_TestSignedCookieNoSeparator)
+    test(_TestSignedCookieEmptySig)
+    test(_TestSignedCookieWrongKey)
+    test(_TestSignedCookieValueWithDots)
+    test(_TestSignedCookieEmptyValue)
+    test(_TestSignedCookieInvalidBase64)
+    test(_TestSignedCookieKeyBoundary)
+    test(_TestSignedCookieRfc4231Vector)
+    test(_TestSignedCookieCrossLanguageVector)
+    test(Property1UnitTest[String](_PropSignedCookieRoundTrip))
+    test(Property1UnitTest[String](_PropSignedCookieDeterministic))
+    test(Property1UnitTest[
+      (String, USize)](_PropSignedCookieTamperDetection))
+    test(Property1UnitTest[String](_PropSignedCookieKeyIndependence))
+    test(Property1UnitTest[String](_PropSignedCookieCookieOctetValidity))
+    test(Property1UnitTest[String](_PropSignedCookieSignatureLength))
+
+class \nodoc\ iso _TestSignedCookieRoundTrip is UnitTest
+  fun name(): String => "SignedCookie/round-trip"
+
+  fun apply(h: TestHelper) ? =>
+    let key = CookieSigningKey.generate()?
+    let value = "user=alice"
+    let signed = SignedCookie.sign(key, value)
+    match \exhaustive\ SignedCookie.verify(key, signed)
+    | let v: String => h.assert_eq[String](value, v)
+    | let e: SignedCookieError => h.fail(e.string())
+    end
+
+class \nodoc\ iso _TestSignedCookieTamperedValue is UnitTest
+  fun name(): String => "SignedCookie/tampered-value"
+
+  fun apply(h: TestHelper) ? =>
+    let key = CookieSigningKey.generate()?
+    let signed = SignedCookie.sign(key, "user=alice")
+    // Replace "alice" with "mallory"
+    let sig_part = signed.trim(signed.rfind(".")?.usize())
+    let tampered =
+      recover val
+        String
+          .> append("user=mallory")
+          .> append(sig_part)
+      end
+    match \exhaustive\ SignedCookie.verify(key, tampered)
+    | let _: String => h.fail("accepted tampered value")
+    | InvalidSignature => None
+    | MalformedSignedValue => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestSignedCookieTamperedSig is UnitTest
+  fun name(): String => "SignedCookie/tampered-signature"
+
+  fun apply(h: TestHelper) ? =>
+    let key = CookieSigningKey.generate()?
+    let signed = SignedCookie.sign(key, "user=alice")
+    let pos = signed.rfind(".")?.usize()
+    let value = signed.trim(0, pos)
+    // Replace the signature with a different valid Base64 string
+    let tampered =
+      recover val
+        String
+          .> append(value)
+          .> push('.')
+          .> append("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+      end
+    match \exhaustive\ SignedCookie.verify(key, tampered)
+    | let _: String => h.fail("accepted tampered signature")
+    | InvalidSignature => None
+    | MalformedSignedValue => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestSignedCookieNoSeparator is UnitTest
+  fun name(): String => "SignedCookie/no-separator"
+
+  fun apply(h: TestHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    match \exhaustive\ SignedCookie.verify(key, "noseparatorhere")
+    | let _: String => h.fail("accepted value without separator")
+    | MalformedSignedValue => None
+    | InvalidSignature => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestSignedCookieEmptySig is UnitTest
+  fun name(): String => "SignedCookie/empty-signature"
+
+  fun apply(h: TestHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    match \exhaustive\ SignedCookie.verify(key, "value.")
+    | let _: String => h.fail("accepted empty signature")
+    | MalformedSignedValue => None
+    | InvalidSignature => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestSignedCookieWrongKey is UnitTest
+  fun name(): String => "SignedCookie/wrong-key"
+
+  fun apply(h: TestHelper) =>
+    (let key1, let key2) =
+      try
+        (CookieSigningKey.generate()?, CookieSigningKey.generate()?)
+      else
+        h.fail("key generation failed"); return
+      end
+    let signed = SignedCookie.sign(key1, "secret")
+    match \exhaustive\ SignedCookie.verify(key2, signed)
+    | let _: String => h.fail("accepted wrong key")
+    | InvalidSignature => None
+    | MalformedSignedValue => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestSignedCookieValueWithDots is UnitTest
+  fun name(): String => "SignedCookie/value-with-dots"
+
+  fun apply(h: TestHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let value = "a.b.c.d"
+    let signed = SignedCookie.sign(key, value)
+    match \exhaustive\ SignedCookie.verify(key, signed)
+    | let v: String => h.assert_eq[String](value, v)
+    | let e: SignedCookieError => h.fail(e.string())
+    end
+
+class \nodoc\ iso _TestSignedCookieEmptyValue is UnitTest
+  fun name(): String => "SignedCookie/empty-value"
+
+  fun apply(h: TestHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let value = ""
+    let signed = SignedCookie.sign(key, value)
+    match \exhaustive\ SignedCookie.verify(key, signed)
+    | let v: String => h.assert_eq[String](value, v)
+    | let e: SignedCookieError => h.fail(e.string())
+    end
+
+class \nodoc\ iso _TestSignedCookieInvalidBase64 is UnitTest
+  fun name(): String => "SignedCookie/invalid-base64"
+
+  fun apply(h: TestHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    match \exhaustive\ SignedCookie.verify(key, "value.@@@not-base64!!!")
+    | let _: String => h.fail("accepted invalid base64")
+    | MalformedSignedValue => None
+    | InvalidSignature => h.fail("wrong error type")
+    end
+
+class \nodoc\ iso _TestSignedCookieKeyBoundary is UnitTest
+  """
+  The minimum key length is 32 bytes. A 31-byte key must be rejected;
+  a 32-byte key must be accepted.
+  """
+
+  fun name(): String => "SignedCookie/key-boundary"
+
+  fun apply(h: TestHelper) =>
+    let too_short: Array[U8] val =
+      recover val Array[U8].init(0xAA, 31) end
+    try
+      CookieSigningKey(too_short)?
+      h.fail("accepted 31-byte key")
+    end
+
+    let just_right: Array[U8] val =
+      recover val Array[U8].init(0xAA, 32) end
+    try
+      CookieSigningKey(just_right)?
+    else
+      h.fail("rejected 32-byte key")
+    end
+
+class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
+  """
+  RFC 4231 Test Case 2: HMAC-SHA256 with "Jefe" key and "what do ya want
+  for nothing?" data. Verifies our HMAC matches the known digest.
+  """
+
+  fun name(): String => "SignedCookie/rfc-4231-vector"
+
+  fun apply(h: TestHelper) =>
+    // RFC 4231 Test Case 2 key: "Jefe" (4 bytes) — too short for
+    // CookieSigningKey, so test the HMAC primitive directly.
+    let key: Array[U8] val = [as U8: 0x4a; 0x65; 0x66; 0x65]
+    let data = "what do ya want for nothing?"
+    let expected: Array[U8] val =
+      [ as U8:
+        0x5b; 0xdc; 0xc1; 0x46; 0xbf; 0x60; 0x75; 0x4e
+        0x6a; 0x04; 0x24; 0x26; 0x08; 0x95; 0x75; 0xc7
+        0x5a; 0x00; 0x3f; 0x08; 0x9d; 0x27; 0x39; 0x83
+        0x9d; 0xec; 0x58; 0xb9; 0x64; 0xec; 0x38; 0x43
+      ]
+    let actual = crypto.HmacSha256(key, data)
+    h.assert_eq[USize](32, actual.size())
+    h.assert_true(
+      crypto.ConstantTimeCompare(expected, actual),
+      "HMAC did not match RFC 4231 test vector")
+
+class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
+  """
+  Cross-language test vector: a known key, value, and expected signed
+  output verified against `openssl dgst -sha256 -hmac`.
+
+  Reproduce with:
+  ```
+  printf 'hello' \
+    | openssl dgst -sha256 \
+        -mac HMAC \
+        -macopt hexkey:$(python3 -c "print('ab'*32)") \
+        -binary \
+    | base64 -w0 \
+    | tr '+/' '-_'
+  ```
+
+  Key: 32 bytes of 0xAB
+  Value: "hello"
+  Expected signed output: "hello.7GT0SrIsQCeVHsMIKW5wg_p2huSb8nTFCUeO-QsJ_Ak="
+  """
+
+  fun name(): String => "SignedCookie/cross-language-vector"
+
+  fun apply(h: TestHelper) ? =>
+    let key_bytes: Array[U8] val =
+      recover val Array[U8].init(0xAB, 32) end
+    let key = CookieSigningKey(key_bytes)?
+
+    let expected = "hello.7GT0SrIsQCeVHsMIKW5wg_p2huSb8nTFCUeO-QsJ_Ak="
+    let signed = SignedCookie.sign(key, "hello")
+    h.assert_eq[String](expected, signed)
+
+    match \exhaustive\ SignedCookie.verify(key, signed)
+    | let v: String => h.assert_eq[String]("hello", v)
+    | let e: SignedCookieError => h.fail(e.string())
+    end
+
+class \nodoc\ iso _PropSignedCookieRoundTrip is Property1[String]
+  """
+  For any printable ASCII value, sign then verify returns the original.
+  """
+
+  fun name(): String => "SignedCookie/prop-round-trip"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_printable(0, 200)
+
+  fun property(sample: String, h: PropertyHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let signed = SignedCookie.sign(key, sample)
+    match \exhaustive\ SignedCookie.verify(key, signed)
+    | let v: String => h.assert_eq[String](sample, v)
+    | let e: SignedCookieError => h.fail(e.string())
+    end
+
+class \nodoc\ iso _PropSignedCookieDeterministic is Property1[String]
+  """
+  Signing the same value with the same key always produces the same output.
+  """
+
+  fun name(): String => "SignedCookie/prop-deterministic"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_printable(0, 200)
+
+  fun property(sample: String, h: PropertyHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let a = SignedCookie.sign(key, sample)
+    let b = SignedCookie.sign(key, sample)
+    h.assert_eq[String](a, b)
+
+class \nodoc\ iso _PropSignedCookieTamperDetection is
+  Property1[(String, USize)]
+  """
+  Flipping any byte in a signed value causes verification to fail.
+  """
+
+  fun name(): String => "SignedCookie/prop-tamper-detection"
+
+  fun gen(): Generator[(String, USize)] =>
+    Generators.map2[String, USize, (String, USize)](
+      Generators.ascii_printable(1, 100),
+      Generators.usize(0, 200),
+      {(s, i) => (s, i) })
+
+  fun property(sample: (String, USize), h: PropertyHelper) =>
+    (let value, let flip_hint) = sample
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let signed = SignedCookie.sign(key, value)
+
+    if signed.size() == 0 then return end
+    let flip_pos = flip_hint % signed.size()
+
+    // Build a tampered copy with one byte flipped
+    let tampered =
+      recover val
+        let buf = signed.clone()
+        try
+          let original = buf(flip_pos)?
+          // XOR with a non-zero value to guarantee a change
+          buf(flip_pos)? = original xor 0xFF
+        else
+          return
+        end
+        consume buf
+      end
+
+    match \exhaustive\ SignedCookie.verify(key, tampered)
+    | let _: String => h.fail("accepted tampered value")
+    | let _: SignedCookieError => None
+    end
+
+class \nodoc\ iso _PropSignedCookieKeyIndependence is Property1[String]
+  """
+  A value signed with one key does not verify with a different key.
+  """
+
+  fun name(): String => "SignedCookie/prop-key-independence"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_printable(0, 200)
+
+  fun property(sample: String, h: PropertyHelper) =>
+    (let key1, let key2) =
+      try
+        (CookieSigningKey.generate()?, CookieSigningKey.generate()?)
+      else
+        h.fail("key generation failed"); return
+      end
+    let signed = SignedCookie.sign(key1, sample)
+    match \exhaustive\ SignedCookie.verify(key2, signed)
+    | let _: String => h.fail("different key accepted")
+    | let _: SignedCookieError => None
+    end
+
+class \nodoc\ iso _PropSignedCookieCookieOctetValidity is Property1[String]
+  """
+  The separator and signature portion of a signed cookie contain only
+  valid cookie-octet bytes (RFC 6265 section 4.1.1): US-ASCII excluding
+  control characters, whitespace, double quote, comma, semicolon, and
+  backslash. The value portion is the caller's responsibility.
+  """
+
+  fun name(): String => "SignedCookie/prop-cookie-octet-validity"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_printable(0, 200)
+
+  fun property(sample: String, h: PropertyHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let signed = SignedCookie.sign(key, sample)
+    // Check only the dot separator and signature, not the user-supplied value
+    let pos =
+      try signed.rfind(".")?.usize()
+      else h.fail("no separator in signed output"); return
+      end
+    let suffix = signed.trim(pos)
+    for byte in suffix.values() do
+      // cookie-octet: 0x21-0x7E minus 0x22 ("), 0x2C (,), 0x3B (;), 0x5C (\)
+      if byte <= 0x20 then
+        h.fail("byte <= 0x20: " + byte.string()); return
+      elseif byte > 0x7E then
+        h.fail("byte > 0x7E: " + byte.string()); return
+      elseif byte == 0x22 then
+        h.fail("contains double quote"); return
+      elseif byte == 0x2C then
+        h.fail("contains comma"); return
+      elseif byte == 0x3B then
+        h.fail("contains semicolon"); return
+      elseif byte == 0x5C then
+        h.fail("contains backslash"); return
+      end
+    end
+
+class \nodoc\ iso _PropSignedCookieSignatureLength is Property1[String]
+  """
+  The signature portion (after the last `.`) is always 44 characters —
+  the Base64-URL encoding of a 32-byte HMAC with padding.
+  """
+
+  fun name(): String => "SignedCookie/prop-signature-length"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii_printable(0, 200)
+
+  fun property(sample: String, h: PropertyHelper) =>
+    let key =
+      try CookieSigningKey.generate()?
+      else h.fail("key generation failed"); return
+      end
+    let signed = SignedCookie.sign(key, sample)
+    let pos =
+      try signed.rfind(".")?.usize()
+      else h.fail("no separator in signed output"); return
+      end
+    let sig = signed.trim(pos + 1)
+    h.assert_eq[USize](44, sig.size())

--- a/hobby/cookie_signing_key.pony
+++ b/hobby/cookie_signing_key.pony
@@ -1,0 +1,31 @@
+use crypto = "ssl/crypto"
+
+class val CookieSigningKey
+  """
+  An HMAC-SHA256 signing key for use with `SignedCookie`.
+
+  Keys must be at least 32 bytes. Use `generate` to create a random key
+  or `create` to wrap an existing one.
+  """
+
+  let _key: Array[U8] val
+
+  new val create(key: Array[U8] val) ? =>
+    """
+    Wrap an existing key. Errors if `key` is shorter than 32 bytes.
+    """
+    if key.size() < 32 then error end
+    _key = key
+
+  new val generate() ? =>
+    """
+    Generate a 32-byte key from a cryptographically secure random source.
+    Errors if the runtime cannot produce secure random bytes.
+    """
+    _key = crypto.RandBytes(32)?
+
+  fun _bytes(): Array[U8] val =>
+    """
+    Return the raw key bytes.
+    """
+    _key

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -207,8 +207,10 @@ resolves to a directory, `ServeFiles` automatically serves `index.html`.
 Users import up to four packages:
 
 - **`hobby`**: Application, AfterContext, BeforeContext, BodyNotNeeded,
-  ContentTypes, HandlerContext, HandlerFactory, HandlerReceiver, Middleware,
-  RequestHandler, RouteGroup, ServeFiles, StreamingStarted
+  ContentTypes, CookieSigningKey, HandlerContext, HandlerFactory,
+  HandlerReceiver, InvalidSignature, MalformedSignedValue, Middleware,
+  RequestHandler, RouteGroup, ServeFiles, SignedCookie, SignedCookieError,
+  StreamingStarted
 - **`stallion`**: HTTP vocabulary (Status codes, Method, Headers, ServerConfig,
   ChunkedNotSupported)
 - **`lori`**: `TCPListenAuth(env.root)` for network access

--- a/hobby/signed_cookie.pony
+++ b/hobby/signed_cookie.pony
@@ -1,0 +1,62 @@
+use crypto = "ssl/crypto"
+use "encode/base64"
+
+primitive SignedCookie
+  """
+  Signs and verifies cookie values using HMAC-SHA256.
+
+  The signed format is `value.base64url(hmac)`. The value is readable
+  (not encrypted); the signature proves integrity.
+  """
+
+  fun sign(key: CookieSigningKey, value: String val): String val =>
+    """
+    Sign `value` and return the signed string `value.signature`.
+    """
+    let hmac: Array[U8] val = crypto.HmacSha256(key._bytes(), value)
+    let sig: String val =
+      Base64.encode_url[String iso](hmac where pad = true)
+    recover val
+      String(value.size() + 1 + sig.size())
+        .> append(value)
+        .> push('.')
+        .> append(sig)
+    end
+
+  fun verify(
+    key: CookieSigningKey,
+    signed_value: String val)
+    : (String val | SignedCookieError)
+  =>
+    """
+    Verify the signature on `signed_value`. Returns the original value
+    on success, or a `SignedCookieError` describing the failure.
+    """
+    let pos: ISize =
+      try
+        signed_value.rfind(".")?
+      else
+        return MalformedSignedValue
+      end
+
+    let value: String val = signed_value.trim(0, pos.usize())
+    let sig_b64: String val = signed_value.trim(pos.usize() + 1)
+
+    if sig_b64.size() == 0 then
+      return MalformedSignedValue
+    end
+
+    let decoded: Array[U8] val =
+      try
+        recover val Base64.decode_url[Array[U8] iso](sig_b64)? end
+      else
+        return MalformedSignedValue
+      end
+
+    let expected: Array[U8] val = crypto.HmacSha256(key._bytes(), value)
+
+    if crypto.ConstantTimeCompare(expected, decoded) then
+      value
+    else
+      InvalidSignature
+    end

--- a/hobby/signed_cookie_error.pony
+++ b/hobby/signed_cookie_error.pony
@@ -1,0 +1,23 @@
+primitive MalformedSignedValue
+  """
+  The signed cookie value is structurally invalid: it is missing the `.`
+  separator between the value and signature, or the signature portion is
+  empty or not valid Base64.
+  """
+
+  fun string(): String iso^ =>
+    "malformed signed value".clone()
+
+primitive InvalidSignature
+  """
+  The signature did not match the value. The cookie was tampered with or
+  signed with a different key.
+  """
+
+  fun string(): String iso^ =>
+    "invalid signature".clone()
+
+type SignedCookieError is (MalformedSignedValue | InvalidSignature)
+  """
+  Errors that can occur when verifying a signed cookie value.
+  """


### PR DESCRIPTION
Move `CookieSigningKey`, `SignedCookie`, and `SignedCookieError` from pyrois to hobby as a prerequisite for session support. Add `ssl` 2.0.1 as a direct dependency for the `ssl/crypto` subpackage (HMAC-SHA256, constant-time compare, secure random bytes).

The code is a direct copy from pyrois with no logic changes. Includes 12 unit tests and 6 property-based tests covering round-trip signing, tamper detection, key boundary validation, RFC 4231 vectors, cross-language vectors, and cookie-octet compliance.

Also adds a `signed-cookie` example demonstrating the sign/verify workflow with a visit counter cookie.

Closes #44