### PR TITLE
Add request interceptors for synchronous request short-circuiting

### DIFF
--- a/.release-notes/add-request-guards.md
+++ b/.release-notes/add-request-guards.md
@@ -1,0 +1,30 @@
+## Add request interceptors for synchronous request short-circuiting
+
+Request interceptors are a new way to short-circuit requests before the handler is created. Interceptors run synchronously in the connection — if an interceptor responds, no handler actor is spawned.
+
+An interceptor returns `InterceptPass` to let the request through or `InterceptRespond` to short-circuit with an HTTP response. The return type forces an explicit decision — the compiler won't accept an interceptor that forgets to decide.
+
+```pony
+class val AuthInterceptor is hobby.RequestInterceptor
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    match request.headers.get("authorization")
+    | let _: String => hobby.InterceptPass
+    else
+      hobby.InterceptRespond(stallion.StatusUnauthorized, "Unauthorized")
+    end
+```
+
+`InterceptRespond` also supports `set_header()` and `add_header()` for custom response headers.
+
+Register interceptors on routes, groups, or the application:
+
+```pony
+let auth_interceptor: Array[hobby.RequestInterceptor val] val =
+  recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
+
+hobby.Application
+  .>get("/public", public_handler)
+  .>get("/api/data", data_handler where interceptors = auth_interceptor)
+```
+
+Application-level interceptors run before group interceptors, which run before per-route interceptors. The first interceptor that returns `InterceptRespond` wins.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,12 @@ The `ssl` option is required — Stallion transitively depends on the `ssl` pack
 
 Users interact with these types:
 
-- **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.), `group()` for route groups, `add_middleware()` for app-level middleware. `serve()` consumes the Application, freezes routes into an immutable router, and starts listening. `handler_timeout` parameter on `serve()` controls inactivity timeout (default 30 seconds, `None` to disable).
-- **`RouteGroup`** (`class iso`): Groups routes under a shared prefix and optional middleware. Supports nesting via `group()`. Consumed by `Application.group()` or outer `RouteGroup.group()`.
+- **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.), `group()` for route groups, `add_middleware()` for app-level middleware, `add_interceptor()` for app-level interceptors. Route methods accept optional `interceptors` parameter. `serve()` consumes the Application, freezes routes into an immutable router, and starts listening. `handler_timeout` parameter on `serve()` controls inactivity timeout (default 30 seconds, `None` to disable).
+- **`RouteGroup`** (`class iso`): Groups routes under a shared prefix and optional middleware/interceptors. Constructor accepts `interceptors` parameter. Supports nesting via `group()`. Consumed by `Application.group()` or outer `RouteGroup.group()`.
+- **`RequestInterceptor`** (`interface val`): Synchronous request gate. `apply(request: Request box): InterceptResult` returns `InterceptPass` or `InterceptRespond`. The return type forces an explicit decision — the compiler won't accept an interceptor that forgets to decide. Interceptors run before middleware — the first interceptor that responds wins.
+- **`InterceptResult`** (type alias): `(InterceptPass | InterceptRespond)`. Return type for request interceptors.
+- **`InterceptPass`** (`primitive`): Returned by an interceptor to pass the request through.
+- **`InterceptRespond`** (`class ref`): Returned by an interceptor to short-circuit with an HTTP response. The handler is not created. Constructed with `(status, body)`. Provides `set_header()` and `add_header()` for adding response headers.
 - **`HandlerFactory`** (type alias): `{(HandlerContext iso): (HandlerReceiver tag | None)} val`. Route handler entry point. Returns `None` for inline handlers, or a `HandlerReceiver tag` for async handlers that need lifecycle signals.
 - **`HandlerContext`** (`class iso`): Request context consumed by the handler factory. Carries `request`, `params`, `body`, and `data` (from before-middleware). Created by `_Connection` and passed to the factory.
 - **`RequestHandler`** (`class ref`): Embedded in handler actors. Created from a consumed `HandlerContext iso`. Provides `respond()`, `respond_with_headers()`, `start_streaming()`, `send_chunk()`, `finish()`, `param()`, `body()`, `get[T]()`, `request()`, `is_head()`.
@@ -60,6 +64,7 @@ Users interact with these types:
 - **`_Connection`** (`actor`): Implements `stallion.HTTPServerActor` and `_ConnectionProtocol`. State machine: `_Idle` → `_HandlerInProgress` → `_Streaming`. Runs before-middleware synchronously, calls factory, receives handler responses via protocol behaviors (`_handler_respond`, `_handler_start_streaming`, `_handler_send_chunk`, `_handler_finish`). Buffers responses for after-middleware modification. Manages handler timeout via interval-based timer.
 - **`_ConnectionProtocol`** (`trait tag`): Protocol behaviors that `RequestHandler` sends to `_Connection`.
 - **`_BufferedResponse`** (`class ref`): Mutable response buffer for after-middleware. After-middleware modifies headers via `AfterContext`, then `_Connection` serializes to wire.
+- **`_RunRequestInterceptors`** (`primitive`): Runs request interceptors in order. Returns `InterceptRespond` on first short-circuit, `None` if all pass.
 - **`_RunBeforeMiddleware`** (`primitive`): Runs middleware `before` phases on `BeforeContext ref`. Returns invoked count.
 - **`_RunAfterMiddleware`** (`primitive`): Runs middleware `after` phases in reverse on `AfterContext ref`.
 - **`_HandlerTimeoutNotify`** (`class iso is TimerNotify`): Sends `_handler_timeout(token)` to `_Connection` on each interval fire.
@@ -85,11 +90,13 @@ Users interact with these types:
 - **HEAD→GET fallback**: When no explicit HEAD route is registered, `_Connection` retries the lookup with GET.
 - **Backpressure forwarding**: `_Connection` forwards `on_throttled()`/`on_unthrottled()` to the handler actor when one is registered.
 - **Directory index auto-serving**: When a request resolves to a directory, `ServeFiles` tries `index.html`. Content type is derived from the resolved filesystem path.
+- **Request interceptors run before middleware**: Interceptors execute in `_Connection._dispatch` after route lookup but before before-middleware. An interceptor short-circuit sends the response directly to the wire without running any middleware. This is consistent with the 404 path, which also sends without middleware.
 
 ## File Layout
 
 ```
 docs/
+  interceptor-guide.md        - Writing Request Interceptors tutorial guide
   middleware-guide.md         - Writing Middleware tutorial guide
 hobby/
   hobby.pony                  - Package docstring
@@ -102,6 +109,8 @@ hobby/
   streaming_started.pony      - StreamingStarted primitive (public)
   body_not_needed.pony        - BodyNotNeeded primitive (public)
   middleware.pony              - Middleware interface (public)
+  request_interceptor.pony     - RequestInterceptor interface (public)
+  intercept_response.pony      - InterceptRespond class + result types (public)
   application.pony            - Application class (public)
   route_group.pony            - RouteGroup class (public)
   serve_files.pony            - ServeFiles handler factory (public)
@@ -111,6 +120,7 @@ hobby/
   signed_cookie_error.pony    - SignedCookieError union type (public)
   _connection_protocol.pony   - Connection protocol trait (internal)
   _buffered_response.pony     - Response buffer for after-middleware (internal)
+  _run_request_interceptors.pony - Interceptor execution (internal)
   _run_before_middleware.pony  - Before-phase execution (internal)
   _run_after_middleware.pony   - After-phase execution (internal)
   _handler_timeout.pony       - Handler timeout timer notify (internal)
@@ -135,6 +145,7 @@ hobby/
   _test_request_handler.pony   - RequestHandler unit tests with mock connection
   _test_integration.pony       - HTTP round-trip integration tests
   _test_serve_files.pony       - ServeFiles integration tests
+  _test_request_interceptor.pony - Interceptor unit + integration tests
   _test_signed_cookie.pony     - Signed cookie unit + property tests
 ```
 

