### PR TITLE
Fix crash when dispose() arrives before connection initialization

### DIFF
--- a/.release-notes/fix-dispose-crash.md
+++ b/.release-notes/fix-dispose-crash.md
@@ -1,0 +1,3 @@
+## Fix crash when dispose() arrives before connection initialization
+
+Fixed a crash that could occur when a connection was closed before its internal initialization completed. This timing-dependent issue was rare but was observed on macOS arm64.

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/stallion.git",
-      "version": "0.5.2"
+      "version": "0.5.3"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Pick up Stallion 0.5.3 which fixes a race between connection disposal and initialization. The race was unlikely but was observed on macOS arm64 CI.