--- a/docs/interceptor-guide.md
+++ b/docs/interceptor-guide.md
@@ -1,0 +1,134 @@
+# Writing Request Interceptors
+
+Request interceptors short-circuit requests before the handler is created. If an interceptor responds, no handler actor is spawned — the response goes straight to the client. Use them for cheap synchronous checks: is the auth header present? Is the content type right? Is the body too large?
+
+Anything that needs async work (verifying credentials against a database, loading session data) belongs in the handler actor, not an interceptor.
+
+## The Interface
+
+```pony
+interface val RequestInterceptor
+  fun apply(request: stallion.Request box): InterceptResult
+```
+
+An interceptor looks at the request and returns one of two things: `InterceptPass` to let it through, or `InterceptRespond` to short-circuit with a response. The return type is a union — `InterceptResult is (InterceptPass | InterceptRespond)` — so the compiler won't let you forget to decide.
+
+Here's the simplest useful interceptor, an auth header check:
+
+```pony
+class val AuthInterceptor is hobby.RequestInterceptor
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    match request.headers.get("authorization")
+    | let _: String => hobby.InterceptPass
+    else
+      hobby.InterceptRespond(stallion.StatusUnauthorized, "Unauthorized")
+    end
+```
+
+Both paths are explicit method calls or constructor calls. There's no "do nothing to pass" — you return `InterceptPass` or you return `InterceptRespond`.
+
+## Building Rejection Responses
+
+`InterceptRespond` takes a status and body at construction. For most rejections, that's all you need:
+
+```pony
+hobby.InterceptRespond(stallion.StatusForbidden, "Forbidden")
+```
+
+When you need custom headers on the response, chain `set_header()` or `add_header()` calls:
+
+```pony
+hobby.InterceptRespond(stallion.StatusTooManyRequests, "Rate limited")
+  .>set_header("retry-after", "60")
+```
+
+`set_header()` replaces any existing header with the same name (case-insensitive). `add_header()` appends without removing, which is what you want for multi-value headers like `Set-Cookie`. Both lowercase the header name.
+
+If no custom headers are set, the framework auto-adds `Content-Length` from the body size. If you set any headers, you're responsible for `Content-Length` — same as `respond_with_headers()` on the handler.
+
+## Interceptors Are `val`
+
+Interceptors must be `val` — immutable and shareable across connections. They hold no per-request state. Configuration goes in constructor parameters:
+
+```pony
+class val ContentTypeInterceptor is hobby.RequestInterceptor
+  let _expected: String
+
+  new val create(expected: String) => _expected = expected
+
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    match request.headers.get("content-type")
+    | let ct: String if ct == _expected => hobby.InterceptPass
+    else
+      hobby.InterceptRespond(stallion.StatusUnsupportedMediaType,
+        "Unsupported Media Type")
+    end
+```
+
+## Registering Interceptors
+
+Interceptors attach to routes through the `interceptors` parameter:
+
+```pony
+let auth: Array[hobby.RequestInterceptor val] val =
+  recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
+
+hobby.Application
+  .>get("/public", public_handler)
+  .>get("/private", private_handler where interceptors = auth)
+```
+
+The `recover val ... end` block lifts the array from `ref` to `val`. The `as hobby.RequestInterceptor val:` inside the literal sets the element type so the compiler knows the array holds interceptors, not concrete classes.
+
+Multiple interceptors on the same route run in array order. The first one that returns `InterceptRespond` wins — the rest don't execute:
+
+```pony
+let upload_checks: Array[hobby.RequestInterceptor val] val =
+  recover val
+    [as hobby.RequestInterceptor val:
+      AuthInterceptor
+      ContentTypeInterceptor("application/json")
+      MaxBodySizeInterceptor(1_048_576)]
+  end
+
+app.>post("/api/upload", upload_handler where interceptors = upload_checks)
+```
+
+If the auth check fails, the content type and body size checks never run.
+
+### Route Groups
+
+`RouteGroup` accepts interceptors in its constructor. Group interceptors run before per-route interceptors:
+
+```pony
+let api_interceptors: Array[hobby.RequestInterceptor val] val =
+  recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
+
+let api = hobby.RouteGroup("/api" where interceptors = api_interceptors)
+  .>get("/users", users_handler)
+  .>get("/users/:id", user_handler)
+app.>group(consume api)
+```
+
+Every route in the group gets the auth interceptor without repeating it.
+
+### Application-Level Interceptors
+
+`add_interceptor()` registers an interceptor that runs on every route:
+
+```pony
+app.>add_interceptor(RequiredHeadersInterceptor(
+  recover val ["accept"] end))
+```
+
+The execution order is: application interceptors first, then group interceptors, then per-route interceptors.
+
+## When to Use Interceptors vs. Handlers
+
+Interceptors are for cheap, synchronous, stateless checks. The request either passes or it doesn't, and deciding shouldn't require talking to another actor.
+
+If the check needs async work — querying a database, calling an external service, loading a session — it belongs in the handler actor. The handler can do async work, respond when it's ready, and has full type safety over its dependencies.
+
+The dividing line: if you can decide by looking at the request headers alone, it's an interceptor. If you need to look anything up, it's handler logic.
+
+See the [interceptors example](../examples/interceptors/main.pony) for a complete demonstration with four interceptor implementations.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@ Starts an HTTP server with two routes: a static greeting at `/` and a parameteri
 
 Demonstrates actor-based handlers that do async work before responding. A `SlowService` actor simulates an async operation (e.g., a database query or external API call). The handler actor creates a `RequestHandler`, sends a query to the service, and responds when the result arrives. Shows the `HandlerReceiver` interface for lifecycle notifications.
 
+## [interceptors](interceptors/)
+
+Demonstrates request interceptors for synchronous request short-circuiting. Includes four interceptor implementations: auth header presence check, content type validation, request body size limit, and required headers. Shows per-route interceptor registration and combining multiple interceptors on a single route.
+
 ## [middleware](middleware/)
 
 Starts an HTTP server with public and protected routes. Demonstrates two middleware patterns: an auth middleware that short-circuits with 401 in the `before` phase when a token is missing, and a logging middleware that records requests in the `after` phase. Also shows the typed accessor pattern for inter-middleware communication — `handler.get[AuthenticatedUser]()` extracts domain types from the data map.

--- a/examples/interceptors/main.pony
+++ b/examples/interceptors/main.pony
@@ -1,0 +1,133 @@
+use hobby = "hobby"
+use stallion = "stallion"
+use lori = "lori"
+
+actor Main
+  """
+  Demonstrates request interceptors for synchronous request short-circuiting.
+
+  Interceptors run before the handler is created. An interceptor returns
+  `InterceptPass` to let the request through or `InterceptRespond` to
+  short-circuit with a response — the compiler forces an explicit decision.
+
+  Routes:
+  - GET /              → always succeeds (no interceptors)
+  - GET /api/:id       → requires Authorization header
+  - POST /api/upload   → requires JSON content type, body under 1 MB
+  - GET /admin         → requires X-Admin and Authorization headers
+
+  """
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+
+    let auth_interceptor: Array[hobby.RequestInterceptor val] val =
+      recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
+
+    let upload_interceptors: Array[hobby.RequestInterceptor val] val =
+      recover val
+        [as hobby.RequestInterceptor val:
+          AuthInterceptor
+          ContentTypeInterceptor("application/json")
+          MaxBodySizeInterceptor(1_048_576)]
+      end
+
+    let admin_interceptors: Array[hobby.RequestInterceptor val] val =
+      recover val
+        [as hobby.RequestInterceptor val:
+          AuthInterceptor
+          RequiredHeadersInterceptor(
+            recover val ["x-admin"] end)]
+      end
+
+    hobby.Application
+      .>get("/", {(ctx) =>
+        hobby.RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "Hello from Hobby!")
+      } val)
+      .>get("/api/:id", {(ctx) =>
+        let handler = hobby.RequestHandler(consume ctx)
+        try
+          let id = handler.param("id")?
+          handler.respond(stallion.StatusOK, "Resource: " + id)
+        else
+          handler.respond(stallion.StatusBadRequest, "Bad Request")
+        end
+      } val where interceptors = auth_interceptor)
+      .>post("/api/upload", {(ctx) =>
+        hobby.RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "Upload accepted")
+      } val where interceptors = upload_interceptors)
+      .>get("/admin", {(ctx) =>
+        hobby.RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "Admin dashboard")
+      } val where interceptors = admin_interceptors)
+      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+
+class val AuthInterceptor is hobby.RequestInterceptor
+  """
+  Rejects requests that lack an Authorization header.
+
+  This is a cheap synchronous check — it only verifies the header is present,
+  not that the credentials are valid. Real credential validation requires
+  async work and belongs in the handler actor.
+  """
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    match request.headers.get("authorization")
+    | let _: String => hobby.InterceptPass
+    else
+      hobby.InterceptRespond(stallion.StatusUnauthorized, "Unauthorized")
+    end
+
+class val ContentTypeInterceptor is hobby.RequestInterceptor
+  """
+  Rejects requests whose Content-Type header doesn't match the expected value.
+  """
+  let _expected: String
+
+  new val create(expected: String) => _expected = expected
+
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    match request.headers.get("content-type")
+    | let ct: String if ct == _expected => hobby.InterceptPass
+    else
+      hobby.InterceptRespond(stallion.StatusUnsupportedMediaType,
+        "Unsupported Media Type")
+    end
+
+class val MaxBodySizeInterceptor is hobby.RequestInterceptor
+  """
+  Rejects requests whose Content-Length exceeds a maximum size in bytes.
+  """
+  let _max: USize
+
+  new val create(max: USize) => _max = max
+
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    match request.headers.get("content-length")
+    | let cl: String =>
+      try
+        if cl.usize()? > _max then
+          return hobby.InterceptRespond(stallion.StatusPayloadTooLarge,
+            "Payload Too Large")
+        end
+      end
+    end
+    hobby.InterceptPass
+
+class val RequiredHeadersInterceptor is hobby.RequestInterceptor
+  """
+  Rejects requests that are missing any of the required headers.
+  """
+  let _headers: Array[String] val
+
+  new val create(headers: Array[String] val) => _headers = headers
+
+  fun apply(request: stallion.Request box): hobby.InterceptResult =>
+    for h in _headers.values() do
+      if request.headers.get(h) is None then
+        return hobby.InterceptRespond(stallion.StatusBadRequest,
+          "Missing required header: " + h)
+      end
+    end
+    hobby.InterceptPass
+

--- a/hobby/_buffered_response.pony
+++ b/hobby/_buffered_response.pony
@@ -43,6 +43,41 @@ class ref _BufferedResponse
     is_streaming = false
     is_head = is_head'
 
+  new ref _from_intercept_respond(respond: InterceptRespond ref,
+    is_head': Bool)
+  =>
+    """Create a buffered response from an interceptor short-circuit."""
+    status = respond._response_status()
+    headers = Array[(String, String)]
+    var i: USize = 0
+    while i < respond._headers_size() do
+      try
+        headers.push(respond._header_at(i)?)
+      else
+        _Unreachable()
+      end
+      i = i + 1
+    end
+    let b = respond._response_body()
+    // Auto-add content-length if not explicitly set
+    var has_content_length = false
+    for (n, _) in headers.values() do
+      if n == "content-length" then
+        has_content_length = true
+        break
+      end
+    end
+    if not has_content_length then
+      let body_size: USize = match \exhaustive\ b
+      | let s: String val => s.size()
+      | let a: Array[U8] val => a.size()
+      end
+      headers.push(("content-length", body_size.string()))
+    end
+    body = b
+    is_streaming = false
+    is_head = is_head'
+
   new ref _streaming_complete(status': stallion.Status, is_head': Bool) =>
     """Create a buffered response for after-middleware on stream finish."""
     status = status'

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -152,6 +152,14 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
     responder: stallion.Responder, body: Array[U8] val,
     m: _RouteMatch, is_head: Bool)
   =>
+    // Run interceptors — short-circuit before creating middleware or handler state
+    match _RunRequestInterceptors(request', m.interceptors)
+    | let respond: InterceptRespond =>
+      let buf = _BufferedResponse._from_intercept_respond(respond, is_head)
+      responder.respond(buf._build())
+      return
+    end
+
     // Run before-middleware synchronously
     let before_ctx = BeforeContext._create(request', m.params, body)
     let invoked = _RunBeforeMiddleware(before_ctx, m.middleware)

--- a/hobby/_flatten.pony
+++ b/hobby/_flatten.pony
@@ -63,3 +63,36 @@ primitive _ConcatMiddleware
     else
       None
     end
+
+primitive _ConcatInterceptors
+  """
+  Concatenate two optional interceptor arrays.
+
+  Returns a combined array with outer interceptors first, then inner.
+  When one side is `None`, returns the other directly (no allocation).
+  When both are `None`, returns `None`.
+  """
+  fun apply(
+    outer: (Array[RequestInterceptor val] val | None),
+    inner: (Array[RequestInterceptor val] val | None))
+    : (Array[RequestInterceptor val] val | None)
+  =>
+    match (outer, inner)
+    | (let o: Array[RequestInterceptor val] val,
+       let i: Array[RequestInterceptor val] val) =>
+      recover val
+        let combined =
+          Array[RequestInterceptor val](o.size() + i.size())
+        for g in o.values() do
+          combined.push(g)
+        end
+        for g in i.values() do
+          combined.push(g)
+        end
+        combined
+      end
+    | (let o: Array[RequestInterceptor val] val, None) => o
+    | (None, let i: Array[RequestInterceptor val] val) => i
+    else
+      None
+    end

--- a/hobby/_route_definition.pony
+++ b/hobby/_route_definition.pony
@@ -12,12 +12,15 @@ class val _RouteDefinition
   let path: String
   let factory: HandlerFactory
   let middleware: (Array[Middleware val] val | None)
+  let interceptors: (Array[RequestInterceptor val] val | None)
 
   new val create(method': stallion.Method, path': String,
     factory': HandlerFactory,
-    middleware': (Array[Middleware val] val | None))
+    middleware': (Array[Middleware val] val | None),
+    interceptors': (Array[RequestInterceptor val] val | None) = None)
   =>
     method = method'
     path = path'
     factory = factory'
     middleware = middleware'
+    interceptors = interceptors'

--- a/hobby/_route_match.pony
+++ b/hobby/_route_match.pony
@@ -10,12 +10,15 @@ class val _RouteMatch
   """
   let factory: HandlerFactory
   let middleware: (Array[Middleware val] val | None)
+  let interceptors: (Array[RequestInterceptor val] val | None)
   let params: Map[String, String] val
 
   new val create(factory': HandlerFactory,
     middleware': (Array[Middleware val] val | None),
+    interceptors': (Array[RequestInterceptor val] val | None),
     params': Map[String, String] val)
   =>
     factory = factory'
     middleware = middleware'
+    interceptors = interceptors'
     params = params'

--- a/hobby/_router.pony
+++ b/hobby/_router.pony
@@ -13,7 +13,8 @@ class ref _RouterBuilder
     _trees = Map[String, _BuildNode ref]
 
   fun ref add(method: stallion.Method, path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None))
+    middleware: (Array[Middleware val] val | None),
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a route. The path must start with `/`."""
     let normalized = _NormalizePath(path)
@@ -25,7 +26,7 @@ class ref _RouterBuilder
       _trees(method_key) = node
       node
     end
-    tree.insert(normalized, factory, middleware)
+    tree.insert(normalized, factory, middleware, interceptors)
 
   fun ref build(): _Router val =>
     """Freeze the builder into an immutable router."""
@@ -87,48 +88,55 @@ class ref _BuildNode
   var _prefix: String = ""
   var _factory: (HandlerFactory | None) = None
   var _middleware: (Array[Middleware val] val | None) = None
+  var _interceptors: (Array[RequestInterceptor val] val | None) = None
   var _param_name: String = ""
   embed _children: Map[U8, _BuildNode ref] = Map[U8, _BuildNode ref]
   var _param_child: (_BuildNode ref | None) = None
   var _wildcard_factory: (HandlerFactory | None) = None
   var _wildcard_middleware: (Array[Middleware val] val | None) = None
+  var _wildcard_interceptors: (Array[RequestInterceptor val] val | None) = None
   var _wildcard_name: String = ""
 
   new create(prefix: String = "") =>
     _prefix = prefix
 
   fun ref insert(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None))
+    middleware: (Array[Middleware val] val | None),
+    interceptors: (Array[RequestInterceptor val] val | None))
   =>
     """Insert a route path into this subtree."""
-    _insert(path, 0, factory, middleware)
+    _insert(path, 0, factory, middleware, interceptors)
 
   fun ref _insert(path: String, offset: USize, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None))
+    middleware: (Array[Middleware val] val | None),
+    interceptors: (Array[RequestInterceptor val] val | None))
   =>
     if offset >= path.size() then
       _factory = factory
       _middleware = middleware
+      _interceptors = interceptors
       return
     end
 
     try
       let c = path(offset)?
       if c == ':' then
-        _insert_param(path, offset, factory, middleware)
+        _insert_param(path, offset, factory, middleware, interceptors)
       elseif c == '*' then
         _wildcard_factory = factory
         _wildcard_middleware = middleware
+        _wildcard_interceptors = interceptors
         _wildcard_name = path.trim(offset + 1)
       else
-        _insert_static(path, offset, factory, middleware)
+        _insert_static(path, offset, factory, middleware, interceptors)
       end
     else
       _Unreachable()
     end
 
   fun ref _insert_param(path: String, offset: USize, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None))
+    middleware: (Array[Middleware val] val | None),
+    interceptors: (Array[RequestInterceptor val] val | None))
   =>
     let name_end = _Paths.find_char(path, '/', offset + 1)
     let name = path.trim(offset + 1, name_end)
@@ -143,12 +151,14 @@ class ref _BuildNode
     if name_end >= path.size() then
       child._factory = factory
       child._middleware = middleware
+      child._interceptors = interceptors
     else
-      child._insert(path, name_end, factory, middleware)
+      child._insert(path, name_end, factory, middleware, interceptors)
     end
 
   fun ref _insert_static(path: String, offset: USize, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None))
+    middleware: (Array[Middleware val] val | None),
+    interceptors: (Array[RequestInterceptor val] val | None))
   =>
     try
       let c = path(offset)?
@@ -157,7 +167,7 @@ class ref _BuildNode
         let common = _Paths.common_prefix_len(child._prefix,
           path.trim(offset))
         if common == child._prefix.size() then
-          child._insert(path, offset + common, factory, middleware)
+          child._insert(path, offset + common, factory, middleware, interceptors)
         else
           // Split the child node at the divergence point
           let new_parent = _BuildNode(child._prefix.trim(0, common))
@@ -170,7 +180,8 @@ class ref _BuildNode
           end
           // Route through _insert so special characters (`:`, `*`) in the
           // remaining suffix are parsed instead of stored as literal prefix.
-          new_parent._insert(path, offset + common, factory, middleware)
+          new_parent._insert(path, offset + common, factory, middleware,
+            interceptors)
           _children(c) = new_parent
         end
       else
@@ -179,12 +190,13 @@ class ref _BuildNode
         let special = _Paths.find_special(remaining)
         if special < remaining.size() then
           let child = _BuildNode(remaining.trim(0, special))
-          child._insert(path, offset + special, factory, middleware)
+          child._insert(path, offset + special, factory, middleware, interceptors)
           _children(c) = child
         else
           let child = _BuildNode(remaining)
           child._factory = factory
           child._middleware = middleware
+          child._interceptors = interceptors
           _children(c) = child
         end
       end
@@ -204,9 +216,9 @@ class ref _BuildNode
     else
       None
     end
-    _TreeNode._create(_prefix, _factory, _middleware, _param_name,
+    _TreeNode._create(_prefix, _factory, _middleware, _interceptors, _param_name,
       consume frozen_children, frozen_param, _wildcard_factory,
-      _wildcard_middleware, _wildcard_name)
+      _wildcard_middleware, _wildcard_interceptors, _wildcard_name)
 
 // --- Immutable lookup node ---
 
@@ -220,35 +232,43 @@ class val _TreeNode
   let _prefix: String
   let _factory: (HandlerFactory | None)
   let _middleware: (Array[Middleware val] val | None)
+  let _interceptors: (Array[RequestInterceptor val] val | None)
   let _param_name: String
   let _children: Array[(U8, _TreeNode val)] val
   let _param_child: (_TreeNode val | None)
   let _wildcard_factory: (HandlerFactory | None)
   let _wildcard_middleware: (Array[Middleware val] val | None)
+  let _wildcard_interceptors: (Array[RequestInterceptor val] val | None)
   let _wildcard_name: String
 
   new val _create(prefix: String, factory': (HandlerFactory | None),
-    middleware': (Array[Middleware val] val | None), param_name: String,
+    middleware': (Array[Middleware val] val | None),
+    interceptors': (Array[RequestInterceptor val] val | None),
+    param_name: String,
     children: Array[(U8, _TreeNode val)] iso,
     param_child: (_TreeNode val | None),
     wildcard_factory': (HandlerFactory | None),
     wildcard_middleware': (Array[Middleware val] val | None),
+    wildcard_interceptors': (Array[RequestInterceptor val] val | None),
     wildcard_name: String)
   =>
     _prefix = prefix
     _factory = factory'
     _middleware = middleware'
+    _interceptors = interceptors'
     _param_name = param_name
     _children = consume children
     _param_child = param_child
     _wildcard_factory = wildcard_factory'
     _wildcard_middleware = wildcard_middleware'
+    _wildcard_interceptors = wildcard_interceptors'
     _wildcard_name = wildcard_name
 
   fun lookup(path: String): (_RouteMatch | None) =>
     """Find a matching route for the given path."""
     match _lookup(path, 0)
     | (let f: HandlerFactory, let mw: (Array[Middleware val] val | None),
+       let gs: (Array[RequestInterceptor val] val | None),
        let p: Array[(String, String)] val) =>
       let frozen: Map[String, String] val = recover val
         let m = Map[String, String]
@@ -257,17 +277,19 @@ class val _TreeNode
         end
         m
       end
-      _RouteMatch(f, mw, frozen)
+      _RouteMatch(f, mw, gs, frozen)
     else
       None
     end
 
   fun _lookup(path: String, offset: USize):
     ((HandlerFactory, (Array[Middleware val] val | None),
+      (Array[RequestInterceptor val] val | None),
       Array[(String, String)] val) | None)
   =>
     """
-    Recursive lookup returning factory, middleware, and accumulated params.
+    Recursive lookup returning factory, middleware, interceptors, and accumulated
+    params.
 
     Params are built bottom-up: the leaf returns an empty val array, and each
     param level prepends its parameter to the child's val result.
@@ -277,7 +299,8 @@ class val _TreeNode
 
     if offset >= path.size() then
       match _factory
-      | let f: HandlerFactory => return (f, _middleware, empty_params)
+      | let f: HandlerFactory =>
+        return (f, _middleware, _interceptors, empty_params)
       end
       return None
     end
@@ -291,8 +314,9 @@ class val _TreeNode
             match child._lookup(path, offset + child._prefix.size())
             | (let f: HandlerFactory,
                let mw: (Array[Middleware val] val | None),
+               let gs: (Array[RequestInterceptor val] val | None),
                let p: Array[(String, String)] val) =>
-              return (f, mw, p)
+              return (f, mw, gs, p)
             end
           end
           break
@@ -311,6 +335,7 @@ class val _TreeNode
         match child._lookup(path, value_end)
         | (let f: HandlerFactory,
            let mw: (Array[Middleware val] val | None),
+           let gs: (Array[RequestInterceptor val] val | None),
            let child_params: Array[(String, String)] val) =>
           let with_param: Array[(String, String)] val = recover val
             let a = Array[(String, String)]
@@ -320,7 +345,7 @@ class val _TreeNode
             end
             a
           end
-          return (f, mw, with_param)
+          return (f, mw, gs, with_param)
         end
       end
     end
@@ -334,7 +359,7 @@ class val _TreeNode
         a.push((_wildcard_name, remainder))
         a
       end
-      return (f, _wildcard_middleware, wildcard_params)
+      return (f, _wildcard_middleware, _wildcard_interceptors, wildcard_params)
     end
 
     None

--- a/hobby/_run_request_interceptors.pony
+++ b/hobby/_run_request_interceptors.pony
@@ -1,0 +1,29 @@
+use stallion = "stallion"
+
+primitive _RunRequestInterceptors
+  """
+  Run request interceptors in order on a request.
+
+  Calls each interceptor and inspects the result. Stops on the first
+  `InterceptRespond`. Returns the response if any interceptor short-circuited,
+  or `None` if all passed.
+  """
+  fun apply(request: stallion.Request val,
+    interceptors: (Array[RequestInterceptor val] val | None))
+    : (InterceptRespond | None)
+  =>
+    match interceptors
+    | let ints: Array[RequestInterceptor val] val =>
+      var i: USize = 0
+      while i < ints.size() do
+        try
+          match ints(i)?(request)
+          | let respond: InterceptRespond => return respond
+          end
+        else
+          _Unreachable()
+        end
+        i = i + 1
+      end
+    end
+    None

--- a/hobby/_test.pony
+++ b/hobby/_test.pony
@@ -11,6 +11,7 @@ actor \nodoc\ Main is TestList
     _TestHttpDateList.tests(test)
     _TestETagList.tests(test)
     _TestRequestHandlerList.tests(test)
+    _TestRequestInterceptorList.tests(test)
     _TestIntegrationList.tests(test)
     _TestServeFilesList.tests(test)
     _TestSignedCookieList.tests(test)

--- a/hobby/_test_integration.pony
+++ b/hobby/_test_integration.pony
@@ -209,11 +209,13 @@ class \nodoc\ val _StreamingAfterHeaderMiddleware is Middleware
 primitive \nodoc\ _IntegrationHelpers
   fun build_router(
     routes: Array[(stallion.Method, String, HandlerFactory,
-      (Array[Middleware val] val | None))] val): _Router val
+      (Array[Middleware val] val | None))] val,
+    interceptors': (Array[RequestInterceptor val] val | None) = None):
+    _Router val
   =>
     let builder = _RouterBuilder
     for (method, path, factory, middleware) in routes.values() do
-      builder.add(method, path, factory, middleware)
+      builder.add(method, path, factory, middleware, interceptors')
     end
     builder.build()
 

--- a/hobby/_test_request_interceptor.pony
+++ b/hobby/_test_request_interceptor.pony
@@ -1,0 +1,310 @@
+use "collections"
+use "pony_test"
+use "uri"
+use stallion = "stallion"
+use lori = "lori"
+
+primitive \nodoc\ _TestRequestInterceptorList
+  fun tests(test: PonyTest) =>
+    test(_TestInterceptRespondSetHeader)
+    test(_TestInterceptRespondSetHeaderReplace)
+    test(_TestInterceptRespondSetHeaderCaseInsensitive)
+    test(_TestInterceptRespondAddHeader)
+    test(_TestInterceptRespondAddHeaderMultiple)
+    test(_TestRunInterceptorsNone)
+    test(_TestRunInterceptorsPass)
+    test(_TestRunInterceptorsReject)
+    test(_TestRunInterceptorsFirstRejectWins)
+    test(_TestConcatInterceptorsNone)
+    test(_TestConcatInterceptorsBoth)
+    test(_TestConcatInterceptorsOuterOnly)
+    test(_TestConcatInterceptorsInnerOnly)
+    test(_TestInterceptRespondIntegration)
+    test(_TestInterceptPassIntegration)
+    test(_TestInterceptWithMiddlewareIntegration)
+    test(_TestInterceptGroupIntegration)
+    test(_TestAppInterceptIntegration)
+
+// --- Test interceptors ---
+
+class \nodoc\ val _RejectInterceptor is RequestInterceptor
+  fun apply(request: stallion.Request box): InterceptResult =>
+    InterceptRespond(stallion.StatusForbidden, "Forbidden by interceptor")
+
+class \nodoc\ val _RejectWithHeaderInterceptor is RequestInterceptor
+  fun apply(request: stallion.Request box): InterceptResult =>
+    InterceptRespond(stallion.StatusForbidden, "Forbidden")
+      .>set_header("x-interceptor", "rejected")
+
+class \nodoc\ val _PassInterceptor is RequestInterceptor
+  fun apply(request: stallion.Request box): InterceptResult =>
+    InterceptPass
+
+class \nodoc\ val _AuthHeaderInterceptor is RequestInterceptor
+  fun apply(request: stallion.Request box): InterceptResult =>
+    match request.headers.get("authorization")
+    | let _: String => InterceptPass
+    else
+      InterceptRespond(stallion.StatusUnauthorized, "Unauthorized")
+    end
+
+// --- InterceptRespond unit tests ---
+
+class \nodoc\ iso _TestInterceptRespondSetHeader is UnitTest
+  fun name(): String => "interceptor/reject set_header"
+
+  fun apply(h: TestHelper) =>
+    let r = InterceptRespond(stallion.StatusForbidden, "no")
+    r.set_header("X-Custom", "value")
+    h.assert_eq[USize](1, r._headers_size())
+    try
+      (let n, let v) = r._header_at(0)?
+      h.assert_eq[String]("x-custom", n)
+      h.assert_eq[String]("value", v)
+    else
+      h.fail("header not found")
+    end
+
+class \nodoc\ iso _TestInterceptRespondSetHeaderReplace is UnitTest
+  fun name(): String => "interceptor/reject set_header replace"
+
+  fun apply(h: TestHelper) =>
+    let r = InterceptRespond(stallion.StatusForbidden, "no")
+    r.set_header("x-custom", "old")
+    r.set_header("x-custom", "new")
+    h.assert_eq[USize](1, r._headers_size())
+    try
+      (_, let v) = r._header_at(0)?
+      h.assert_eq[String]("new", v)
+    else
+      h.fail("header not found")
+    end
+
+class \nodoc\ iso _TestInterceptRespondSetHeaderCaseInsensitive is UnitTest
+  fun name(): String => "interceptor/reject set_header case insensitive"
+
+  fun apply(h: TestHelper) =>
+    let r = InterceptRespond(stallion.StatusForbidden, "no")
+    r.set_header("X-Custom", "old")
+    r.set_header("x-custom", "new")
+    h.assert_eq[USize](1, r._headers_size())
+    try
+      (_, let v) = r._header_at(0)?
+      h.assert_eq[String]("new", v)
+    else
+      h.fail("header not found")
+    end
+
+class \nodoc\ iso _TestInterceptRespondAddHeader is UnitTest
+  fun name(): String => "interceptor/reject add_header"
+
+  fun apply(h: TestHelper) =>
+    let r = InterceptRespond(stallion.StatusForbidden, "no")
+    r.add_header("Set-Cookie", "a=1")
+    h.assert_eq[USize](1, r._headers_size())
+    try
+      (let n, let v) = r._header_at(0)?
+      h.assert_eq[String]("set-cookie", n)
+      h.assert_eq[String]("a=1", v)
+    else
+      h.fail("header not found")
+    end
+
+class \nodoc\ iso _TestInterceptRespondAddHeaderMultiple is UnitTest
+  fun name(): String => "interceptor/reject add_header multiple"
+
+  fun apply(h: TestHelper) =>
+    let r = InterceptRespond(stallion.StatusForbidden, "no")
+    r.add_header("Set-Cookie", "a=1")
+    r.add_header("Set-Cookie", "b=2")
+    h.assert_eq[USize](2, r._headers_size())
+
+// --- _RunRequestInterceptors unit tests ---
+
+class \nodoc\ iso _TestRunInterceptorsNone is UnitTest
+  fun name(): String => "interceptor/run interceptors none"
+
+  fun apply(h: TestHelper) =>
+    let request = _InterceptorTestRequest()
+    h.assert_true(_RunRequestInterceptors(request, None) is None)
+
+class \nodoc\ iso _TestRunInterceptorsPass is UnitTest
+  fun name(): String => "interceptor/run interceptors pass"
+
+  fun apply(h: TestHelper) =>
+    let request = _InterceptorTestRequest()
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    h.assert_true(_RunRequestInterceptors(request, interceptors) is None)
+
+class \nodoc\ iso _TestRunInterceptorsReject is UnitTest
+  fun name(): String => "interceptor/run interceptors reject"
+
+  fun apply(h: TestHelper) =>
+    let request = _InterceptorTestRequest()
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    match _RunRequestInterceptors(request, interceptors)
+    | let r: InterceptRespond =>
+      h.assert_true(r._response_status() is stallion.StatusForbidden)
+    else
+      h.fail("expected rejection")
+    end
+
+class \nodoc\ iso _TestRunInterceptorsFirstRejectWins is UnitTest
+  fun name(): String => "interceptor/run interceptors first reject wins"
+
+  fun apply(h: TestHelper) =>
+    let request = _InterceptorTestRequest()
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val
+        [as RequestInterceptor val: _PassInterceptor; _RejectInterceptor; _PassInterceptor]
+      end
+    match _RunRequestInterceptors(request, interceptors)
+    | let r: InterceptRespond =>
+      h.assert_true(r._response_status() is stallion.StatusForbidden)
+    else
+      h.fail("expected rejection")
+    end
+
+// --- _ConcatInterceptors unit tests ---
+
+class \nodoc\ iso _TestConcatInterceptorsNone is UnitTest
+  fun name(): String => "interceptor/concat interceptors none"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(_ConcatInterceptors(None, None) is None)
+
+class \nodoc\ iso _TestConcatInterceptorsBoth is UnitTest
+  fun name(): String => "interceptor/concat interceptors both"
+
+  fun apply(h: TestHelper) =>
+    let outer: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let inner: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    match _ConcatInterceptors(outer, inner)
+    | let combined: Array[RequestInterceptor val] val =>
+      h.assert_eq[USize](2, combined.size())
+    else
+      h.fail("expected combined array")
+    end
+
+class \nodoc\ iso _TestConcatInterceptorsOuterOnly is UnitTest
+  fun name(): String => "interceptor/concat interceptors outer only"
+
+  fun apply(h: TestHelper) =>
+    let outer: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    match _ConcatInterceptors(outer, None)
+    | let result: Array[RequestInterceptor val] val =>
+      h.assert_eq[USize](1, result.size())
+    else
+      h.fail("expected array")
+    end
+
+class \nodoc\ iso _TestConcatInterceptorsInnerOnly is UnitTest
+  fun name(): String => "interceptor/concat interceptors inner only"
+
+  fun apply(h: TestHelper) =>
+    let inner: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    match _ConcatInterceptors(None, inner)
+    | let result: Array[RequestInterceptor val] val =>
+      h.assert_eq[USize](1, result.size())
+    else
+      h.fail("expected array")
+    end
+
+// --- Integration tests ---
+
+class \nodoc\ iso _TestInterceptRespondIntegration is UnitTest
+  fun name(): String => "integration/interceptor reject"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let router = _IntegrationHelpers.build_router(recover val
+      [(stallion.GET, "/", _HelloFactory, None)]
+    end where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(h, router,
+      "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "Forbidden by interceptor")
+
+class \nodoc\ iso _TestInterceptPassIntegration is UnitTest
+  fun name(): String => "integration/interceptor pass"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let router = _IntegrationHelpers.build_router(recover val
+      [(stallion.GET, "/", _HelloFactory, None)]
+    end where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(h, router,
+      "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "Hello from Hobby!")
+
+class \nodoc\ iso _TestInterceptWithMiddlewareIntegration is UnitTest
+  fun name(): String => "integration/interceptor with middleware"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let mw: Array[Middleware val] val =
+      recover val
+        [as Middleware val: _SetDataMiddleware("test_key", "from_middleware")]
+      end
+    let router = _IntegrationHelpers.build_router(recover val
+      [(stallion.GET, "/", _DataReadFactory, mw)]
+    end where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(h, router,
+      "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "from_middleware")
+
+class \nodoc\ iso _TestInterceptGroupIntegration is UnitTest
+  """Interceptors on a route group reject before the handler runs."""
+  fun name(): String => "integration/interceptor route group"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/api/users", _HelloFactory, None, interceptors)
+    let router = builder.build()
+    _IntegrationHelpers.run_test(h, router,
+      "GET /api/users HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "Forbidden by interceptor")
+
+class \nodoc\ iso _TestAppInterceptIntegration is UnitTest
+  fun name(): String => "integration/app-level interceptor"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let router = _IntegrationHelpers.build_router(recover val
+      [(stallion.GET, "/", _HelloFactory, None)]
+    end where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(h, router,
+      "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "Forbidden by interceptor")
+
+// --- Helpers ---
+
+primitive \nodoc\ _InterceptorTestRequest
+  fun apply(): stallion.Request val =>
+    let mock_uri = URI(None, None, "/", None, None)
+    let mock_headers: stallion.Headers val =
+      recover val stallion.Headers end
+    let mock_cookies = stallion.ParseCookies("")
+    stallion.Request(stallion.GET, mock_uri, stallion.HTTP11,
+      mock_headers, mock_cookies)

--- a/hobby/application.pony
+++ b/hobby/application.pony
@@ -41,61 +41,77 @@ class iso Application
   """
   embed _routes: Array[_RouteDefinition]
   embed _app_middleware: Array[Middleware val]
+  embed _app_interceptors: Array[RequestInterceptor val]
 
   new iso create() =>
     _routes = Array[_RouteDefinition]
     _app_middleware = Array[Middleware val]
+    _app_interceptors = Array[RequestInterceptor val]
 
   fun ref get(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a GET route."""
-    _routes.push(_RouteDefinition(stallion.GET, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.GET, path, factory, middleware, interceptors))
 
   fun ref post(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a POST route."""
-    _routes.push(_RouteDefinition(stallion.POST, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.POST, path, factory, middleware, interceptors))
 
   fun ref put(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a PUT route."""
-    _routes.push(_RouteDefinition(stallion.PUT, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.PUT, path, factory, middleware, interceptors))
 
   fun ref delete(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a DELETE route."""
     _routes.push(
-      _RouteDefinition(stallion.DELETE, path, factory, middleware))
+      _RouteDefinition(stallion.DELETE, path, factory, middleware, interceptors))
 
   fun ref patch(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a PATCH route."""
-    _routes.push(_RouteDefinition(stallion.PATCH, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.PATCH, path, factory, middleware, interceptors))
 
   fun ref head(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a HEAD route."""
-    _routes.push(_RouteDefinition(stallion.HEAD, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.HEAD, path, factory, middleware, interceptors))
 
   fun ref options(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register an OPTIONS route."""
     _routes.push(
-      _RouteDefinition(stallion.OPTIONS, path, factory, middleware))
+      _RouteDefinition(stallion.OPTIONS, path, factory, middleware, interceptors))
 
   fun ref route(method: stallion.Method, path: String,
     factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a route with an arbitrary HTTP method."""
-    _routes.push(_RouteDefinition(method, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(method, path, factory, middleware, interceptors))
 
   fun ref add_middleware(middleware: Array[Middleware val] val) =>
     """
@@ -108,6 +124,17 @@ class iso Application
     for m in middleware.values() do
       _app_middleware.push(m)
     end
+
+  fun ref add_interceptor(interceptor: RequestInterceptor val) =>
+    """
+    Add an application-level request interceptor.
+
+    Interceptors run before middleware on every route. Application interceptors
+    run before group interceptors, which run before per-route interceptors. The
+    first interceptor that calls `respond()` rejects the request — the handler
+    is never created.
+    """
+    _app_interceptors.push(interceptor)
 
   fun ref group(g: RouteGroup iso) =>
     """
@@ -149,10 +176,26 @@ class iso Application
         None
       end
 
+    // Build app-level interceptors as a val array (or None if empty)
+    let app_interceptors: (Array[RequestInterceptor val] val | None) =
+      if self._app_interceptors.size() > 0 then
+        let gs_iso: Array[RequestInterceptor val] iso =
+          recover iso Array[RequestInterceptor val] end
+        for g in self._app_interceptors.values() do
+          gs_iso.push(g)
+        end
+        consume gs_iso
+      else
+        None
+      end
+
     let builder = _RouterBuilder
     for r in self._routes.values() do
       let combined_mw = _ConcatMiddleware(app_mw, r.middleware)
-      builder.add(r.method, r.path, r.factory, combined_mw)
+      let combined_interceptors =
+        _ConcatInterceptors(app_interceptors, r.interceptors)
+      builder.add(r.method, r.path, r.factory, combined_mw,
+        combined_interceptors)
     end
     let router: _Router val = builder.build()
 

--- a/hobby/intercept_response.pony
+++ b/hobby/intercept_response.pony
@@ -1,0 +1,79 @@
+use stallion = "stallion"
+
+primitive InterceptPass
+  """
+  Returned by a request interceptor to pass the request through to the handler.
+  """
+
+class ref InterceptRespond
+  """
+  Returned by a request interceptor to short-circuit with an HTTP response.
+
+  The handler is not created — the interceptor's response goes directly to
+  the client. Use for rejections (401, 403, 413), cached responses (304),
+  redirects (301, 302), or any case where the handler isn't needed.
+
+  Build the response with `set_header()`, `add_header()`, and the status
+  and body provided at construction.
+
+  ```pony
+  // Reject unauthorized
+  InterceptRespond(stallion.StatusUnauthorized, "Unauthorized")
+
+  // Short-circuit with custom headers
+  InterceptRespond(stallion.StatusTooManyRequests, "Rate limited")
+    .>set_header("retry-after", "60")
+  ```
+  """
+  let _status: stallion.Status
+  let _body: ByteSeq
+  embed _headers: Array[(String, String)]
+
+  new ref create(status: stallion.Status, body: ByteSeq) =>
+    _status = status
+    _body = body
+    _headers = Array[(String, String)]
+
+  fun ref set_header(name: String, value: String) =>
+    """
+    Set a response header, replacing any existing header with the same name.
+
+    The name is lowercased for consistency with HTTP's case-insensitive
+    header names.
+    """
+    let lower_name: String val = name.lower()
+    var i: USize = 0
+    while i < _headers.size() do
+      try
+        if _headers(i)?._1 == lower_name then
+          try _headers.delete(i)? end
+        else
+          i = i + 1
+        end
+      else
+        _Unreachable()
+      end
+    end
+    _headers.push((lower_name, value))
+
+  fun ref add_header(name: String, value: String) =>
+    """
+    Add a response header without removing existing entries.
+
+    The name is lowercased for consistency. Use for multi-value headers like
+    `Set-Cookie`.
+    """
+    _headers.push((name.lower(), value))
+
+  // --- Package-private accessors for _Connection ---
+
+  fun box _response_status(): stallion.Status => _status
+  fun box _response_body(): ByteSeq => _body
+  fun box _headers_size(): USize => _headers.size()
+  fun box _header_at(i: USize): (String, String) ? => _headers(i)?
+
+type InterceptResult is (InterceptPass | InterceptRespond)
+  """
+  The result of a request interceptor: either pass the request through or
+  short-circuit with a response.
+  """

--- a/hobby/request_interceptor.pony
+++ b/hobby/request_interceptor.pony
@@ -1,0 +1,17 @@
+use stallion = "stallion"
+
+interface val RequestInterceptor
+  """
+  Synchronous request interceptor that runs before the handler is created.
+
+  Interceptors inspect the request and return `InterceptPass` to let it
+  through or `InterceptRespond` to short-circuit with an HTTP response.
+  The return type forces an explicit decision — the compiler won't accept
+  an interceptor that forgets to decide.
+
+  Interceptors are `val` and must be stateless or capture only immutable
+  configuration. They run synchronously in the connection actor, so they
+  should do only cheap work (header checks, size limits). Expensive or
+  async work belongs in the handler.
+  """
+  fun apply(request: stallion.Request box): InterceptResult

--- a/hobby/route_group.pony
+++ b/hobby/route_group.pony
@@ -24,71 +24,89 @@ class iso RouteGroup
   """
   let _prefix: String
   let _middleware: (Array[Middleware val] val | None)
+  let _interceptors: (Array[RequestInterceptor val] val | None)
   embed _routes: Array[_RouteDefinition]
 
   new iso create(prefix: String,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """
-    Create a route group with a path prefix and optional middleware.
+    Create a route group with a path prefix and optional middleware/interceptors.
 
     The prefix is prepended to every route path in the group. Middleware, if
-    provided, runs before each route's own middleware.
+    provided, runs before each route's own middleware. Interceptors, if
+    provided, run before each route's own interceptors.
     """
     _prefix = prefix
     _middleware = middleware
+    _interceptors = interceptors
     _routes = Array[_RouteDefinition]
 
   fun ref get(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a GET route."""
-    _routes.push(_RouteDefinition(stallion.GET, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.GET, path, factory, middleware, interceptors))
 
   fun ref post(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a POST route."""
-    _routes.push(_RouteDefinition(stallion.POST, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.POST, path, factory, middleware, interceptors))
 
   fun ref put(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a PUT route."""
-    _routes.push(_RouteDefinition(stallion.PUT, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.PUT, path, factory, middleware, interceptors))
 
   fun ref delete(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a DELETE route."""
     _routes.push(
-      _RouteDefinition(stallion.DELETE, path, factory, middleware))
+      _RouteDefinition(stallion.DELETE, path, factory, middleware, interceptors))
 
   fun ref patch(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a PATCH route."""
-    _routes.push(_RouteDefinition(stallion.PATCH, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.PATCH, path, factory, middleware, interceptors))
 
   fun ref head(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a HEAD route."""
-    _routes.push(_RouteDefinition(stallion.HEAD, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(stallion.HEAD, path, factory, middleware, interceptors))
 
   fun ref options(path: String, factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register an OPTIONS route."""
     _routes.push(
-      _RouteDefinition(stallion.OPTIONS, path, factory, middleware))
+      _RouteDefinition(stallion.OPTIONS, path, factory, middleware, interceptors))
 
   fun ref route(method: stallion.Method, path: String,
     factory: HandlerFactory,
-    middleware: (Array[Middleware val] val | None) = None)
+    middleware: (Array[Middleware val] val | None) = None,
+    interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
     """Register a route with an arbitrary HTTP method."""
-    _routes.push(_RouteDefinition(method, path, factory, middleware))
+    _routes.push(
+      _RouteDefinition(method, path, factory, middleware, interceptors))
 
   fun ref group(inner: RouteGroup iso) =>
     """
@@ -105,6 +123,8 @@ class iso RouteGroup
     for r in _routes.values() do
       let joined_path = _JoinPath(_prefix, r.path)
       let combined_mw = _ConcatMiddleware(_middleware, r.middleware)
+      let combined_interceptors =
+        _ConcatInterceptors(_interceptors, r.interceptors)
       target.push(_RouteDefinition(r.method, joined_path, r.factory,
-        combined_mw))
+        combined_mw, combined_interceptors))
     end


### PR DESCRIPTION
Request interceptors short-circuit requests before the handler is created. Interceptors run synchronously in the connection — if an interceptor responds, no handler actor is spawned.

An interceptor returns `InterceptPass` or `InterceptRespond` — the compiler forces an explicit decision, no implicit behavior for any outcome. `InterceptRespond` is constructed with `(status, body)` and supports `set_header()` and `add_header()` for custom response headers. Use for rejections (401, 403), cached responses (304), redirects, or any case where the handler isn't needed.

New public types: `RequestInterceptor` (interface), `InterceptResult` (type alias), `InterceptPass` (primitive), `InterceptRespond` (class). Register interceptors per-route, per-group, or application-wide via `add_interceptor()`. Application interceptors run before group interceptors, which run before per-route interceptors. The first interceptor that returns `InterceptRespond` wins.

Includes `docs/interceptor-guide.md`, an `examples/interceptors/` example with four implementations, and 18 tests.

Design: #51