### PR TITLE
Interceptors now run on 404 responses under their path

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -51,7 +51,7 @@ hobby.Application
     where response_interceptors = cache_interceptors)
 ```
 
-App-level response interceptors also run on 404 responses where no route matched, so security headers and CORS headers cover error responses too.
+Response interceptors run on 404 responses too — app-level interceptors run on all 404s, and group-level interceptors run on 404s under their prefix. Security headers and CORS headers cover error responses automatically.
 
 For streaming responses, all mutations (`set_status()`, `set_header()`, `add_header()`, `set_body()`) are silently ignored since headers and status are already on the wire. The interceptor still runs, so logging interceptors work regardless of response type.
 

--- a/.release-notes/shared-path-tree.md
+++ b/.release-notes/shared-path-tree.md
@@ -1,0 +1,33 @@
+## Interceptors now run on 404 and 405 responses under their path
+
+Group-level and application-level interceptors now run on 404 and 405 responses when the request path traverses through their prefix. Previously, only app-level response interceptors ran on 404s — group interceptors were skipped because the per-method tree had no path context for failed lookups, and 405 was not distinguished from 404.
+
+This enables the auth use case: an auth request interceptor on `/api` now rejects unauthenticated requests to `/api/nonexistent` with 401/403 instead of leaking API structure with 404. A CORS response interceptor on `/api` now adds headers to error responses under `/api`.
+
+The router now distinguishes 404 (path doesn't exist) from 405 (path exists, method not allowed). A 405 response includes an `Allow` header listing the methods the path supports. HEAD is implicitly allowed when GET is registered.
+
+The router uses a single shared path tree instead of per-method trees. Interceptors are path-scoped and accumulate from root to leaf during traversal. On a 404, the deepest reached node's accumulated interceptors run — the same ones that would run on a successful match at that depth.
+
+Per-method group interceptors (two groups with the same prefix but different methods and different interceptors) are no longer possible. This was an accidental capability of per-method trees, never a designed feature. Use per-route interceptors instead:
+
+```pony
+let api = hobby.RouteGroup("/api")
+api.>get("/users", users_factory
+  where interceptors = recover val [as hobby.RequestInterceptor val: CacheInterceptor] end)
+api.>post("/users", create_user_factory
+  where interceptors = recover val [as hobby.RequestInterceptor val: CsrfInterceptor] end)
+```
+
+`Application.serve()` now returns `ServeResult` — either `Serving` on success or `ConfigError` with a message describing the problem. Configuration errors (overlapping group prefixes, empty group prefix, special characters in group prefix, conflicting param names) are detected at `serve()` time and reported as data instead of panicking:
+
+```pony
+match
+  hobby.Application
+    .>get("/", handler)
+    .serve(auth, config, env.out)
+| let err: hobby.ConfigError =>
+  env.err.print(err.message)
+end
+```
+
+Registering two groups with the same prefix, or using an empty or parameterized group prefix, produces a `ConfigError`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ An HTTP server framework for Pony, powered by [Stallion](https://github.com/pony
 Design: https://github.com/ponylang/hobby/discussions/2
 Static file serving design: https://github.com/ponylang/hobby/discussions/18
 Actor-per-request design: https://github.com/ponylang/hobby/discussions/41
+Shared path tree design: https://github.com/ponylang/hobby/discussions/58
 
 ## Building and Testing
 
@@ -35,7 +36,10 @@ The `ssl` option is required — Stallion transitively depends on the `ssl` pack
 
 Users interact with these types:
 
-- **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.), `group()` for route groups, `add_request_interceptor()` for app-level request interceptors, `add_response_interceptor()` for app-level response interceptors. Route methods accept optional `response_interceptors` parameter. `serve()` consumes the Application, freezes routes into an immutable router, and starts listening. `handler_timeout` parameter on `serve()` controls inactivity timeout (default 30 seconds, `None` to disable).
+- **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.), `group()` for route groups, `add_request_interceptor()` for app-level request interceptors, `add_response_interceptor()` for app-level response interceptors. Route methods accept optional `response_interceptors` parameter. `serve()` consumes the Application, validates configuration, freezes routes into an immutable router, and starts listening. Returns `ServeResult` — `Serving` on success or `ConfigError` with a description of the problem. `handler_timeout` parameter on `serve()` controls inactivity timeout (default 30 seconds, `None` to disable).
+- **`Serving`** (`primitive`): Returned by `serve()` when the server started successfully.
+- **`ConfigError`** (`class val`): Returned by `serve()` when a configuration error prevented startup. Carries a `message: String` describing the error. Detected errors: overlapping group prefixes, empty group prefix, special characters in group prefix, conflicting param names.
+- **`ServeResult`** (type alias): `(Serving | ConfigError)`. Return type of `serve()`.
 - **`RouteGroup`** (`class iso`): Groups routes under a shared prefix and optional response interceptors. Constructor accepts `response_interceptors` parameter. Supports nesting via `group()`. Consumed by `Application.group()` or outer `RouteGroup.group()`.
 - **`RequestInterceptor`** (`interface val`): Synchronous request gate. `apply(request: Request box): InterceptResult` returns `InterceptPass` or `InterceptRespond`. The return type forces an explicit decision — the compiler won't accept an interceptor that forgets to decide. The first interceptor that responds wins.
 - **`InterceptResult`** (type alias): `(InterceptPass | InterceptRespond)`. Return type for request interceptors.
@@ -60,13 +64,21 @@ Users interact with these types:
 ### Internal layers
 
 - **`_Listener`** (`actor`): Implements `lori.TCPListenerActor`. Accepts TCP connections and spawns `_Connection` actors. Creates a shared `Timers` actor for handler timeout management.
-- **`_Connection`** (`actor`): Implements `stallion.HTTPServerActor` and `_ConnectionProtocol`. State machine: `_Idle` → `_HandlerInProgress` → `_Streaming`. Runs request interceptors, calls factory, receives handler responses via protocol behaviors (`_handler_respond`, `_handler_start_streaming`, `_handler_send_chunk`, `_handler_finish`). Buffers responses for response interceptors → wire. Manages handler timeout via interval-based timer.
+- **`_Connection`** (`actor`): Implements `stallion.HTTPServerActor` and `_ConnectionProtocol`. State machine: `_Idle` → `_HandlerInProgress` → `_Streaming`. Matches on `(_RouteMatch | _RouteMiss | _MethodNotAllowed)` from router lookup. On match: runs request interceptors, calls factory, receives handler responses via protocol behaviors. On miss: runs accumulated request interceptors (may short-circuit), then sends 404 with accumulated response interceptors. On method-not-allowed: runs accumulated interceptors, then sends 405 with `Allow` header. Manages handler timeout via interval-based timer.
 - **`_ConnectionProtocol`** (`trait tag`): Protocol behaviors that `RequestHandler` sends to `_Connection`.
 - **`_BufferedResponse`** (`class ref`): Mutable response buffer for response interceptors. Response interceptors modify status, headers, and body via `ResponseContext`; `_build()` serializes to wire and auto-adds Content-Length from the final body.
 - **`_RunRequestInterceptors`** (`primitive`): Runs request interceptors in order. Returns `InterceptRespond` on first short-circuit, `None` if all pass.
 - **`_RunResponseInterceptors`** (`primitive`): Runs response interceptors in forward order on a `ResponseContext ref`.
 - **`_HandlerTimeoutNotify`** (`class iso is TimerNotify`): Sends `_handler_timeout(token)` to `_Connection` on each interval fire.
-- **`_Router`** (`class val`): Immutable radix tree router. One tree per HTTP method.
+- **`_Router`** (`class val`): Immutable single shared path tree router. Handlers are keyed by HTTP method at leaf nodes. Interceptors are path-scoped on shared nodes.
+- **`_RouterBuilder`** (`class ref`): Mutable builder. `add()` registers routes, `add_interceptors()` tags path nodes with group/app interceptors. `build()` freezes into `_Router`.
+- **`_BuildNode`** / **`_TreeNode`** (`class ref` / `class val`): Mutable build-time and immutable lookup-time radix tree nodes. Each node carries path-level interceptors and method-keyed handler entries.
+- **`_MethodEntry`** (`class val`): Handler factory + final pre-computed interceptor arrays for a specific HTTP method at a path node.
+- **`_BuildMethodEntry`** (`class ref`): Mutable method entry during construction, before freeze-time interceptor concatenation.
+- **`_RouteMatch`** (`class val`): Successful lookup result — factory, interceptors, params.
+- **`_RouteMiss`** (`class val`): Failed lookup result (path doesn't exist) — carries accumulated interceptors from deepest reached node for 404 interceptor execution.
+- **`_MethodNotAllowed`** (`class val`): Path exists but method doesn't match — carries allowed methods list and accumulated interceptors for 405 response with `Allow` header.
+- **`_GroupInfo`** (`class val`): Group metadata (prefix + interceptors) preserved for tree building. Created during `group()`, consumed by `serve()`.
 - **`_FileStreamer`** (`actor`): Reads files in 64 KB chunks. Sends to `_FileTarget tag`. Supports backpressure via `pause()`/`resume()`.
 - **`_ServeFilesHandler`** (`actor`): Handler actor for large file streaming. Implements `HandlerReceiver` and `_FileTarget`. Receives file chunks from `_FileStreamer` and forwards through `RequestHandler`. Forwards `throttled()`/`unthrottled()` to `_FileStreamer` as `pause()`/`resume()`.
 - **`_FileTarget`** (`trait tag`): Internal interface for `_FileStreamer` to send to.
@@ -77,18 +89,22 @@ Users interact with these types:
 - **Factory returns `(HandlerReceiver tag | None)`**: Inline handlers return None; async handlers return the actor's tag for dispose/throttle signals. No timing gap for lifecycle signals.
 - **Response buffering for response interceptors**: Responses are buffered in `_BufferedResponse` before going to the wire. Response interceptors modify status, headers, and body via `ResponseContext`. Content-Length is computed automatically by `_build()` from the final body after all interceptors run. For streaming, interceptors run but mutations are no-ops (headers/status already on wire).
 - **Route methods are `fun ref`**: Auto receiver recovery handles calling them on the `iso` Application since all arguments are `val`. `serve()` is `fun iso` and uses `consume this`.
-- **Build/lookup separation**: Mutable `_BuildNode ref` trees for construction, frozen into immutable `_TreeNode val` trees for lookup.
-- **Static priority**: Static children checked before param child during lookup.
+- **Single shared path tree**: One radix tree for all HTTP methods. Handlers are keyed by method at leaf nodes. Interceptors live on shared path nodes and are method-independent. Replaces the old per-method tree map.
+- **Build/lookup separation**: Mutable `_BuildNode ref` tree for construction, frozen into immutable `_TreeNode val` tree for lookup. `freeze()` pre-computes accumulated interceptor arrays from root to each node, so lookup is zero-allocation.
+- **Lookup priority: static > param > wildcard**: During lookup, static children are tried first, then the param child, then the wildcard. If a higher-priority branch fails (returns miss or method-not-allowed), lookup falls back to the next branch. A match from any branch is returned immediately. This priority means `/users/new` (static) beats `/users/:id` (param), and `/files/:id` (param) beats `/files/*path` (wildcard).
 - **Trailing slash normalization**: `/users/` and `/users` match the same route.
-- **Flatten at registration time**: Route groups are flattened when consumed by `group()`.
+- **Group info preservation**: Route groups are flattened into routes when consumed by `group()`, but group metadata (prefix + interceptors) is preserved separately as `_GroupInfo` entries. `Application.serve()` registers group interceptors on tree path nodes via `add_interceptors()`, and registers routes with per-route interceptors only via `add()`.
+- **Overlapping group prefix rejection**: Two groups registering interceptors on the same prefix is a configuration error detected at `serve()` time via `_ValidateGroups`, returned as `ConfigError`.
+- **Segment-boundary scoping**: A node's own interceptors only propagate to children at segment boundaries (child key `'/'`) and param children, not to children sharing a character prefix (e.g., `/api` interceptors don't leak to `/api-docs`). `_TreeNode` stores both parent-level and accumulated interceptors; `_RouteMiss` uses parent interceptors when the remaining path starts with a non-`'/'` character.
 - **Interval-based handler timeout**: Uses a repeating timer that checks a `_last_handler_activity` timestamp rather than cancel+recreate on every chunk. Avoids per-chunk timer allocation overhead during streaming.
 - **Pipelined request buffering**: Requests arriving during `_HandlerInProgress` or `_Streaming` are buffered and drained when the handler completes.
 - **HEAD via split handling**: `RequestHandler.start_streaming()` returns `BodyNotNeeded` for HEAD (local check). `_Connection` uses `is_head` when building buffered responses for the wire (suppresses body, preserves Content-Length).
-- **HEAD→GET fallback**: When no explicit HEAD route is registered, `_Connection` retries the lookup with GET.
+- **HEAD→GET fallback**: When no explicit HEAD handler exists at a leaf, `_resolve_method` in `_TreeNode` checks the HEAD key first then falls back to GET — single traversal, no second lookup.
 - **Backpressure forwarding**: `_Connection` forwards `on_throttled()`/`on_unthrottled()` to the handler actor when one is registered.
 - **Directory index auto-serving**: When a request resolves to a directory, `ServeFiles` tries `index.html`. Content type is derived from the resolved filesystem path.
 - **Request interceptors run before the handler**: Interceptors execute in `_Connection._dispatch` after route lookup. An interceptor short-circuit sends the response (with response interceptors applied) without creating the handler.
-- **Response interceptors run on all response paths**: Response interceptors run after the handler responds and before the wire. For routed requests, the full concatenated array (app + group + route) from `_RouteMatch` is used. For 404s, app-level response interceptors (passed through `_Listener`) run. Exception: streaming timeout closes the connection directly.
+- **Interceptors run on 404s and 405s**: On a failed lookup, `_RouteMiss` carries accumulated interceptors from the deepest reached tree node. `_Connection` runs request interceptors (may short-circuit with 401/403) then sends 404 with response interceptors applied. `_MethodNotAllowed` carries interceptors and the allowed methods list — `_Connection` sends 405 with `Allow` header. App-level interceptors run on all error responses; group-level interceptors run on errors under their prefix.
+- **Response interceptors run on all response paths**: Response interceptors run after the handler responds and before the wire. For routed requests, the pre-computed array from `_RouteMatch` is used. For 404s, the accumulated array from `_RouteMiss` is used. Exception: streaming timeout closes the connection directly.
 - **Content-Length deferred to serialization**: `_BufferedResponse._build()` auto-adds Content-Length from the final body after all response interceptors have run. Interceptors that call `set_body()` get correct Content-Length automatically. If Content-Length is already present (from explicit user headers), `_build()` does not override it.
 - **REVISIT: response interceptor mutators on streaming responses**: `set_body()`, `set_status()`, `set_header()`, and `add_header()` on `ResponseContext` are silent no-ops for streaming responses. The no-op behavior is correct (headers/status are already on the wire, body chunks are already sent), but `set_body()` being callable but silently ignored for streaming is a confusing API. Revisit whether the type system can make this a compile-time distinction rather than a runtime no-op.
 
@@ -111,6 +127,7 @@ hobby/
   intercept_response.pony      - InterceptRespond class + result types (public)
   application.pony            - Application class (public)
   route_group.pony            - RouteGroup class (public)
+  serve_result.pony           - Serving, ConfigError, ServeResult types (public)
   serve_files.pony            - ServeFiles handler factory (public)
   content_types.pony          - ContentTypes class + defaults (public)
   cookie_signing_key.pony     - CookieSigningKey class (public)
@@ -124,14 +141,16 @@ hobby/
   _connection.pony             - Connection actor (internal)
   _listener.pony               - Listener actor (internal)
   _router.pony                 - Router + radix tree (internal)
-  _route_match.pony            - Route match result type (internal)
+  _route_match.pony            - Route match + route miss result types (internal)
   _route_definition.pony       - Route definition for building (internal)
+  _method_entry.pony           - Per-method handler entry at tree leaf (internal)
+  _group_info.pony             - Group metadata for tree building (internal)
   _file_streamer.pony          - Chunked file reader actor (internal)
   _file_target.pony            - File target trait (internal)
   _serve_files_handler.pony    - ServeFiles handler actor (internal)
   _http_date.pony              - RFC 7231 HTTP-date formatting (internal)
   _etag.pony                   - Weak ETag computation and matching (internal)
-  _flatten.pony                - Path joining + array concatenation (internal)
+  _flatten.pony                - Path joining, array concatenation, overlap detection, prefix validation (internal)
   _mort.pony                   - _Unreachable primitive (internal)
   _test.pony                   - Test runner
   _test_router.pony            - Router property-based + example tests

--- a/docs/interceptor-guide.md
+++ b/docs/interceptor-guide.md
@@ -112,9 +112,19 @@ app.>group(consume api)
 
 Every route in the group gets the auth interceptor without repeating it.
 
+Group interceptors are path-scoped — they apply to all HTTP methods under the group's prefix. If you need different interceptors for different methods at the same path, use per-route interceptors:
+
+```pony
+let api = hobby.RouteGroup("/api")
+api.>get("/users", users_handler
+  where interceptors = recover val [as hobby.RequestInterceptor val: CacheInterceptor] end)
+api.>post("/users", create_user_handler
+  where interceptors = recover val [as hobby.RequestInterceptor val: CsrfInterceptor] end)
+```
+
 ### Application-Level Interceptors
 
-`add_request_interceptor()` registers an interceptor that runs on every route:
+`add_request_interceptor()` registers an interceptor that runs on every request, including 404s:
 
 ```pony
 app.>add_request_interceptor(RequiredHeadersInterceptor(

--- a/examples/async-handler/main.pony
+++ b/examples/async-handler/main.pony
@@ -24,15 +24,19 @@ actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
     let slow = SlowService
-    hobby.Application
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Hello from Hobby!")
-      } val)
-      .>get("/slow", {(ctx)(slow) =>
-        SlowHandler(consume ctx, slow)
-      } val)
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Hello from Hobby!")
+        } val)
+        .>get("/slow", {(ctx)(slow) =>
+          SlowHandler(consume ctx, slow)
+        } val)
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 
 actor SlowService
   """Simulates an async service via self-directed message."""

--- a/examples/custom-content-types/main.pony
+++ b/examples/custom-content-types/main.pony
@@ -33,7 +33,11 @@ actor Main
       .add("webp", "image/webp")
       .add("avif", "image/avif")
 
-    hobby.Application
-      .>get("/static/*filepath",
-        hobby.ServeFiles(root where content_types = types))
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/static/*filepath",
+          hobby.ServeFiles(root where content_types = types))
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end

--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -18,18 +18,22 @@ actor Main
   """
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    hobby.Application
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Hello from Hobby!")
-      } val)
-      .>get("/greet/:name", {(ctx) =>
-        let handler = hobby.RequestHandler(consume ctx)
-        try
-          let name = handler.param("name")?
-          handler.respond(stallion.StatusOK, "Hello, " + name + "!")
-        else
-          handler.respond(stallion.StatusBadRequest, "Bad Request")
-        end
-      } val)
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Hello from Hobby!")
+        } val)
+        .>get("/greet/:name", {(ctx) =>
+          let handler = hobby.RequestHandler(consume ctx)
+          try
+            let name = handler.param("name")?
+            handler.respond(stallion.StatusOK, "Hello, " + name + "!")
+          else
+            handler.respond(stallion.StatusBadRequest, "Bad Request")
+          end
+        } val)
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end

--- a/examples/request-interceptors/main.pony
+++ b/examples/request-interceptors/main.pony
@@ -39,29 +39,33 @@ actor Main
             recover val ["x-admin"] end)]
       end
 
-    hobby.Application
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Hello from Hobby!")
-      } val)
-      .>get("/api/:id", {(ctx) =>
-        let handler = hobby.RequestHandler(consume ctx)
-        try
-          let id = handler.param("id")?
-          handler.respond(stallion.StatusOK, "Resource: " + id)
-        else
-          handler.respond(stallion.StatusBadRequest, "Bad Request")
-        end
-      } val where interceptors = auth_interceptor)
-      .>post("/api/upload", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Upload accepted")
-      } val where interceptors = upload_interceptors)
-      .>get("/admin", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Admin dashboard")
-      } val where interceptors = admin_interceptors)
-      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Hello from Hobby!")
+        } val)
+        .>get("/api/:id", {(ctx) =>
+          let handler = hobby.RequestHandler(consume ctx)
+          try
+            let id = handler.param("id")?
+            handler.respond(stallion.StatusOK, "Resource: " + id)
+          else
+            handler.respond(stallion.StatusBadRequest, "Bad Request")
+          end
+        } val where interceptors = auth_interceptor)
+        .>post("/api/upload", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Upload accepted")
+        } val where interceptors = upload_interceptors)
+        .>get("/admin", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Admin dashboard")
+        } val where interceptors = admin_interceptors)
+        .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 
 class val AuthInterceptor is hobby.RequestInterceptor
   """

--- a/examples/response-interceptors/main.pony
+++ b/examples/response-interceptors/main.pony
@@ -34,24 +34,28 @@ actor Main
     let auth_interceptor: Array[hobby.RequestInterceptor val] val =
       recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
 
-    hobby.Application
-      .>add_response_interceptor(CorsResponseInterceptor("*"))
-      .>add_response_interceptor(SecurityHeadersInterceptor)
-      .>add_response_interceptor(LogResponseInterceptor(env.out))
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Hello from Hobby!")
-      } val)
-      .>get("/api/:id", {(ctx) =>
-        let handler = hobby.RequestHandler(consume ctx)
-        try
-          let id = handler.param("id")?
-          handler.respond(stallion.StatusOK, "Resource: " + id)
-        else
-          handler.respond(stallion.StatusBadRequest, "Bad Request")
-        end
-      } val where interceptors = auth_interceptor)
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>add_response_interceptor(CorsResponseInterceptor("*"))
+        .>add_response_interceptor(SecurityHeadersInterceptor)
+        .>add_response_interceptor(LogResponseInterceptor(env.out))
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Hello from Hobby!")
+        } val)
+        .>get("/api/:id", {(ctx) =>
+          let handler = hobby.RequestHandler(consume ctx)
+          try
+            let id = handler.param("id")?
+            handler.respond(stallion.StatusOK, "Resource: " + id)
+          else
+            handler.respond(stallion.StatusBadRequest, "Bad Request")
+          end
+        } val where interceptors = auth_interceptor)
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 
 // --- Response interceptors ---
 

--- a/examples/route-groups/main.pony
+++ b/examples/route-groups/main.pony
@@ -34,37 +34,41 @@ actor Main
     let auth_interceptor: Array[hobby.RequestInterceptor val] val =
       recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
 
-    hobby.Application
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Hello from Hobby!")
-      } val)
-      .>get("/health", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "OK")
-      } val)
-      .>group(
-        hobby.RouteGroup("/api" where interceptors = auth_interceptor)
-          .>get("/users", {(ctx) =>
-            hobby.RequestHandler(consume ctx)
-              .respond(stallion.StatusOK, "User list")
-          } val)
-          .>get("/users/:id", {(ctx) =>
-            let handler = hobby.RequestHandler(consume ctx)
-            try
-              let id = handler.param("id")?
-              handler.respond(stallion.StatusOK, "User " + id)
-            else
-              handler.respond(stallion.StatusBadRequest, "Bad Request")
-            end
-          } val)
-          .>group(
-            hobby.RouteGroup("/admin")
-              .>get("/dashboard", {(ctx) =>
-                hobby.RequestHandler(consume ctx)
-                  .respond(stallion.StatusOK, "Admin dashboard")
-              } val)))
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Hello from Hobby!")
+        } val)
+        .>get("/health", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "OK")
+        } val)
+        .>group(
+          hobby.RouteGroup("/api" where interceptors = auth_interceptor)
+            .>get("/users", {(ctx) =>
+              hobby.RequestHandler(consume ctx)
+                .respond(stallion.StatusOK, "User list")
+            } val)
+            .>get("/users/:id", {(ctx) =>
+              let handler = hobby.RequestHandler(consume ctx)
+              try
+                let id = handler.param("id")?
+                handler.respond(stallion.StatusOK, "User " + id)
+              else
+                handler.respond(stallion.StatusBadRequest, "Bad Request")
+              end
+            } val)
+            .>group(
+              hobby.RouteGroup("/admin")
+                .>get("/dashboard", {(ctx) =>
+                  hobby.RequestHandler(consume ctx)
+                    .respond(stallion.StatusOK, "Admin dashboard")
+                } val)))
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 
 // --- Request interceptor ---
 

--- a/examples/serve-files/main.pony
+++ b/examples/serve-files/main.pony
@@ -30,13 +30,17 @@ actor Main
       let auth = lori.TCPListenAuth(env.root)
       let root = FilePath(FileAuth(env.root), dir)
 
-      hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx).respond(stallion.StatusOK,
-            "Visit /static/index.html to see a served file.")
-        } val)
-        .>get("/static/*filepath", hobby.ServeFiles(root))
-        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+      match
+        hobby.Application
+          .>get("/", {(ctx) =>
+            hobby.RequestHandler(consume ctx).respond(stallion.StatusOK,
+              "Visit /static/index.html to see a served file.")
+          } val)
+          .>get("/static/*filepath", hobby.ServeFiles(root))
+          .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+      | let err: hobby.ConfigError =>
+        env.err.print(err.message)
+      end
     else
       env.err.print("Usage: serve-files <directory>")
       env.exitcode(1)

--- a/examples/signed-cookie/main.pony
+++ b/examples/signed-cookie/main.pony
@@ -29,58 +29,62 @@ actor Main
       else env.err.print("Failed to generate signing key"); return
       end
     let auth = lori.TCPListenAuth(env.root)
-    hobby.Application
-      .>get("/", {(ctx)(key) =>
-        let handler = hobby.RequestHandler(consume ctx)
-        // Read and verify the signed visit count from the cookie
-        let count: U64 =
-          match handler.request().cookies.get("visits")
-          | let raw: String =>
-            match \exhaustive\ hobby.SignedCookie.verify(key, raw)
-            | let value: String =>
-              try value.u64()? else 0 end
-            | let _: hobby.SignedCookieError => 0
+    match
+      hobby.Application
+        .>get("/", {(ctx)(key) =>
+          let handler = hobby.RequestHandler(consume ctx)
+          // Read and verify the signed visit count from the cookie
+          let count: U64 =
+            match handler.request().cookies.get("visits")
+            | let raw: String =>
+              match \exhaustive\ hobby.SignedCookie.verify(key, raw)
+              | let value: String =>
+                try value.u64()? else 0 end
+              | let _: hobby.SignedCookieError => 0
+              end
+            else
+              0
             end
-          else
-            0
-          end
-        let new_count: String val = (count + 1).string()
-        let signed = hobby.SignedCookie.sign(key, new_count)
-        // Build response headers with the signed cookie.
-        // Secure=false for localhost testing; use the default (true) in
-        // production.
-        let headers: stallion.Headers val =
-          recover val
-            let h = stallion.Headers
-            match stallion.SetCookieBuilder("visits", signed)
-              .with_path("/")
-              .with_secure(false)
-              .build()
-            | let sc: stallion.SetCookie val =>
-              h.add("Set-Cookie", sc.header_value())
+          let new_count: String val = (count + 1).string()
+          let signed = hobby.SignedCookie.sign(key, new_count)
+          // Build response headers with the signed cookie.
+          // Secure=false for localhost testing; use the default (true) in
+          // production.
+          let headers: stallion.Headers val =
+            recover val
+              let h = stallion.Headers
+              match stallion.SetCookieBuilder("visits", signed)
+                .with_path("/")
+                .with_secure(false)
+                .build()
+              | let sc: stallion.SetCookie val =>
+                h.add("Set-Cookie", sc.header_value())
+              end
+              h
             end
-            h
-          end
-        handler.respond_with_headers(stallion.StatusOK, headers,
-          "Visit #" + new_count)
-      } val)
-      .>get("/clear", {(ctx) =>
-        let handler = hobby.RequestHandler(consume ctx)
-        // Clear the cookie by setting Max-Age=0
-        let headers: stallion.Headers val =
-          recover val
-            let h = stallion.Headers
-            match stallion.SetCookieBuilder("visits", "")
-              .with_path("/")
-              .with_max_age(0)
-              .with_secure(false)
-              .build()
-            | let sc: stallion.SetCookie val =>
-              h.add("Set-Cookie", sc.header_value())
+          handler.respond_with_headers(stallion.StatusOK, headers,
+            "Visit #" + new_count)
+        } val)
+        .>get("/clear", {(ctx) =>
+          let handler = hobby.RequestHandler(consume ctx)
+          // Clear the cookie by setting Max-Age=0
+          let headers: stallion.Headers val =
+            recover val
+              let h = stallion.Headers
+              match stallion.SetCookieBuilder("visits", "")
+                .with_path("/")
+                .with_max_age(0)
+                .with_secure(false)
+                .build()
+              | let sc: stallion.SetCookie val =>
+                h.add("Set-Cookie", sc.header_value())
+              end
+              h
             end
-            h
-          end
-        handler.respond_with_headers(stallion.StatusOK, headers,
-          "Visit counter cleared.")
-      } val)
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+          handler.respond_with_headers(stallion.StatusOK, headers,
+            "Visit counter cleared.")
+        } val)
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -22,15 +22,19 @@ actor Main
   """
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    hobby.Application
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx).respond(stallion.StatusOK,
-          "Visit /stream to see a chunked streaming response.")
-      } val)
-      .>get("/stream", {(ctx) =>
-        StreamHandler(consume ctx)
-      } val)
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx).respond(stallion.StatusOK,
+            "Visit /stream to see a chunked streaming response.")
+        } val)
+        .>get("/stream", {(ctx) =>
+          StreamHandler(consume ctx)
+        } val)
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 
 actor StreamHandler is hobby.HandlerReceiver
   """Starts streaming and sends 5 numbered chunks."""

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -25,8 +25,6 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   let _router: _Router val
   let _timers: Timers tag
   let _timeout_ns: U64
-  let _app_response_interceptors:
-    (Array[ResponseInterceptor val] val | None)
   var _body: Array[U8] iso = recover iso Array[U8] end
   var _has_body: Bool = false
 
@@ -46,13 +44,11 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
 
   new create(auth: lori.TCPServerAuth, fd: U32,
     config: stallion.ServerConfig, router: _Router val,
-    timers: Timers tag, timeout_ns: U64,
-    response_interceptors: (Array[ResponseInterceptor val] val | None))
+    timers: Timers tag, timeout_ns: U64)
   =>
     _router = router
     _timers = timers
     _timeout_ns = timeout_ns
-    _app_response_interceptors = response_interceptors
     _pending_requests = Array[_PendingRequest]
     _http = stallion.HTTPServer(auth, fd, this, config)
 
@@ -121,24 +117,44 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
     let path = request'.uri.path
     let is_head = request'.method is stallion.HEAD
 
-    let route_match = match _router.lookup(request'.method, path)
-    | let m: _RouteMatch => m
-    else
-      // HEAD falls back to GET handler when no explicit HEAD route exists
-      if is_head then
-        _router.lookup(stallion.GET, path)
-      end
-    end
-
-    match route_match
+    // Single lookup — HEAD→GET fallback is handled inside the router
+    match _router.lookup(request'.method, path)
     | let m: _RouteMatch =>
       _dispatch(request', responder, body, m, is_head)
-    else
-      // No route match — send 404 with app-level response interceptors
+    | let na: _MethodNotAllowed =>
+      // Path exists but method not allowed — run interceptors then send 405
+      match _RunRequestInterceptors(request', na.interceptors)
+      | let respond: InterceptRespond =>
+        let buf = _BufferedResponse._from_intercept_respond(respond, is_head)
+        let ctx = ResponseContext._create(buf, request')
+        _RunResponseInterceptors(ctx, na.response_interceptors)
+        responder.respond(buf._build())
+        return
+      end
+      let allow_value: String val = ", ".join(
+        na.allowed_methods.values())
+      let buf = _BufferedResponse._standard(
+        stallion.StatusMethodNotAllowed, "Method Not Allowed", is_head)
+      buf.headers.push(("allow", allow_value))
+      let ctx = ResponseContext._create(buf, request')
+      _RunResponseInterceptors(ctx, na.response_interceptors)
+      responder.respond(buf._build())
+    | let miss: _RouteMiss =>
+      // Run request interceptors from the traversal — may short-circuit
+      match _RunRequestInterceptors(request', miss.interceptors)
+      | let respond: InterceptRespond =>
+        let buf = _BufferedResponse._from_intercept_respond(respond, is_head)
+        let ctx = ResponseContext._create(buf, request')
+        _RunResponseInterceptors(ctx, miss.response_interceptors)
+        responder.respond(buf._build())
+        return
+      end
+      // No interceptor short-circuit — send 404 with accumulated response
+      // interceptors
       let buf = _BufferedResponse._standard(
         stallion.StatusNotFound, "Not Found", is_head)
       let ctx = ResponseContext._create(buf, request')
-      _RunResponseInterceptors(ctx, _app_response_interceptors)
+      _RunResponseInterceptors(ctx, miss.response_interceptors)
       responder.respond(buf._build())
     end
 

--- a/hobby/_flatten.pony
+++ b/hobby/_flatten.pony
@@ -33,6 +33,69 @@ primitive _TrimTrailingSlash
     end
     s
 
+primitive _ValidateGroups
+  """
+  Validate group configuration before tree insertion.
+
+  Called in `Application.serve()` where the original full prefix strings
+  are available. Returns the first error found, or `None` if all groups
+  are valid. Checks:
+  - Empty prefix (collides with app-level interceptors)
+  - Special characters in prefix (`:` or `*`)
+  - Overlapping prefixes (two groups with the same prefix)
+  """
+  fun apply(infos: Array[_GroupInfo] box): (ConfigError | None) =>
+    for gi in infos.values() do
+      if (gi.prefix.size() == 0) or (gi.prefix == "/") then
+        return ConfigError(
+          "RouteGroup with prefix \"" + gi.prefix +
+          "\" is equivalent to app-level interceptors. " +
+          "Use add_request_interceptor() / " +
+          "add_response_interceptor() instead.")
+      end
+      if _HasSpecialChars(gi.prefix) then
+        return ConfigError(
+          "RouteGroup prefix '" + gi.prefix +
+          "' contains ':' or '*'. Group prefixes must be static paths " +
+          "— use route-level params instead.")
+      end
+    end
+    var i: USize = 0
+    while i < infos.size() do
+      var j = i + 1
+      while j < infos.size() do
+        try
+          if infos(i)?.prefix == infos(j)?.prefix then
+            return ConfigError(
+              "Overlapping group interceptors on prefix '" +
+              infos(i)?.prefix +
+              "'. Two groups cannot register interceptors on the same " +
+              "prefix.")
+          end
+        else
+          _Unreachable()
+        end
+        j = j + 1
+      end
+      i = i + 1
+    end
+    None
+
+primitive _HasSpecialChars
+  """Check if a string contains `:` or `*` (param/wildcard markers)."""
+  fun apply(s: String box): Bool =>
+    var i: USize = 0
+    try
+      while i < s.size() do
+        let c = s(i)?
+        if (c == ':') or (c == '*') then return true end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    false
+
 primitive _ConcatResponseInterceptors
   """
   Concatenate two optional response interceptor arrays.

--- a/hobby/_group_info.pony
+++ b/hobby/_group_info.pony
@@ -1,0 +1,20 @@
+class val _GroupInfo
+  """
+  Group metadata preserved for tree building.
+
+  Carries the fully-joined prefix and interceptors for a route group. Created
+  during `Application.group()` / `RouteGroup.group()` and consumed by
+  `Application.serve()` to tag intermediate tree nodes with group-level
+  interceptors via `_RouterBuilder.add_interceptors()`.
+  """
+  let prefix: String
+  let interceptors: (Array[RequestInterceptor val] val | None)
+  let response_interceptors: (Array[ResponseInterceptor val] val | None)
+
+  new val create(prefix': String,
+    interceptors': (Array[RequestInterceptor val] val | None),
+    response_interceptors': (Array[ResponseInterceptor val] val | None))
+  =>
+    prefix = prefix'
+    interceptors = interceptors'
+    response_interceptors = response_interceptors'

--- a/hobby/_listener.pony
+++ b/hobby/_listener.pony
@@ -6,14 +6,12 @@ actor _Listener is lori.TCPListenerActor
   """
   Internal TCP listener that accepts connections and spawns connection actors.
 
-  Created by `Application.serve()` with a frozen `_Router val` and app-level
-  response interceptors. Each accepted connection gets its own `_Connection`
-  actor. A shared `Timers` actor is created once and passed to every connection
-  for handler timeout management.
+  Created by `Application.serve()` with a frozen `_Router val`. Each accepted
+  connection gets its own `_Connection` actor. A shared `Timers` actor is
+  created once and passed to every connection for handler timeout management.
 
-  App-level response interceptors are passed through to each connection so they
-  can run on 404 responses (where no route matched and no per-route interceptors
-  are available).
+  Interceptors are carried by the router's path tree — the listener no longer
+  needs to pass them through separately.
   """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
@@ -22,11 +20,9 @@ actor _Listener is lori.TCPListenerActor
   let _out: OutStream
   let _timers: Timers tag
   let _timeout_ns: U64
-  let _response_interceptors: (Array[ResponseInterceptor val] val | None)
 
   new create(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
-    router: _Router val, out: OutStream, timeout_ns: U64,
-    response_interceptors: (Array[ResponseInterceptor val] val | None))
+    router: _Router val, out: OutStream, timeout_ns: U64)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = config
@@ -34,14 +30,12 @@ actor _Listener is lori.TCPListenerActor
     _out = out
     _timers = Timers
     _timeout_ns = timeout_ns
-    _response_interceptors = response_interceptors
     _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
 
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    _Connection(_server_auth, fd, _config, _router, _timers, _timeout_ns,
-      _response_interceptors)
+    _Connection(_server_auth, fd, _config, _router, _timers, _timeout_ns)
 
   fun ref _on_listening() =>
     try

--- a/hobby/_method_entry.pony
+++ b/hobby/_method_entry.pony
@@ -1,0 +1,20 @@
+class val _MethodEntry
+  """
+  A handler and its per-route interceptors for a specific HTTP method at a
+  path node.
+
+  Stored in method-keyed maps on tree nodes. The interceptors here are the
+  final pre-computed arrays: accumulated path interceptors concatenated with
+  per-route interceptors, computed at freeze time.
+  """
+  let factory: HandlerFactory
+  let interceptors: (Array[RequestInterceptor val] val | None)
+  let response_interceptors: (Array[ResponseInterceptor val] val | None)
+
+  new val create(factory': HandlerFactory,
+    interceptors': (Array[RequestInterceptor val] val | None),
+    response_interceptors': (Array[ResponseInterceptor val] val | None))
+  =>
+    factory = factory'
+    interceptors = interceptors'
+    response_interceptors = response_interceptors'

--- a/hobby/_route_definition.pony
+++ b/hobby/_route_definition.pony
@@ -5,9 +5,11 @@ class val _RouteDefinition
   A route registration captured during route setup.
 
   Stores the HTTP method, path pattern, handler factory, and optional
-  response interceptor and request interceptor chains. Created by `Application`
-  and `RouteGroup` route methods, then iterated by `Application.serve()` to
-  populate the router.
+  per-route response interceptor and request interceptor chains. Created by
+  `Application` and `RouteGroup` route methods, then iterated by
+  `Application.serve()` to populate the router. Group-level and app-level
+  interceptors are registered separately on tree nodes — the interceptors
+  here are per-route only.
   """
   let method: stallion.Method
   let path: String

--- a/hobby/_route_match.pony
+++ b/hobby/_route_match.pony
@@ -22,3 +22,58 @@ class val _RouteMatch
     response_interceptors = response_interceptors'
     interceptors = interceptors'
     params = params'
+
+class val _RouteMiss
+  """
+  Result of a failed route lookup.
+
+  Carries accumulated request and response interceptors from the deepest
+  node reached during traversal. This allows interceptors registered on
+  group prefixes to run on 404 responses — e.g., an auth interceptor on
+  `/api` can reject unauthenticated requests to `/api/nonexistent`.
+  """
+  let response_interceptors: (Array[ResponseInterceptor val] val | None)
+  let interceptors: (Array[RequestInterceptor val] val | None)
+
+  new val create(
+    response_interceptors': (Array[ResponseInterceptor val] val | None),
+    interceptors': (Array[RequestInterceptor val] val | None))
+  =>
+    response_interceptors = response_interceptors'
+    interceptors = interceptors'
+
+  fun _interceptor_count(): USize =>
+    """Total interceptor count — used to compare miss depth."""
+    let req_count = match interceptors
+    | let a: Array[RequestInterceptor val] val => a.size()
+    else
+      0
+    end
+    let resp_count = match response_interceptors
+    | let a: Array[ResponseInterceptor val] val => a.size()
+    else
+      0
+    end
+    req_count + resp_count
+
+class val _MethodNotAllowed
+  """
+  Result of a lookup where the path exists but no handler matches the
+  requested method.
+
+  Carries the list of allowed methods (for the `Allow` response header)
+  and accumulated interceptors from the matched path node. Interceptors
+  still run on 405 responses — an auth interceptor should reject before
+  revealing which methods are allowed.
+  """
+  let allowed_methods: Array[String] val
+  let response_interceptors: (Array[ResponseInterceptor val] val | None)
+  let interceptors: (Array[RequestInterceptor val] val | None)
+
+  new val create(allowed_methods': Array[String] val,
+    response_interceptors': (Array[ResponseInterceptor val] val | None),
+    interceptors': (Array[RequestInterceptor val] val | None))
+  =>
+    allowed_methods = allowed_methods'
+    response_interceptors = response_interceptors'
+    interceptors = interceptors'

--- a/hobby/_router.pony
+++ b/hobby/_router.pony
@@ -5,65 +5,105 @@ class ref _RouterBuilder
   """
   Mutable builder for constructing a `_Router`.
 
-  Accumulates route definitions and builds an immutable router via `build()`.
+  Accumulates route definitions and group interceptors into a single shared
+  path tree, then freezes it into an immutable router via `build()`.
+  Configuration errors (e.g., conflicting param names) are accumulated in
+  `_errors` and available via `first_error()`.
   """
-  embed _trees: Map[String, _BuildNode ref]
+  var _root: _BuildNode ref
+  embed _errors: Array[String]
 
   new create() =>
-    _trees = Map[String, _BuildNode ref]
+    _root = _BuildNode
+    _errors = Array[String]
 
-  fun ref add(method: stallion.Method, path: String, factory: HandlerFactory,
+  fun ref add(method: stallion.Method, path: String,
+    factory: HandlerFactory,
     response_interceptors: (Array[ResponseInterceptor val] val | None) = None,
     interceptors: (Array[RequestInterceptor val] val | None) = None)
   =>
-    """Register a route. The path must start with `/`."""
+    """
+    Register a route handler for a specific method and path.
+
+    Per-route interceptors are stored in the method entry at the leaf node.
+    Path-level interceptors are registered separately via `add_interceptors()`.
+    """
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
-    let tree = try
-      _trees(method_key)?
-    else
-      let node = _BuildNode
-      _trees(method_key) = node
-      node
+    _root.insert(normalized, method_key, factory, response_interceptors,
+      interceptors, _errors)
+
+  fun ref add_interceptors(path: String,
+    interceptors: (Array[RequestInterceptor val] val | None),
+    response_interceptors: (Array[ResponseInterceptor val] val | None))
+  =>
+    """
+    Register path-level interceptors on a tree node.
+
+    Used for app-level interceptors (on the root node, path `""`) and
+    group-level interceptors (on the group prefix node). Overlap detection
+    happens earlier in `Application.serve()` via `_ValidateGroups`.
+    `_set_interceptors` concatenates as defense-in-depth.
+    """
+    if (interceptors is None) and (response_interceptors is None) then
+      return
     end
-    tree.insert(normalized, factory, response_interceptors, interceptors)
+    if path.size() == 0 then
+      // Root node — app-level interceptors
+      _root._set_interceptors(interceptors, response_interceptors)
+      return
+    end
+    let normalized = _NormalizePath(path)
+    _root._ensure_path(normalized, 0, interceptors, response_interceptors)
 
   fun ref build(): _Router val =>
     """Freeze the builder into an immutable router."""
-    let frozen_trees: Map[String, _TreeNode val] iso =
-      recover iso Map[String, _TreeNode val] end
-    for (method, node) in _trees.pairs() do
-      frozen_trees(method) = node.freeze()
-    end
-    _Router._create(consume frozen_trees)
+    _Router._create(_root.freeze(None, None))
 
-class val _Router
-  """
-  Immutable radix tree router.
-
-  One tree per HTTP method. `lookup()` finds the matching handler, response
-  interceptors, request interceptors, and extracted parameters for a given
-  method and path.
-  """
-  let _trees: Map[String, _TreeNode val] val
-
-  new val _create(trees: Map[String, _TreeNode val] iso) =>
-    _trees = consume trees
-
-  fun lookup(method: stallion.Method, path: String): (_RouteMatch | None) =>
+  fun box first_error(): (ConfigError | None) =>
     """
-    Look up a route for the given method and path.
-
-    Returns a `_RouteMatch` with handler, response interceptors, request
-    interceptors, and extracted parameters, or `None` if no route matches.
+    Return the first configuration error detected during route registration,
+    or `None` if no errors were found.
     """
-    let normalized = _NormalizePath(path)
-    let method_key: String val = method.string()
-    try
-      _trees(method_key)?.lookup(normalized)
+    if _errors.size() > 0 then
+      try
+        ConfigError(_errors(0)?)
+      else
+        _Unreachable()
+        ConfigError("")
+      end
     else
       None
     end
+
+class val _Router
+  """
+  Immutable radix tree router with a single shared path tree.
+
+  Handlers are keyed by HTTP method at leaf nodes. Interceptors live on
+  shared path nodes and are method-independent. `lookup()` finds the matching
+  handler, accumulated interceptors, and extracted parameters.
+  """
+  let _root: _TreeNode val
+
+  new val _create(root: _TreeNode val) =>
+    _root = root
+
+  fun lookup(method: stallion.Method, path: String):
+    (_RouteMatch | _RouteMiss | _MethodNotAllowed)
+  =>
+    """
+    Look up a route for the given method and path.
+
+    Returns `_RouteMatch` on success, `_RouteMiss` when the path doesn't
+    exist, or `_MethodNotAllowed` when the path exists but no handler
+    matches the method. For HEAD requests, automatically falls back to GET
+    if no explicit HEAD handler exists.
+    """
+    let normalized = _NormalizePath(path)
+    let method_key: String val = method.string()
+    let is_head = method is stallion.HEAD
+    _root.lookup(normalized, method_key, is_head)
 
 primitive _NormalizePath
   """Strip trailing slash (except root `/`)."""
@@ -84,62 +124,140 @@ class ref _BuildNode
   Mutable radix tree node for route construction.
 
   Used by `_RouterBuilder` during route registration, then frozen into a
-  `_TreeNode val` for immutable lookup.
+  `_TreeNode val` for immutable lookup. Each node carries:
+  - Path-level interceptors (from groups or app-level registration)
+  - Method-keyed handler entries (from route registration)
+  - Static children and param/wildcard children for tree structure
   """
   var _prefix: String = ""
-  var _factory: (HandlerFactory | None) = None
-  var _response_interceptors: (Array[ResponseInterceptor val] val | None) = None
   var _interceptors: (Array[RequestInterceptor val] val | None) = None
+  var _response_interceptors: (Array[ResponseInterceptor val] val | None) = None
   var _param_name: String = ""
   embed _children: Map[U8, _BuildNode ref] = Map[U8, _BuildNode ref]
   var _param_child: (_BuildNode ref | None) = None
-  var _wildcard_factory: (HandlerFactory | None) = None
-  var _wildcard_response_interceptors:
-    (Array[ResponseInterceptor val] val | None) = None
-  var _wildcard_interceptors: (Array[RequestInterceptor val] val | None) = None
+  embed _method_entries: Map[String, _BuildMethodEntry ref] =
+    Map[String, _BuildMethodEntry ref]
+  embed _wildcard_entries: Map[String, _BuildMethodEntry ref] =
+    Map[String, _BuildMethodEntry ref]
   var _wildcard_name: String = ""
 
   new create(prefix: String = "") =>
     _prefix = prefix
 
-  fun ref insert(path: String, factory: HandlerFactory,
+  fun ref _set_interceptors(
+    interceptors: (Array[RequestInterceptor val] val | None),
+    response_interceptors: (Array[ResponseInterceptor val] val | None))
+  =>
+    """
+    Set path-level interceptors on this node.
+
+    Overlap detection happens earlier in `Application.serve()` via
+    `_ValidateGroups`, where the original full prefix strings are
+    available for a clear error message. As defense-in-depth,
+    concatenates rather than overwrites if interceptors already exist.
+    """
+    _interceptors = _ConcatInterceptors(_interceptors, interceptors)
+    _response_interceptors =
+      _ConcatResponseInterceptors(_response_interceptors,
+        response_interceptors)
+
+  fun ref insert(path: String, method: String, factory: HandlerFactory,
     response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None))
+    interceptors: (Array[RequestInterceptor val] val | None),
+    errors: Array[String] ref)
   =>
     """Insert a route path into this subtree."""
-    _insert(path, 0, factory, response_interceptors, interceptors)
+    _insert(path, 0, method, factory, response_interceptors, interceptors,
+      errors)
 
-  fun ref _insert(path: String, offset: USize, factory: HandlerFactory,
+  fun ref _ensure_path(path: String, offset: USize,
+    interceptors: (Array[RequestInterceptor val] val | None),
+    response_interceptors: (Array[ResponseInterceptor val] val | None))
+  =>
+    """
+    Traverse or create nodes to reach the given path and set interceptors.
+
+    Uses the same prefix-matching logic as insert to handle post-split node
+    structure correctly.
+    """
+    if offset >= path.size() then
+      _set_interceptors(interceptors, response_interceptors)
+      return
+    end
+
+    try
+      let c = path(offset)?
+      // Only handle static paths for group interceptors (no : or * in group prefixes)
+      match try _children(c)? end
+      | let child: _BuildNode ref =>
+        let common = _Paths.common_prefix_len(child._prefix,
+          path.trim(offset))
+        if common == child._prefix.size() then
+          child._ensure_path(path, offset + common, interceptors,
+            response_interceptors)
+        else
+          // Split the child node at the divergence point
+          let new_parent = _BuildNode(child._prefix.trim(0, common))
+          let old_suffix = child._prefix.trim(common)
+          child._prefix = old_suffix
+          try
+            new_parent._children(old_suffix(0)?) = child
+          else
+            _Unreachable()
+          end
+          if (offset + common) >= path.size() then
+            new_parent._set_interceptors(interceptors, response_interceptors)
+          else
+            new_parent._ensure_path(path, offset + common, interceptors,
+              response_interceptors)
+          end
+          _children(c) = new_parent
+        end
+      else
+        // No existing child — create the path
+        let remaining = path.trim(offset)
+        let child = _BuildNode(remaining)
+        child._set_interceptors(interceptors, response_interceptors)
+        _children(c) = child
+      end
+    else
+      _Unreachable()
+    end
+
+  fun ref _insert(path: String, offset: USize, method: String,
+    factory: HandlerFactory,
     response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None))
+    interceptors: (Array[RequestInterceptor val] val | None),
+    errors: Array[String] ref)
   =>
     if offset >= path.size() then
-      _factory = factory
-      _response_interceptors = response_interceptors
-      _interceptors = interceptors
+      _method_entries(method) = _BuildMethodEntry(factory,
+        interceptors, response_interceptors)
       return
     end
 
     try
       let c = path(offset)?
       if c == ':' then
-        _insert_param(path, offset, factory, response_interceptors, interceptors)
+        _insert_param(path, offset, method, factory, response_interceptors,
+          interceptors, errors)
       elseif c == '*' then
-        _wildcard_factory = factory
-        _wildcard_response_interceptors = response_interceptors
-        _wildcard_interceptors = interceptors
+        _wildcard_entries(method) = _BuildMethodEntry(factory,
+          interceptors, response_interceptors)
         _wildcard_name = path.trim(offset + 1)
       else
-        _insert_static(path, offset, factory, response_interceptors,
-          interceptors)
+        _insert_static(path, offset, method, factory, response_interceptors,
+          interceptors, errors)
       end
     else
       _Unreachable()
     end
 
-  fun ref _insert_param(path: String, offset: USize, factory: HandlerFactory,
+  fun ref _insert_param(path: String, offset: USize, method: String,
+    factory: HandlerFactory,
     response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None))
+    interceptors: (Array[RequestInterceptor val] val | None),
+    errors: Array[String] ref)
   =>
     let name_end = _Paths.find_char(path, '/', offset + 1)
     let name = path.trim(offset + 1, name_end)
@@ -150,18 +268,26 @@ class ref _BuildNode
       _param_child = c
       c
     end
+    if (child._param_name.size() > 0) and (child._param_name != name) then
+      errors.push(
+        "Conflicting param names at the same path position: ':" +
+        child._param_name + "' vs ':" + name +
+        "'. All methods at the same path must use the same param name.")
+    end
     child._param_name = name
     if name_end >= path.size() then
-      child._factory = factory
-      child._response_interceptors = response_interceptors
-      child._interceptors = interceptors
+      child._method_entries(method) = _BuildMethodEntry(factory,
+        interceptors, response_interceptors)
     else
-      child._insert(path, name_end, factory, response_interceptors, interceptors)
+      child._insert(path, name_end, method, factory, response_interceptors,
+        interceptors, errors)
     end
 
-  fun ref _insert_static(path: String, offset: USize, factory: HandlerFactory,
+  fun ref _insert_static(path: String, offset: USize, method: String,
+    factory: HandlerFactory,
     response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None))
+    interceptors: (Array[RequestInterceptor val] val | None),
+    errors: Array[String] ref)
   =>
     try
       let c = path(offset)?
@@ -170,8 +296,8 @@ class ref _BuildNode
         let common = _Paths.common_prefix_len(child._prefix,
           path.trim(offset))
         if common == child._prefix.size() then
-          child._insert(path, offset + common, factory, response_interceptors,
-            interceptors)
+          child._insert(path, offset + common, method, factory,
+            response_interceptors, interceptors, errors)
         else
           // Split the child node at the divergence point
           let new_parent = _BuildNode(child._prefix.trim(0, common))
@@ -184,8 +310,8 @@ class ref _BuildNode
           end
           // Route through _insert so special characters (`:`, `*`) in the
           // remaining suffix are parsed instead of stored as literal prefix.
-          new_parent._insert(path, offset + common, factory,
-            response_interceptors, interceptors)
+          new_parent._insert(path, offset + common, method, factory,
+            response_interceptors, interceptors, errors)
           _children(c) = new_parent
         end
       else
@@ -194,14 +320,13 @@ class ref _BuildNode
         let special = _Paths.find_special(remaining)
         if special < remaining.size() then
           let child = _BuildNode(remaining.trim(0, special))
-          child._insert(path, offset + special, factory, response_interceptors,
-            interceptors)
+          child._insert(path, offset + special, method, factory,
+            response_interceptors, interceptors, errors)
           _children(c) = child
         else
           let child = _BuildNode(remaining)
-          child._factory = factory
-          child._response_interceptors = response_interceptors
-          child._interceptors = interceptors
+          child._method_entries(method) = _BuildMethodEntry(factory,
+            interceptors, response_interceptors)
           _children(c) = child
         end
       end
@@ -209,21 +334,101 @@ class ref _BuildNode
       _Unreachable()
     end
 
-  fun box freeze(): _TreeNode val =>
-    """Create an immutable deep copy of this node tree."""
+  fun box freeze(
+    parent_interceptors: (Array[RequestInterceptor val] val | None),
+    parent_response_interceptors:
+      (Array[ResponseInterceptor val] val | None))
+    : _TreeNode val
+  =>
+    """
+    Create an immutable deep copy of this node tree.
+
+    Pre-computes accumulated interceptor arrays from root to each node.
+    Per-route interceptors in method entries are concatenated with the
+    accumulated path interceptors at freeze time, so lookup is zero-allocation.
+    """
+    // Accumulate this node's interceptors with parent's
+    let accumulated_interceptors =
+      _ConcatInterceptors(parent_interceptors, _interceptors)
+    let accumulated_response_interceptors =
+      _ConcatResponseInterceptors(parent_response_interceptors,
+        _response_interceptors)
+
+    // Freeze children — only propagate this node's interceptors to sub-path
+    // children (key == '/'). Children at other keys share a character prefix
+    // but are in different path segments (e.g., /api-docs is not under /api).
     let frozen_children: Array[(U8, _TreeNode val)] iso =
       recover iso Array[(U8, _TreeNode val)] end
     for (key, child) in _children.pairs() do
-      frozen_children.push((key, child.freeze()))
+      if key == '/' then
+        frozen_children.push((key, child.freeze(accumulated_interceptors,
+          accumulated_response_interceptors)))
+      else
+        frozen_children.push((key, child.freeze(parent_interceptors,
+          parent_response_interceptors)))
+      end
     end
+    // Param child is always a sub-segment — gets full accumulated
     let frozen_param: (_TreeNode val | None) = match _param_child
-    | let child: _BuildNode box => child.freeze()
+    | let child: _BuildNode box =>
+      child.freeze(accumulated_interceptors, accumulated_response_interceptors)
     else
       None
     end
-    _TreeNode._create(_prefix, _factory, _response_interceptors, _interceptors,
-      _param_name, consume frozen_children, frozen_param, _wildcard_factory,
-      _wildcard_response_interceptors, _wildcard_interceptors, _wildcard_name)
+
+    // Freeze method entries — concatenate accumulated path interceptors
+    // with per-route interceptors
+    let frozen_method_entries: Map[String, _MethodEntry val] iso =
+      recover iso Map[String, _MethodEntry val] end
+    for (method, entry) in _method_entries.pairs() do
+      let final_interceptors =
+        _ConcatInterceptors(accumulated_interceptors, entry.interceptors)
+      let final_response_interceptors =
+        _ConcatResponseInterceptors(accumulated_response_interceptors,
+          entry.response_interceptors)
+      frozen_method_entries(method) = _MethodEntry(entry.factory,
+        final_interceptors, final_response_interceptors)
+    end
+
+    let frozen_wildcard_entries: Map[String, _MethodEntry val] iso =
+      recover iso Map[String, _MethodEntry val] end
+    for (method, entry) in _wildcard_entries.pairs() do
+      let final_interceptors =
+        _ConcatInterceptors(accumulated_interceptors, entry.interceptors)
+      let final_response_interceptors =
+        _ConcatResponseInterceptors(accumulated_response_interceptors,
+          entry.response_interceptors)
+      frozen_wildcard_entries(method) = _MethodEntry(entry.factory,
+        final_interceptors, final_response_interceptors)
+    end
+
+    _TreeNode._create(_prefix,
+      parent_interceptors, parent_response_interceptors,
+      accumulated_interceptors, accumulated_response_interceptors,
+      _param_name, consume frozen_children, frozen_param,
+      consume frozen_method_entries, consume frozen_wildcard_entries,
+      _wildcard_name)
+
+// --- Build-time method entry (mutable) ---
+
+class ref _BuildMethodEntry
+  """
+  Mutable method entry during tree construction.
+
+  Holds the handler factory and per-route interceptors before freeze-time
+  concatenation with accumulated path interceptors.
+  """
+  let factory: HandlerFactory
+  let interceptors: (Array[RequestInterceptor val] val | None)
+  let response_interceptors: (Array[ResponseInterceptor val] val | None)
+
+  new ref create(factory': HandlerFactory,
+    interceptors': (Array[RequestInterceptor val] val | None),
+    response_interceptors': (Array[ResponseInterceptor val] val | None))
+  =>
+    factory = factory'
+    interceptors = interceptors'
+    response_interceptors = response_interceptors'
 
 // --- Immutable lookup node ---
 
@@ -231,54 +436,69 @@ class val _TreeNode
   """
   Immutable radix tree node for route lookup.
 
-  Produced by freezing a `_BuildNode`. Supports `lookup()` to find a matching
-  handler, response interceptors, request interceptors, and parameters for a
-  given path.
+  Produced by freezing a `_BuildNode`. Each node stores two levels of
+  pre-computed interceptors: parent-level (from ancestors only) and
+  accumulated (parent + own). This separation is needed because
+  interceptors are segment-scoped — a node's own interceptors only apply
+  to sub-paths (children at '/'), not to sibling routes that share a
+  character prefix (children at other keys like '-').
+
+  Method entries store final interceptor arrays (accumulated + per-route,
+  concatenated at freeze time). Lookup is zero-allocation for both hits
+  and misses.
   """
   let _prefix: String
-  let _factory: (HandlerFactory | None)
-  let _response_interceptors: (Array[ResponseInterceptor val] val | None)
-  let _interceptors: (Array[RequestInterceptor val] val | None)
+  // Interceptors from ancestor nodes only — for misses on sibling paths
+  let _parent_interceptors:
+    (Array[RequestInterceptor val] val | None)
+  let _parent_response_interceptors:
+    (Array[ResponseInterceptor val] val | None)
+  // Interceptors accumulated through this node — for sub-path matches/misses
+  let _accumulated_interceptors:
+    (Array[RequestInterceptor val] val | None)
+  let _accumulated_response_interceptors:
+    (Array[ResponseInterceptor val] val | None)
   let _param_name: String
   let _children: Array[(U8, _TreeNode val)] val
   let _param_child: (_TreeNode val | None)
-  let _wildcard_factory: (HandlerFactory | None)
-  let _wildcard_response_interceptors:
-    (Array[ResponseInterceptor val] val | None)
-  let _wildcard_interceptors: (Array[RequestInterceptor val] val | None)
+  let _method_entries: Map[String, _MethodEntry val] val
+  let _wildcard_entries: Map[String, _MethodEntry val] val
   let _wildcard_name: String
 
-  new val _create(prefix: String, factory': (HandlerFactory | None),
-    response_interceptors': (Array[ResponseInterceptor val] val | None),
-    interceptors': (Array[RequestInterceptor val] val | None),
+  new val _create(prefix: String,
+    parent_interceptors':
+      (Array[RequestInterceptor val] val | None),
+    parent_response_interceptors':
+      (Array[ResponseInterceptor val] val | None),
+    accumulated_interceptors':
+      (Array[RequestInterceptor val] val | None),
+    accumulated_response_interceptors':
+      (Array[ResponseInterceptor val] val | None),
     param_name: String,
     children: Array[(U8, _TreeNode val)] iso,
     param_child: (_TreeNode val | None),
-    wildcard_factory': (HandlerFactory | None),
-    wildcard_response_interceptors':
-      (Array[ResponseInterceptor val] val | None),
-    wildcard_interceptors': (Array[RequestInterceptor val] val | None),
+    method_entries: Map[String, _MethodEntry val] iso,
+    wildcard_entries: Map[String, _MethodEntry val] iso,
     wildcard_name: String)
   =>
     _prefix = prefix
-    _factory = factory'
-    _response_interceptors = response_interceptors'
-    _interceptors = interceptors'
+    _parent_interceptors = parent_interceptors'
+    _parent_response_interceptors = parent_response_interceptors'
+    _accumulated_interceptors = accumulated_interceptors'
+    _accumulated_response_interceptors = accumulated_response_interceptors'
     _param_name = param_name
     _children = consume children
     _param_child = param_child
-    _wildcard_factory = wildcard_factory'
-    _wildcard_response_interceptors = wildcard_response_interceptors'
-    _wildcard_interceptors = wildcard_interceptors'
+    _method_entries = consume method_entries
+    _wildcard_entries = consume wildcard_entries
     _wildcard_name = wildcard_name
 
-  fun lookup(path: String): (_RouteMatch | None) =>
-    """Find a matching route for the given path."""
-    match _lookup(path, 0)
-    | (let f: HandlerFactory,
-       let ri: (Array[ResponseInterceptor val] val | None),
-       let gs: (Array[RequestInterceptor val] val | None),
-       let p: Array[(String, String)] val) =>
+  fun lookup(path: String, method_key: String, is_head: Bool):
+    (_RouteMatch | _RouteMiss | _MethodNotAllowed)
+  =>
+    """Find a matching route for the given path and method."""
+    match _lookup(path, 0, method_key, is_head)
+    | (let entry: _MethodEntry val, let p: Array[(String, String)] val) =>
       let frozen: Map[String, String] val = recover val
         let m = Map[String, String]
         for (k, v) in p.values() do
@@ -286,46 +506,61 @@ class val _TreeNode
         end
         m
       end
-      _RouteMatch(f, ri, gs, frozen)
-    else
-      None
+      _RouteMatch(entry.factory, entry.response_interceptors,
+        entry.interceptors, frozen)
+    | let miss: _RouteMiss => miss
+    | let na: _MethodNotAllowed => na
     end
 
-  fun _lookup(path: String, offset: USize):
-    ((HandlerFactory, (Array[ResponseInterceptor val] val | None),
-      (Array[RequestInterceptor val] val | None),
-      Array[(String, String)] val) | None)
+  fun _lookup(path: String, offset: USize, method_key: String,
+    is_head: Bool):
+    ((_MethodEntry val, Array[(String, String)] val) |
+      _RouteMiss | _MethodNotAllowed)
   =>
     """
-    Recursive lookup returning factory, response interceptors, request
-    interceptors, and accumulated params.
+    Recursive lookup returning method entry and accumulated params on hit,
+    `_RouteMiss` when the path doesn't exist, or `_MethodNotAllowed` when
+    the path exists but no handler matches the requested method.
 
     Params are built bottom-up: the leaf returns an empty val array, and each
     param level prepends its parameter to the child's val result.
     """
-    let empty_params: Array[(String, String)] val =
-      recover val Array[(String, String)] end
-
     if offset >= path.size() then
-      match _factory
-      | let f: HandlerFactory =>
-        return (f, _response_interceptors, _interceptors, empty_params)
+      match _resolve_or_405(method_key, is_head, _method_entries)
+      | let entry: _MethodEntry val =>
+        return (entry, _EmptyParams())
+      | let na: _MethodNotAllowed =>
+        return na
       end
-      return None
+      return _RouteMiss(_accumulated_response_interceptors,
+        _accumulated_interceptors)
     end
 
-    // Try static children first (priority over param)
+    // Try all branches in priority order (static > param > wildcard) for
+    // the requested method. A match from any branch returns immediately.
+    // Misses and method-not-allowed results are saved — we only decide
+    // 404 vs 405 after all branches are exhausted.
+    var deepest_miss: (_RouteMiss | None) = None
+    var method_not_allowed: (_MethodNotAllowed | None) = None
+
+    // Try static children first (highest priority)
     try
       let c = path(offset)?
       for (key, child) in _children.values() do
         if key == c then
           if _Paths.starts_with(path, offset, child._prefix) then
-            match child._lookup(path, offset + child._prefix.size())
-            | (let f: HandlerFactory,
-               let ri: (Array[ResponseInterceptor val] val | None),
-               let gs: (Array[RequestInterceptor val] val | None),
+            match child._lookup(path, offset + child._prefix.size(),
+              method_key, is_head)
+            | (let entry: _MethodEntry val,
                let p: Array[(String, String)] val) =>
-              return (f, ri, gs, p)
+              return (entry, p)
+            | let na: _MethodNotAllowed =>
+              // Save but continue — a lower-priority branch may match
+              if method_not_allowed is None then
+                method_not_allowed = na
+              end
+            | let miss: _RouteMiss =>
+              deepest_miss = miss
             end
           end
           break
@@ -335,16 +570,14 @@ class val _TreeNode
       _Unreachable()
     end
 
-    // Try parameter child
+    // Try parameter child (second priority)
     match _param_child
     | let child: _TreeNode val =>
       let value_end = _Paths.find_char(path, '/', offset)
       if value_end > offset then
         let value = path.trim(offset, value_end)
-        match child._lookup(path, value_end)
-        | (let f: HandlerFactory,
-           let ri: (Array[ResponseInterceptor val] val | None),
-           let gs: (Array[RequestInterceptor val] val | None),
+        match child._lookup(path, value_end, method_key, is_head)
+        | (let entry: _MethodEntry val,
            let child_params: Array[(String, String)] val) =>
           let with_param: Array[(String, String)] val = recover val
             let a = Array[(String, String)]
@@ -354,25 +587,115 @@ class val _TreeNode
             end
             a
           end
-          return (f, ri, gs, with_param)
+          return (entry, with_param)
+        | let na: _MethodNotAllowed =>
+          if method_not_allowed is None then
+            method_not_allowed = na
+          end
+        | let miss: _RouteMiss =>
+          // Keep whichever miss traversed deeper (has richer interceptors).
+          match deepest_miss
+          | let prev: _RouteMiss =>
+            if miss._interceptor_count() > prev._interceptor_count() then
+              deepest_miss = miss
+            end
+          else
+            deepest_miss = miss
+          end
         end
       end
     end
 
-    // Try wildcard
-    match _wildcard_factory
-    | let f: HandlerFactory =>
+    // Try wildcard (lowest priority)
+    match _resolve_or_405(method_key, is_head, _wildcard_entries)
+    | let entry: _MethodEntry val =>
       let remainder = path.trim(offset)
       let wildcard_params: Array[(String, String)] val = recover val
         let a = Array[(String, String)]
         a.push((_wildcard_name, remainder))
         a
       end
-      return (f, _wildcard_response_interceptors, _wildcard_interceptors,
-        wildcard_params)
+      return (entry, wildcard_params)
+    | let na: _MethodNotAllowed =>
+      if method_not_allowed is None then
+        method_not_allowed = na
+      end
     end
 
-    None
+    // All branches exhausted. Priority: 405 > deepest miss > fresh miss.
+    // 405 means the path exists (for some method), which is more specific
+    // than a miss (path doesn't exist at all).
+    match method_not_allowed
+    | let na: _MethodNotAllowed => return na
+    end
+
+    // Interceptor selection for the miss depends on whether the remaining
+    // path is a sub-path (starts with '/') or a sibling route sharing a
+    // character prefix (starts with non-'/'). Sub-paths get accumulated
+    // interceptors; siblings get parent-only interceptors.
+    match deepest_miss
+    | let miss: _RouteMiss => miss
+    else
+      let at_segment_boundary = try path(offset)? == '/' else true end
+      if at_segment_boundary then
+        _RouteMiss(_accumulated_response_interceptors,
+          _accumulated_interceptors)
+      else
+        _RouteMiss(_parent_response_interceptors,
+          _parent_interceptors)
+      end
+    end
+
+  fun _resolve_or_405(method_key: String, is_head: Bool,
+    entries: Map[String, _MethodEntry val] val)
+    : (_MethodEntry val | _MethodNotAllowed | None)
+  =>
+    """
+    Try to resolve a method entry from the given entries map.
+
+    Returns the entry on match, `_MethodNotAllowed` if the map has entries
+    but not for this method (with HEAD→GET fallback for HEAD requests),
+    or `None` if the map is empty. The `_MethodNotAllowed` carries only
+    the methods from this specific map — exact-path and wildcard entries
+    are never mixed.
+    """
+    try
+      return entries(method_key)?
+    end
+    if is_head then
+      try
+        return entries("GET")?
+      end
+    end
+    if entries.size() > 0 then
+      let allowed: Array[String] val = recover val
+        let methods = Array[String]
+        var has_get = false
+        for k in entries.keys() do
+          methods.push(k)
+          if k == "GET" then has_get = true end
+        end
+        if has_get then
+          var has_head = false
+          for m in methods.values() do
+            if m == "HEAD" then has_head = true; break end
+          end
+          if not has_head then methods.push("HEAD") end
+        end
+        methods
+      end
+      _MethodNotAllowed(allowed,
+        _accumulated_response_interceptors, _accumulated_interceptors)
+    else
+      None
+    end
+
+// --- Shared constants ---
+
+primitive _EmptyParams
+  """Empty params array for leaf returns — avoids allocation at each recursion level."""
+  fun apply(): Array[(String, String)] val =>
+    recover val Array[(String, String)] end
 
 // --- Path utilities ---
 

--- a/hobby/_test_integration.pony
+++ b/hobby/_test_integration.pony
@@ -32,6 +32,7 @@ primitive \nodoc\ _TestIntegrationList
     test(_TestPipelinedMultipleRequests)
     test(_TestNormalCompletionWithTimeout)
     test(_TestOnClosedStreamingDispose)
+    test(_TestMethodNotAllowed405)
 
 // --- Test helpers ---
 
@@ -105,7 +106,7 @@ actor \nodoc\ _TestIntegrationListener is lori.TCPListenerActor
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    _Connection(_server_auth, fd, _config, _router, _timers, 0, None)
+    _Connection(_server_auth, fd, _config, _router, _timers, 0)
 
   fun ref _on_listening() =>
     try
@@ -582,7 +583,7 @@ class \nodoc\ iso _TestHeadStreamingHandler is UnitTest
       "200 OK", "chunk-1;")
 
 class \nodoc\ iso _TestHeadPostOnlyRoute is UnitTest
-  """HEAD to POST-only route returns 404 (HEAD only falls back to GET)."""
+  """HEAD to POST-only route returns 405 with Allow header."""
   fun name(): String => "integration/HEAD on POST-only route"
 
   fun label(): String => "integration"
@@ -591,11 +592,9 @@ class \nodoc\ iso _TestHeadPostOnlyRoute is UnitTest
     let router = _IntegrationHelpers.build_router(recover val
       [(stallion.POST, "/echo", _EchoBodyFactory)]
     end)
-    // Forbid "\r\n\r\nNot Found" (body after headers), not just "Not Found"
-    // which also appears in the status line "404 Not Found".
     _HeadIntegrationHelpers.run_head_test(h, router,
       "HEAD /echo HTTP/1.1\r\nHost: localhost\r\n\r\n",
-      "content-length: 9", "\r\n\r\nNot Found")
+      "405 Method Not Allowed", "\r\n\r\nMethod Not Allowed")
 
 class \nodoc\ iso _TestHeadStreamingPipelinedGet is UnitTest
   """
@@ -661,7 +660,7 @@ actor \nodoc\ _TestTimeoutListener is lori.TCPListenerActor
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
     // 500ms timeout in nanoseconds
-    _Connection(_server_auth, fd, _config, _router, _timers, 500_000_000, None)
+    _Connection(_server_auth, fd, _config, _router, _timers, 500_000_000)
 
   fun ref _on_listening() =>
     try
@@ -1163,4 +1162,20 @@ class \nodoc\ iso _TestOnClosedStreamingDispose is UnitTest
         _DisconnectAfterSendClient(connect_auth, host, port, h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
       })
+
+class \nodoc\ iso _TestMethodNotAllowed405 is UnitTest
+  """GET to a POST-only route returns 405 with Allow header."""
+  fun name(): String => "integration/method not allowed 405"
+
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    let router = _IntegrationHelpers.build_router(recover val
+      [(stallion.POST, "/echo", _EchoBodyFactory)]
+    end)
+    // Check for Allow header — implies 405 status and verifies the header
+    // appears on the wire
+    _IntegrationHelpers.run_test(h, router,
+      "GET /echo HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "allow: POST")
 

--- a/hobby/_test_request_interceptor.pony
+++ b/hobby/_test_request_interceptor.pony
@@ -23,6 +23,8 @@ primitive \nodoc\ _TestRequestInterceptorList
     test(_TestInterceptPassIntegration)
     test(_TestInterceptGroupIntegration)
     test(_TestAppInterceptIntegration)
+    test(_TestInterceptGroup404Integration)
+    test(_TestInterceptGroup405Integration)
 
 // --- Test interceptors ---
 
@@ -276,6 +278,44 @@ class \nodoc\ iso _TestAppInterceptIntegration is UnitTest
     end where interceptors' = interceptors)
     _IntegrationHelpers.run_test(h, router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "Forbidden by interceptor")
+
+class \nodoc\ iso _TestInterceptGroup404Integration is UnitTest
+  """Group request interceptor fires on 404 under the group's prefix."""
+  fun name(): String => "integration/interceptor group 404"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, None)
+    builder.add(stallion.GET, "/api/users", _HelloFactory)
+    let router = builder.build()
+    // Request to /api/nonexistent should hit the /api group's interceptor
+    // and get rejected with 403 instead of 404
+    _IntegrationHelpers.run_test(h, router,
+      "GET /api/nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "Forbidden by interceptor")
+
+class \nodoc\ iso _TestInterceptGroup405Integration is UnitTest
+  """Group request interceptor fires on 405 under the group's prefix."""
+  fun name(): String => "integration/interceptor group 405"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, None)
+    builder.add(stallion.POST, "/api/users", _HelloFactory)
+    let router = builder.build()
+    // GET to POST-only /api/users should hit the /api group's interceptor
+    // and get rejected with 403 instead of 405
+    _IntegrationHelpers.run_test(h, router,
+      "GET /api/users HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Forbidden by interceptor")
 
 // --- Helpers ---

--- a/hobby/_test_response_interceptor.pony
+++ b/hobby/_test_response_interceptor.pony
@@ -28,6 +28,7 @@ primitive \nodoc\ _TestResponseInterceptorList
     test(_TestResponseInterceptorOnRejectIntercept)
     test(_TestResponseInterceptorSetBodyIntegration)
     test(_TestResponseInterceptorStreamingIntegration)
+    test(_TestResponseInterceptorGroupOn404)
 
 // --- Test interceptors ---
 
@@ -255,20 +256,18 @@ class \nodoc\ iso _TestConcatResponseInterceptorsInnerOnly is UnitTest
 // --- Integration test infrastructure ---
 
 actor \nodoc\ _TestResponseInterceptorListener is lori.TCPListenerActor
-  """Listener that passes app-level response interceptors to connections."""
+  """Listener for response interceptor integration tests."""
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: stallion.ServerConfig
   let _router: _Router val
   let _timers: Timers tag
   let _h: TestHelper
-  let _response_interceptors: (Array[ResponseInterceptor val] val | None)
   let _run_client:
     {(TestHelper, String, _TestResponseInterceptorListener)} val
 
   new create(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
     router: _Router val, h: TestHelper,
-    response_interceptors: (Array[ResponseInterceptor val] val | None),
     run_client:
       {(TestHelper, String, _TestResponseInterceptorListener)} val)
   =>
@@ -277,15 +276,13 @@ actor \nodoc\ _TestResponseInterceptorListener is lori.TCPListenerActor
     _router = router
     _timers = Timers
     _h = h
-    _response_interceptors = response_interceptors
     _run_client = run_client
     _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
 
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    _Connection(_server_auth, fd, _config, _router, _timers, 0,
-      _response_interceptors)
+    _Connection(_server_auth, fd, _config, _router, _timers, 0)
 
   fun ref _on_listening() =>
     try
@@ -346,7 +343,6 @@ actor \nodoc\ _TestResponseInterceptorClient is (lori.TCPConnectionActor & lori.
 
 primitive \nodoc\ _ResponseInterceptorIntegrationHelpers
   fun run_test(h: TestHelper, router: _Router val,
-    response_interceptors: (Array[ResponseInterceptor val] val | None),
     request: String, expected: String)
   =>
     h.long_test(5_000_000_000)
@@ -355,7 +351,6 @@ primitive \nodoc\ _ResponseInterceptorIntegrationHelpers
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
     _TestResponseInterceptorListener(auth, config, router, h,
-      response_interceptors,
       {(h': TestHelper, port: String,
         listener: _TestResponseInterceptorListener) =>
         _TestResponseInterceptorClient(connect_auth, host, port, h',
@@ -379,7 +374,6 @@ class \nodoc\ iso _TestResponseInterceptorSetHeaderIntegration is UnitTest
     builder.add(stallion.GET, "/", _HelloFactory, interceptors)
     let router = builder.build()
     _ResponseInterceptorIntegrationHelpers.run_test(h, router,
-      interceptors,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-custom: test-value")
 
@@ -395,10 +389,11 @@ class \nodoc\ iso _TestResponseInterceptorOn404 is UnitTest
           _AddHeaderResponseInterceptor("x-custom", "on-404")]
       end
     let builder = _RouterBuilder
+    // Register app-level interceptors on root node
+    builder.add_interceptors("", None, interceptors)
     builder.add(stallion.GET, "/exists", _HelloFactory)
     let router = builder.build()
     _ResponseInterceptorIntegrationHelpers.run_test(h, router,
-      interceptors,
       "GET /nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-custom: on-404")
 
@@ -420,7 +415,6 @@ class \nodoc\ iso _TestResponseInterceptorOnRejectIntercept is UnitTest
       request_interceptors)
     let router = builder.build()
     _ResponseInterceptorIntegrationHelpers.run_test(h, router,
-      response_interceptors,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-custom: on-reject")
 
@@ -439,7 +433,6 @@ class \nodoc\ iso _TestResponseInterceptorSetBodyIntegration is UnitTest
     builder.add(stallion.GET, "/", _HelloFactory, interceptors)
     let router = builder.build()
     _ResponseInterceptorIntegrationHelpers.run_test(h, router,
-      interceptors,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "replaced-body")
 
@@ -463,13 +456,31 @@ class \nodoc\ iso _TestResponseInterceptorStreamingIntegration is UnitTest
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
     _TestResponseInterceptorListener(auth, config, router, h,
-      interceptors,
       {(h': TestHelper, port: String,
         listener: _TestResponseInterceptorListener) =>
         _TestStreamingNoOpClient(connect_auth, host, port, h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
           "chunk-1;", "x-after-stream", listener)
       })
+
+class \nodoc\ iso _TestResponseInterceptorGroupOn404 is UnitTest
+  """Group response interceptor runs on 404 under the group's prefix."""
+  fun name(): String => "integration/response interceptor group on 404"
+  fun label(): String => "integration"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[ResponseInterceptor val] val =
+      recover val
+        [as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor("x-group", "api-404")]
+      end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", None, interceptors)
+    builder.add(stallion.GET, "/api/users", _HelloFactory)
+    let router = builder.build()
+    _ResponseInterceptorIntegrationHelpers.run_test(h, router,
+      "GET /api/nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      "x-group: api-404")
 
 actor \nodoc\ _TestStreamingNoOpClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
   """

--- a/hobby/_test_route_group.pony
+++ b/hobby/_test_route_group.pony
@@ -16,6 +16,9 @@ primitive \nodoc\ _TestRouteGroupList
     test(_TestJoinPath)
     test(_TestEmptyGroup)
     test(_TestMultipleGroupsOnApplication)
+    test(_TestGroupInfoCollection)
+    test(_TestNestedGroupInfoCollection)
+    test(_TestTripleLevelGroupInfoCollection)
 
 // --- Generators ---
 
@@ -45,7 +48,7 @@ class \nodoc\ iso _PropertyGroupPrefixMatches is
     let router = builder.build()
     match router.lookup(stallion.GET, joined)
     | let _: _RouteMatch => None
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match at " + joined)
     end
 
@@ -68,7 +71,7 @@ class \nodoc\ iso _PropertyNestedGroupPrefixOrder is
     let router = builder.build()
     match router.lookup(stallion.GET, joined)
     | let _: _RouteMatch => None
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match at " + joined)
     end
 
@@ -97,9 +100,17 @@ class \nodoc\ iso _PropertyGroupFlattenEquivalence is
     builder2.add(stallion.GET, manual, _NoOpFactory, None)
     let router2 = builder2.build()
 
-    let r1_matches = router1.lookup(stallion.GET, joined) isnt None
-    let r2_matches = router2.lookup(stallion.GET, joined) isnt None
-    h.assert_eq[Bool](r1_matches, r2_matches)
+    let r1_match = match router1.lookup(stallion.GET, joined)
+    | let _: _RouteMatch => true
+    else
+      false
+    end
+    let r2_match = match router2.lookup(stallion.GET, joined)
+    | let _: _RouteMatch => true
+    else
+      false
+    end
+    h.assert_eq[Bool](r1_match, r2_match)
 
 // --- Example-based tests ---
 
@@ -133,7 +144,7 @@ class \nodoc\ iso _TestEmptyGroup is UnitTest
     let g = RouteGroup("/api")
     let target = Array[_RouteDefinition]
     let g_ref: RouteGroup ref = consume g
-    g_ref._flatten_into(target)
+    g_ref._flatten_routes_into(target)
     h.assert_eq[USize](0, target.size())
 
 class \nodoc\ iso _TestMultipleGroupsOnApplication is UnitTest
@@ -156,9 +167,9 @@ class \nodoc\ iso _TestMultipleGroupsOnApplication is UnitTest
 
     let target = Array[_RouteDefinition]
     let g1_ref: RouteGroup ref = consume g1
-    g1_ref._flatten_into(target)
+    g1_ref._flatten_routes_into(target)
     let g2_ref: RouteGroup ref = consume g2
-    g2_ref._flatten_into(target)
+    g2_ref._flatten_routes_into(target)
 
     h.assert_eq[USize](2, target.size())
     try
@@ -168,4 +179,96 @@ class \nodoc\ iso _TestMultipleGroupsOnApplication is UnitTest
       h.assert_is[HandlerFactory](f2, target(1)?.factory)
     else
       h.fail("expected two routes")
+    end
+
+class \nodoc\ iso _TestGroupInfoCollection is UnitTest
+  """Group info is collected with prefix and interceptors."""
+  fun name(): String => "route-group/group info collection"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let g = RouteGroup("/api" where interceptors = interceptors)
+    g.get("/users", _NoOpFactory)
+
+    let infos = Array[_GroupInfo]
+    let g_ref: RouteGroup ref = consume g
+    g_ref._collect_group_infos(infos)
+
+    h.assert_eq[USize](1, infos.size())
+    try
+      h.assert_eq[String]("/api", infos(0)?.prefix)
+      match infos(0)?.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+      else
+        h.fail("expected interceptors on group info")
+      end
+    else
+      h.fail("expected one group info")
+    end
+
+class \nodoc\ iso _TestNestedGroupInfoCollection is UnitTest
+  """Nested group infos are collected with joined prefixes."""
+  fun name(): String => "route-group/nested group info collection"
+
+  fun apply(h: TestHelper) =>
+    let outer_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let inner_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+
+    let inner = RouteGroup("/v1" where interceptors = inner_interceptors)
+    inner.get("/users", _NoOpFactory)
+
+    let outer = RouteGroup("/api" where interceptors = outer_interceptors)
+    outer.get("/health", _NoOpFactory)
+    outer.group(consume inner)
+
+    let infos = Array[_GroupInfo]
+    let outer_ref: RouteGroup ref = consume outer
+    outer_ref._collect_group_infos(infos)
+
+    // Should have two infos: outer (/api) and inner (/api/v1)
+    h.assert_eq[USize](2, infos.size())
+    try
+      h.assert_eq[String]("/api", infos(0)?.prefix)
+      h.assert_eq[String]("/api/v1", infos(1)?.prefix)
+    else
+      h.fail("expected two group infos with correct prefixes")
+    end
+
+class \nodoc\ iso _TestTripleLevelGroupInfoCollection is UnitTest
+  """3-level nested group infos have fully joined prefixes."""
+  fun name(): String => "route-group/triple level group info collection"
+
+  fun apply(h: TestHelper) =>
+    let deep_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let inner_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let outer_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+
+    let deep = RouteGroup("/settings" where interceptors = deep_interceptors)
+    deep.get("/profile", _NoOpFactory)
+
+    let inner = RouteGroup("/admin" where interceptors = inner_interceptors)
+    inner.group(consume deep)
+
+    let outer = RouteGroup("/api" where interceptors = outer_interceptors)
+    outer.group(consume inner)
+
+    let infos = Array[_GroupInfo]
+    let outer_ref: RouteGroup ref = consume outer
+    outer_ref._collect_group_infos(infos)
+
+    // Should have three infos: /api, /api/admin, /api/admin/settings
+    h.assert_eq[USize](3, infos.size())
+    try
+      h.assert_eq[String]("/api", infos(0)?.prefix)
+      h.assert_eq[String]("/api/admin", infos(1)?.prefix)
+      h.assert_eq[String]("/api/admin/settings", infos(2)?.prefix)
+    else
+      h.fail("expected three group infos with correct prefixes")
     end

--- a/hobby/_test_router.pony
+++ b/hobby/_test_router.pony
@@ -6,7 +6,7 @@ use stallion = "stallion"
 primitive \nodoc\ _TestRouterList
   fun tests(test: PonyTest) =>
     test(Property1UnitTest[String](_PropertyStaticRouteMatches))
-    test(Property1UnitTest[String](_PropertyUnregisteredReturnsNone))
+    test(Property1UnitTest[String](_PropertyUnregisteredReturnsMiss))
     test(Property1UnitTest[
       (String, String)](_PropertyParamExtraction))
     test(Property1UnitTest[
@@ -25,9 +25,38 @@ primitive \nodoc\ _TestRouterList
     test(_TestSplitAtSegmentBoundary)
     test(_TestSplitMidSegmentParam)
     test(_TestDeepNestedParamSharedPrefix)
+    test(_TestStaticPrefixFallsBackToParam)
     test(Property1UnitTest[
       (Array[USize] val, Array[USize] val)](
       _PropertyInsertionOrderInvariance))
+    test(_TestHeadFallbackInRouter)
+    test(_TestInterceptorAccumulation)
+    test(_TestMissCarriesInterceptors)
+    test(_TestRootMissCarriesInterceptors)
+    test(_TestPerRouteInterceptorsMethodSpecific)
+    test(_TestValidateGroupsDistinctPrefixes)
+    test(_TestValidateGroupsOverlappingPrefixes)
+    test(_TestValidateGroupsEmptyPrefix)
+    test(_TestValidateGroupsRootPrefix)
+    test(_TestValidateGroupsSpecialChars)
+    test(_TestParamNameConflictReturnsError)
+    test(_TestInterceptorSegmentBoundary)
+    test(_TestInterceptorSegmentBoundaryMiss)
+    test(_TestInterceptorSegmentBoundaryNestedGroups)
+    test(_TestDeepestMissPreservesRicherInterceptors)
+    test(_TestSharedParamNameConsistent)
+    test(_TestMethodNotAllowed)
+    test(_TestMethodNotAllowedAllowHeader)
+    test(_TestWildcardMethodIsolation)
+    test(_TestWildcardHeadFallback)
+    test(_TestParamPriorityOverWildcard)
+    test(_TestStaticParamWildcardPriority)
+    test(_Test405FallsBackToLowerPriorityMatch)
+    test(_Test405FallsBackStaticToParam)
+    test(_Test405AllowHeaderScopedToEntryType)
+    test(_TestEmptyParamSegmentSkipped)
+    test(_TestRoutesBeforeInterceptors)
+    test(_TestMethodNotAllowedCarriesInterceptors)
 
 // --- Generators ---
 
@@ -89,21 +118,24 @@ class \nodoc\ iso _PropertyStaticRouteMatches is Property1[String]
     match router.lookup(stallion.GET, path)
     | let m: _RouteMatch =>
       h.assert_eq[USize](0, m.params.size())
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for " + path)
     end
 
-class \nodoc\ iso _PropertyUnregisteredReturnsNone is Property1[String]
-  """An unregistered path returns None."""
-  fun name(): String => "router/property/unregistered returns None"
+class \nodoc\ iso _PropertyUnregisteredReturnsMiss is Property1[String]
+  """An unregistered path returns _RouteMiss."""
+  fun name(): String => "router/property/unregistered returns miss"
 
   fun gen(): Generator[String] => _GenStaticPath()
 
   fun property(path: String, h: PropertyHelper) =>
     let router = _RouterBuilder.build()
     match router.lookup(stallion.GET, path)
+    | let _: _RouteMiss => None
     | let _: _RouteMatch =>
-      h.fail("expected None for " + path + " on empty router")
+      h.fail("expected miss for " + path + " on empty router")
+    | let _: _MethodNotAllowed =>
+      h.fail("expected miss for " + path + " on empty router")
     end
 
 class \nodoc\ iso _PropertyParamExtraction is
@@ -124,14 +156,14 @@ class \nodoc\ iso _PropertyParamExtraction is
     let router = builder.build()
 
     let lookup_path: String val = prefix + "/testvalue"
-    match \exhaustive\ router.lookup(stallion.GET, lookup_path)
+    match router.lookup(stallion.GET, lookup_path)
     | let m: _RouteMatch =>
       try
         h.assert_eq[String]("testvalue", m.params(param_name)?)
       else
         h.fail("param not found in match")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match")
     end
 
@@ -168,7 +200,7 @@ class \nodoc\ iso _PropertyMultipleParams is
       else
         h.fail("param p2 not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match")
     end
 
@@ -180,6 +212,9 @@ class \nodoc\ iso _PropertyMethodIsolation is
   fun gen(): Generator[stallion.Method] => _GenMethod()
 
   fun property(method: stallion.Method, h: PropertyHelper) =>
+    // Skip HEAD — it falls back to GET in the shared tree
+    if method is stallion.HEAD then return end
+
     let builder = _RouterBuilder
     builder.add(method, "/test", _NoOpFactory, None)
     let router = builder.build()
@@ -191,15 +226,18 @@ class \nodoc\ iso _PropertyMethodIsolation is
       h.fail("expected match for registered method")
     end
 
-    // Should NOT match a different method
+    // Should return 405 for a different method (excluding HEAD→GET)
     let other: stallion.Method = if method is stallion.GET then
       stallion.POST
     else
       stallion.GET
     end
     match router.lookup(other, "/test")
+    | let _: _MethodNotAllowed => None
     | let _: _RouteMatch =>
       h.fail("should not match different method")
+    | let _: _RouteMiss =>
+      h.fail("should be 405, not 404")
     end
 
 class \nodoc\ iso _PropertyWildcardCapture is Property1[String]
@@ -222,7 +260,7 @@ class \nodoc\ iso _PropertyWildcardCapture is Property1[String]
       else
         h.fail("wildcard param 'path' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match")
     end
 
@@ -247,7 +285,7 @@ class \nodoc\ iso _TestStaticPriorityOverParam is UnitTest
     match router.lookup(stallion.GET, "/users/new")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](static_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /users/new")
     end
 
@@ -259,7 +297,7 @@ class \nodoc\ iso _TestStaticPriorityOverParam is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /users/42")
     end
 
@@ -274,7 +312,7 @@ class \nodoc\ iso _TestRootPath is UnitTest
 
     match router.lookup(stallion.GET, "/")
     | let _: _RouteMatch => None
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /")
     end
 
@@ -296,13 +334,13 @@ class \nodoc\ iso _TestOverlappingPrefixes is UnitTest
 
     match router.lookup(stallion.GET, "/api/v1/users")
     | let m: _RouteMatch => h.assert_is[HandlerFactory](f1, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /api/v1/users")
     end
 
     match router.lookup(stallion.GET, "/api/v2/users")
     | let m: _RouteMatch => h.assert_is[HandlerFactory](f2, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /api/v2/users")
     end
 
@@ -322,7 +360,7 @@ class \nodoc\ iso _TestWildcardSingleSegment is UnitTest
       else
         h.fail("wildcard param 'path' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /files/readme.txt")
     end
 
@@ -343,13 +381,13 @@ class \nodoc\ iso _TestTrailingSlashNormalization is UnitTest
 
     match router.lookup(stallion.GET, "/users")
     | let _: _RouteMatch => None
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /users")
     end
 
     match router.lookup(stallion.GET, "/users/")
     | let _: _RouteMatch => None
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /users/ (trailing slash)")
     end
 
@@ -380,7 +418,7 @@ class \nodoc\ iso _TestSplitThenParam is UnitTest
     match router.lookup(stallion.POST, "/a/b/c/login")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](login_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /a/b/c/login")
     end
 
@@ -393,7 +431,7 @@ class \nodoc\ iso _TestSplitThenParam is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /a/b/c/user/42/filter")
     end
 
@@ -418,7 +456,7 @@ class \nodoc\ iso _TestSplitThenWildcard is UnitTest
     match router.lookup(stallion.GET, "/static/page")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](exact_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /static/page")
     end
 
@@ -430,7 +468,7 @@ class \nodoc\ iso _TestSplitThenWildcard is UnitTest
       else
         h.fail("wildcard param 'rest' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /static/other/deep/path")
     end
 
@@ -453,7 +491,7 @@ class \nodoc\ iso _TestSplitThenMultipleParams is UnitTest
     match router.lookup(stallion.GET, "/api/v1/health")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](static_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /api/v1/health")
     end
 
@@ -470,7 +508,7 @@ class \nodoc\ iso _TestSplitThenMultipleParams is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /api/v1/users/99")
     end
 
@@ -495,7 +533,7 @@ class \nodoc\ iso _TestSplitParamThenStatic is UnitTest
     match router.lookup(stallion.POST, "/a/b/c/login")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](static_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /a/b/c/login")
     end
 
@@ -507,7 +545,7 @@ class \nodoc\ iso _TestSplitParamThenStatic is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /a/b/c/user/42/filter")
     end
 
@@ -530,7 +568,7 @@ class \nodoc\ iso _TestSplitAtSegmentBoundary is UnitTest
     match router.lookup(stallion.GET, "/items/list")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](list_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /items/list")
     end
 
@@ -542,7 +580,7 @@ class \nodoc\ iso _TestSplitAtSegmentBoundary is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /items/42")
     end
 
@@ -569,7 +607,7 @@ class \nodoc\ iso _TestSplitMidSegmentParam is UnitTest
     match router.lookup(stallion.GET, "/prefix/index")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](index_factory, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /prefix/index")
     end
 
@@ -581,7 +619,7 @@ class \nodoc\ iso _TestSplitMidSegmentParam is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /prefix/item/7")
     end
 
@@ -608,7 +646,7 @@ class \nodoc\ iso _TestDeepNestedParamSharedPrefix is UnitTest
     match router.lookup(stallion.GET, "/x/y/z/alpha")
     | let m: _RouteMatch =>
       h.assert_is[HandlerFactory](fa, m.factory)
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /x/y/z/alpha")
     end
 
@@ -620,7 +658,7 @@ class \nodoc\ iso _TestDeepNestedParamSharedPrefix is UnitTest
       else
         h.fail("param 'id' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /x/y/z/a/10")
     end
 
@@ -637,8 +675,265 @@ class \nodoc\ iso _TestDeepNestedParamSharedPrefix is UnitTest
       else
         h.fail("param 'sid' not found")
       end
-    else
+    | let _: _RouteMiss =>
       h.fail("expected match for /x/y/z/a/10/sub/20")
+    end
+
+class \nodoc\ iso _TestStaticPrefixFallsBackToParam is UnitTest
+  """
+  When a static child's prefix matches as a prefix of the remaining path
+  but the subtree doesn't match, lookup falls back to the param child.
+
+  Regression: _RouteMiss from a static child must not block param fallback.
+  `/users/new` and `/users/:id` — a lookup for `/users/newsletter` enters
+  the `new` static child (since "newsletter" starts with "new") but fails.
+  The param child `:id` should still match.
+  """
+  fun name(): String => "router/static prefix falls back to param"
+
+  fun apply(h: TestHelper) =>
+    let static_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
+    } val
+    let param_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/users/new", static_factory, None)
+    builder.add(stallion.GET, "/users/:id", param_factory, None)
+    let router = builder.build()
+
+    // Exact static match still works
+    match router.lookup(stallion.GET, "/users/new")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](static_factory, m.factory)
+    | let _: _RouteMiss =>
+      h.fail("expected match for /users/new")
+    end
+
+    // "newsletter" starts with "new" — must fall back to param
+    match router.lookup(stallion.GET, "/users/newsletter")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](param_factory, m.factory)
+      try
+        h.assert_eq[String]("newsletter", m.params("id")?)
+      else
+        h.fail("param 'id' not found")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected param match for /users/newsletter (backtrack from static)")
+    end
+
+class \nodoc\ iso _TestParamPriorityOverWildcard is UnitTest
+  """Param child is tried before wildcard at the same node."""
+  fun name(): String => "router/param priority over wildcard"
+
+  fun apply(h: TestHelper) =>
+    let param_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
+    } val
+    let wildcard_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "wildcard")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files/:id", param_factory, None)
+    builder.add(stallion.GET, "/files/*path", wildcard_factory, None)
+    let router = builder.build()
+
+    // Single segment — param wins over wildcard
+    match router.lookup(stallion.GET, "/files/readme.txt")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](param_factory, m.factory)
+      try
+        h.assert_eq[String]("readme.txt", m.params("id")?)
+      else
+        h.fail("param 'id' not found")
+      end
+    else
+      h.fail("expected param match for /files/readme.txt")
+    end
+
+    // Multi-segment — param can't match (stops at /), wildcard takes it
+    match router.lookup(stallion.GET, "/files/css/style.css")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](wildcard_factory, m.factory)
+      try
+        h.assert_eq[String]("css/style.css", m.params("path")?)
+      else
+        h.fail("wildcard param 'path' not found")
+      end
+    else
+      h.fail("expected wildcard match for /files/css/style.css")
+    end
+
+class \nodoc\ iso _TestStaticParamWildcardPriority is UnitTest
+  """Full three-level priority: static > param > wildcard."""
+  fun name(): String => "router/static param wildcard priority"
+
+  fun apply(h: TestHelper) =>
+    let static_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
+    } val
+    let param_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
+    } val
+    let wildcard_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "wildcard")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files/special", static_factory, None)
+    builder.add(stallion.GET, "/files/:id", param_factory, None)
+    builder.add(stallion.GET, "/files/*path", wildcard_factory, None)
+    let router = builder.build()
+
+    // Exact static match — highest priority
+    match router.lookup(stallion.GET, "/files/special")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](static_factory, m.factory)
+    else
+      h.fail("expected static match for /files/special")
+    end
+
+    // Single segment, not "special" — param wins over wildcard
+    match router.lookup(stallion.GET, "/files/other")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](param_factory, m.factory)
+    else
+      h.fail("expected param match for /files/other")
+    end
+
+    // Multi-segment — only wildcard can match
+    match router.lookup(stallion.GET, "/files/a/b/c")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](wildcard_factory, m.factory)
+    else
+      h.fail("expected wildcard match for /files/a/b/c")
+    end
+
+class \nodoc\ iso _Test405FallsBackToLowerPriorityMatch is UnitTest
+  """
+  405 from param falls back to wildcard match.
+
+  POST /files/:id + GET /files/*path — GET /files/readme.txt should match
+  the wildcard, not return 405 from the param branch.
+  """
+  fun name(): String => "router/405 falls back to lower priority match"
+
+  fun apply(h: TestHelper) =>
+    let param_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
+    } val
+    let wildcard_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "wildcard")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.POST, "/files/:id", param_factory, None)
+    builder.add(stallion.GET, "/files/*path", wildcard_factory, None)
+    let router = builder.build()
+
+    // GET should fall through param (POST-only) to wildcard (GET)
+    match router.lookup(stallion.GET, "/files/readme.txt")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](wildcard_factory, m.factory)
+      try
+        h.assert_eq[String]("readme.txt", m.params("path")?)
+      else
+        h.fail("wildcard param 'path' not found")
+      end
+    | let _: _MethodNotAllowed =>
+      h.fail("should match GET wildcard, not return 405 from POST param")
+    | let _: _RouteMiss =>
+      h.fail("expected match")
+    end
+
+    // POST should match param (higher priority than wildcard)
+    match router.lookup(stallion.POST, "/files/readme.txt")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](param_factory, m.factory)
+    else
+      h.fail("expected POST param match")
+    end
+
+class \nodoc\ iso _Test405FallsBackStaticToParam is UnitTest
+  """
+  405 from static falls back to param match.
+
+  POST /users/new + GET /users/:id — GET /users/new should match the param
+  with id="new", not return 405 from the static branch.
+  """
+  fun name(): String => "router/405 falls back static to param"
+
+  fun apply(h: TestHelper) =>
+    let static_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
+    } val
+    let param_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.POST, "/users/new", static_factory, None)
+    builder.add(stallion.GET, "/users/:id", param_factory, None)
+    let router = builder.build()
+
+    // GET /users/new: static has POST-only → falls back to param GET
+    match router.lookup(stallion.GET, "/users/new")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](param_factory, m.factory)
+      try
+        h.assert_eq[String]("new", m.params("id")?)
+      else
+        h.fail("param 'id' not found")
+      end
+    | let _: _MethodNotAllowed =>
+      h.fail("should match GET param, not return 405 from POST static")
+    | let _: _RouteMiss =>
+      h.fail("expected match")
+    end
+
+    // POST /users/new: static matches (highest priority)
+    match router.lookup(stallion.POST, "/users/new")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](static_factory, m.factory)
+    else
+      h.fail("expected POST static match")
+    end
+
+class \nodoc\ iso _Test405AllowHeaderScopedToEntryType is UnitTest
+  """
+  Allow header on 405 lists only methods from the matching entry type.
+
+  GET /files + POST /files/*path → DELETE /files gets Allow: GET, HEAD
+  (from exact-path entries only), not GET, HEAD, POST (which would leak
+  wildcard methods).
+  """
+  fun name(): String => "router/405 allow header scoped to entry type"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files", _NoOpFactory, None)
+    builder.add(stallion.POST, "/files/*path", _NoOpFactory, None)
+    let router = builder.build()
+
+    // DELETE /files → 405 from exact-path entries (GET only)
+    match router.lookup(stallion.DELETE, "/files")
+    | let na: _MethodNotAllowed =>
+      // Should have GET and HEAD (implicit), but NOT POST
+      var has_get = false
+      var has_head = false
+      var has_post = false
+      for m in na.allowed_methods.values() do
+        if m == "GET" then has_get = true end
+        if m == "HEAD" then has_head = true end
+        if m == "POST" then has_post = true end
+      end
+      h.assert_true(has_get, "Allow should include GET")
+      h.assert_true(has_head, "Allow should include HEAD")
+      h.assert_false(has_post,
+        "Allow must NOT include POST (wildcard method, different resource)")
+    | let _: _RouteMatch =>
+      h.fail("DELETE should not match")
+    | let _: _RouteMiss =>
+      h.fail("should be 405, not 404")
     end
 
 // --- Property test: insertion order invariance ---
@@ -663,40 +958,60 @@ class \nodoc\ iso _PropertyInsertionOrderInvariance is
   =>
     (let perm_a, let perm_b) = sample
 
+    // Distinct factories per route so we can verify the same route matched
+    let f0: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "0")
+    } val
+    let f1: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "1")
+    } val
+    let f2: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "2")
+    } val
+    let f3: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "3")
+    } val
+    let f4: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "4")
+    } val
+
     // Fixed route set mixing static, param, and wildcard patterns
-    let routes: Array[(String, String)] val = [
-      ("/api/v1/users", "/api/v1/users")
-      ("/api/v1/users/:id", "/api/v1/users/42")
-      ("/api/v1/items", "/api/v1/items")
-      ("/api/v1/items/:id/detail", "/api/v1/items/7/detail")
-      ("/api/v1/*rest", "/api/v1/anything/here")
+    let routes: Array[(String, String, HandlerFactory)] val = [
+      ("/api/v1/users", "/api/v1/users", f0)
+      ("/api/v1/users/:id", "/api/v1/users/42", f1)
+      ("/api/v1/items", "/api/v1/items", f2)
+      ("/api/v1/items/:id/detail", "/api/v1/items/7/detail", f3)
+      ("/api/v1/*rest", "/api/v1/anything/here", f4)
     ]
 
     let router_a = _build_in_order(routes, perm_a)
     let router_b = _build_in_order(routes, perm_b)
 
-    // Both routers must agree on every lookup path
-    for (_, lookup_path) in routes.values() do
+    // Both routers must agree on every lookup path AND match the same route
+    for (_, lookup_path, _) in routes.values() do
       let result_a = router_a.lookup(stallion.GET, lookup_path)
       let result_b = router_b.lookup(stallion.GET, lookup_path)
       match (result_a, result_b)
-      | (let _: _RouteMatch, let _: _RouteMatch) => None
-      | (None, None) => None
+      | (let ma: _RouteMatch, let mb: _RouteMatch) =>
+        h.assert_true(ma.factory is mb.factory,
+          "insertion order changed matched route for " + lookup_path)
+      | (let _: _RouteMiss, let _: _RouteMiss) => None
+      | (let _: _MethodNotAllowed, let _: _MethodNotAllowed) => None
       else
-        h.fail("insertion order changed result for " + lookup_path)
+        h.fail("insertion order changed result type for " + lookup_path)
       end
     end
 
   fun _build_in_order(
-    routes: Array[(String, String)] val,
+    routes: Array[(String, String, HandlerFactory)] val,
     order: Array[USize] val)
     : _Router val
   =>
     let builder = _RouterBuilder
     for idx in order.values() do
       try
-        (let pattern, _) = routes(idx)?
-        builder.add(stallion.GET, pattern, _NoOpFactory, None)
+        (let pattern, _, let factory) = routes(idx)?
+        builder.add(stallion.GET, pattern, factory, None)
       else
         _Unreachable()
       end
@@ -722,3 +1037,801 @@ primitive \nodoc\ _GenPermutation
           consume result
       end)
 
+// --- New tests for shared path tree ---
+
+class \nodoc\ iso _TestHeadFallbackInRouter is UnitTest
+  """HEAD falls back to GET handler in a single tree traversal."""
+  fun name(): String => "router/HEAD fallback in router"
+
+  fun apply(h: TestHelper) =>
+    let get_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "get")
+    } val
+    let head_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "head")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/fallback", get_factory, None)
+    builder.add(stallion.HEAD, "/explicit", head_factory, None)
+    builder.add(stallion.GET, "/explicit", get_factory, None)
+    let router = builder.build()
+
+    // HEAD to /fallback should resolve to GET handler
+    match router.lookup(stallion.HEAD, "/fallback")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](get_factory, m.factory)
+    | let _: _RouteMiss =>
+      h.fail("HEAD should fall back to GET for /fallback")
+    end
+
+    // HEAD to /explicit should resolve to HEAD handler
+    match router.lookup(stallion.HEAD, "/explicit")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](head_factory, m.factory)
+    | let _: _RouteMiss =>
+      h.fail("expected match for HEAD /explicit")
+    end
+
+class \nodoc\ iso _TestInterceptorAccumulation is UnitTest
+  """Interceptors on a path node accumulate into matched routes under it."""
+  fun name(): String => "router/interceptor accumulation"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, None)
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    let router = builder.build()
+
+    match router.lookup(stallion.GET, "/api/users")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor,
+            "accumulated interceptor should be the one registered on /api")
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("expected interceptors on matched route")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for /api/users")
+    end
+
+class \nodoc\ iso _TestMissCarriesInterceptors is UnitTest
+  """A miss under a group carries the group's accumulated interceptors."""
+  fun name(): String => "router/miss carries interceptors"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let resp_interceptor: ResponseInterceptor val = _NoOpResponseInterceptor
+    let resp_interceptors: Array[ResponseInterceptor val] val =
+      recover val [as ResponseInterceptor val: resp_interceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, resp_interceptors)
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    let router = builder.build()
+
+    // Miss under /api should carry /api's interceptors
+    match router.lookup(stallion.GET, "/api/nonexistent")
+    | let miss: _RouteMiss =>
+      match miss.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor,
+            "miss should carry the request interceptor from /api")
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("expected request interceptors on miss")
+      end
+      match miss.response_interceptors
+      | let ris: Array[ResponseInterceptor val] val =>
+        h.assert_eq[USize](1, ris.size())
+        try
+          h.assert_true(ris(0)? is resp_interceptor,
+            "miss should carry the response interceptor from /api")
+        else
+          h.fail("response interceptor access failed")
+        end
+      else
+        h.fail("expected response interceptors on miss")
+      end
+    | let _: _RouteMatch =>
+      h.fail("expected miss for /api/nonexistent")
+    end
+
+class \nodoc\ iso _TestRootMissCarriesInterceptors is UnitTest
+  """A miss at the root carries root-level interceptors."""
+  fun name(): String => "router/root miss carries interceptors"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("", interceptors, None)
+    builder.add(stallion.GET, "/exists", _NoOpFactory, None)
+    let router = builder.build()
+
+    match router.lookup(stallion.GET, "/nonexistent")
+    | let miss: _RouteMiss =>
+      match miss.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor,
+            "root miss should carry the root interceptor")
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("expected root interceptors on miss")
+      end
+    | let _: _RouteMatch =>
+      h.fail("expected miss for /nonexistent")
+    end
+
+class \nodoc\ iso _TestPerRouteInterceptorsMethodSpecific is UnitTest
+  """Per-route interceptors are method-specific at the same leaf."""
+  fun name(): String => "router/per-route interceptors method-specific"
+
+  fun apply(h: TestHelper) =>
+    let get_interceptor: RequestInterceptor val = _PassInterceptor
+    let get_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: get_interceptor] end
+    let post_interceptor: RequestInterceptor val = _RejectInterceptor
+    let post_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: post_interceptor] end
+
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None,
+      get_interceptors)
+    builder.add(stallion.POST, "/api/users", _NoOpFactory, None,
+      post_interceptors)
+    let router = builder.build()
+
+    match router.lookup(stallion.GET, "/api/users")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is get_interceptor)
+        else
+          h.fail("unexpected interceptor on GET")
+        end
+      else
+        h.fail("expected interceptors on GET")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for GET /api/users")
+    end
+
+    match router.lookup(stallion.POST, "/api/users")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is post_interceptor)
+        else
+          h.fail("unexpected interceptor on POST")
+        end
+      else
+        h.fail("expected interceptors on POST")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for POST /api/users")
+    end
+
+class \nodoc\ iso _TestValidateGroupsDistinctPrefixes is UnitTest
+  """Distinct sibling and nested group prefixes pass validation."""
+  fun name(): String => "router/validate groups distinct prefixes"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let infos: Array[_GroupInfo] ref = Array[_GroupInfo]
+    infos.push(_GroupInfo("/api", interceptors, None))
+    infos.push(_GroupInfo("/admin", interceptors, None))
+    infos.push(_GroupInfo("/api/v1", interceptors, None))
+    h.assert_true(_ValidateGroups(infos) is None,
+      "distinct prefixes should pass validation")
+
+class \nodoc\ iso _TestValidateGroupsOverlappingPrefixes is UnitTest
+  """Overlapping group prefixes produce a ConfigError."""
+  fun name(): String => "router/validate groups overlapping prefixes"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let infos: Array[_GroupInfo] ref = Array[_GroupInfo]
+    infos.push(_GroupInfo("/api", interceptors, None))
+    infos.push(_GroupInfo("/api", interceptors, None))
+    match _ValidateGroups(infos)
+    | let err: ConfigError =>
+      h.assert_true(err.message.contains("Overlapping"))
+    else
+      h.fail("overlapping prefixes should produce ConfigError")
+    end
+
+class \nodoc\ iso _TestValidateGroupsEmptyPrefix is UnitTest
+  """Empty group prefix produces a ConfigError."""
+  fun name(): String => "router/validate groups empty prefix"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let infos: Array[_GroupInfo] ref = Array[_GroupInfo]
+    infos.push(_GroupInfo("", interceptors, None))
+    match _ValidateGroups(infos)
+    | let err: ConfigError =>
+      h.assert_true(err.message.contains("app-level interceptors"))
+    else
+      h.fail("empty prefix should produce ConfigError")
+    end
+
+class \nodoc\ iso _TestValidateGroupsRootPrefix is UnitTest
+  """RouteGroup("/") with interceptors produces a ConfigError."""
+  fun name(): String => "router/validate groups root prefix"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let infos: Array[_GroupInfo] ref = Array[_GroupInfo]
+    infos.push(_GroupInfo("/", interceptors, None))
+    match _ValidateGroups(infos)
+    | let err: ConfigError =>
+      h.assert_true(err.message.contains("app-level interceptors"))
+    else
+      h.fail("root prefix should produce ConfigError")
+    end
+
+class \nodoc\ iso _TestValidateGroupsSpecialChars is UnitTest
+  """Special characters in group prefix produce a ConfigError."""
+  fun name(): String => "router/validate groups special chars"
+
+  fun apply(h: TestHelper) =>
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: _PassInterceptor] end
+
+    // Colon in prefix
+    let infos_colon: Array[_GroupInfo] ref = Array[_GroupInfo]
+    infos_colon.push(_GroupInfo("/:org", interceptors, None))
+    match _ValidateGroups(infos_colon)
+    | let err: ConfigError =>
+      h.assert_true(err.message.contains("':'"))
+    else
+      h.fail("colon in prefix should produce ConfigError")
+    end
+
+    // Wildcard in prefix
+    let infos_star: Array[_GroupInfo] ref = Array[_GroupInfo]
+    infos_star.push(_GroupInfo("/files/*path", interceptors, None))
+    match _ValidateGroups(infos_star)
+    | let err: ConfigError =>
+      h.assert_true(err.message.contains("'*'"))
+    else
+      h.fail("wildcard in prefix should produce ConfigError")
+    end
+
+class \nodoc\ iso _TestParamNameConflictReturnsError is UnitTest
+  """Conflicting param names at the same position produce a ConfigError."""
+  fun name(): String => "router/param name conflict returns error"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/users/:userId", _NoOpFactory, None)
+    builder.add(stallion.POST, "/users/:id", _NoOpFactory, None)
+    match builder.first_error()
+    | let err: ConfigError =>
+      h.assert_true(err.message.contains("Conflicting param names"))
+      h.assert_true(err.message.contains("userId"))
+      h.assert_true(err.message.contains("id"))
+    else
+      h.fail("conflicting param names should produce ConfigError")
+    end
+
+class \nodoc\ iso _TestInterceptorSegmentBoundary is UnitTest
+  """
+  Group interceptors at /api must NOT leak to /api-docs.
+
+  A radix tree node for /api has children at '/' (sub-paths like /api/users)
+  and '-' (sibling routes like /api-docs). Only sub-path children should
+  inherit the group's interceptors.
+  """
+  fun name(): String => "router/interceptor segment boundary"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, None)
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    builder.add(stallion.GET, "/api-docs", _NoOpFactory, None)
+    let router = builder.build()
+
+    // /api/users is under the /api group — should get interceptors
+    match router.lookup(stallion.GET, "/api/users")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size(),
+          "/api/users should have group interceptors")
+      else
+        h.fail("/api/users should have interceptors")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for /api/users")
+    end
+
+    // /api-docs is NOT under the /api group — must NOT get interceptors
+    match router.lookup(stallion.GET, "/api-docs")
+    | let m: _RouteMatch =>
+      h.assert_true(m.interceptors is None,
+        "/api-docs must not inherit /api group interceptors")
+    | let _: _RouteMiss =>
+      h.fail("expected match for /api-docs")
+    end
+
+class \nodoc\ iso _TestInterceptorSegmentBoundaryMiss is UnitTest
+  """
+  A 404 miss at a sibling path (/api-unknown) must NOT carry group
+  interceptors from /api.
+  """
+  fun name(): String => "router/interceptor segment boundary miss"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, None)
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    builder.add(stallion.GET, "/api-docs", _NoOpFactory, None)
+    let router = builder.build()
+
+    // Miss under /api/ — SHOULD carry /api's interceptors
+    match router.lookup(stallion.GET, "/api/nonexistent")
+    | let miss: _RouteMiss =>
+      match miss.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size(),
+          "/api/nonexistent should carry group interceptors")
+      else
+        h.fail("/api/nonexistent miss should have interceptors")
+      end
+    | let _: _RouteMatch =>
+      h.fail("expected miss for /api/nonexistent")
+    end
+
+    // Miss at /api-unknown — must NOT carry /api's interceptors
+    match router.lookup(stallion.GET, "/api-unknown")
+    | let miss: _RouteMiss =>
+      h.assert_true(miss.interceptors is None,
+        "/api-unknown miss must not inherit /api group interceptors")
+    | let _: _RouteMatch =>
+      h.fail("expected miss for /api-unknown")
+    end
+
+class \nodoc\ iso _TestInterceptorSegmentBoundaryNestedGroups is UnitTest
+  """
+  App-level interceptors propagate everywhere. Group interceptors at /api
+  propagate to /api/admin/users but not to /api-docs.
+  """
+  fun name(): String => "router/interceptor segment boundary nested groups"
+
+  fun apply(h: TestHelper) =>
+    let app_interceptor: RequestInterceptor val = _PassInterceptor
+    let app_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: app_interceptor] end
+    let api_interceptor: RequestInterceptor val = _RejectInterceptor
+    let api_interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: api_interceptor] end
+
+    let builder = _RouterBuilder
+    builder.add_interceptors("", app_interceptors, None)
+    builder.add_interceptors("/api", api_interceptors, None)
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    builder.add(stallion.GET, "/api-docs", _NoOpFactory, None)
+    let router = builder.build()
+
+    // /api/users gets app + api interceptors (2 total)
+    match router.lookup(stallion.GET, "/api/users")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](2, ints.size(),
+          "/api/users should have app + api interceptors")
+      else
+        h.fail("/api/users should have interceptors")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for /api/users")
+    end
+
+    // /api-docs gets ONLY app interceptors (1 total, not 2)
+    match router.lookup(stallion.GET, "/api-docs")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size(),
+          "/api-docs should have only app interceptors")
+        try
+          h.assert_true(ints(0)? is app_interceptor,
+            "/api-docs should have app interceptor, not api interceptor")
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("/api-docs should have app interceptors")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for /api-docs")
+    end
+
+class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
+  """
+  When static and param children both miss, the miss with richer interceptors
+  wins.
+
+  Group [A] on /api, group [B] on /api/users/new. Routes: GET
+  /api/users/new/settings and GET /api/users/:id. Lookup for GET
+  /api/users/new/nonexistent — static child reaches depth with [A, B] but
+  misses, param child :id misses with only [A]. The 404 must carry [A, B].
+  """
+  fun name(): String => "router/deepest miss preserves richer interceptors"
+
+  fun apply(h: TestHelper) =>
+    let int_a: RequestInterceptor val = _PassInterceptor
+    let ints_a: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: int_a] end
+    let int_b: RequestInterceptor val = _RejectInterceptor
+    let ints_b: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: int_b] end
+
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", ints_a, None)
+    builder.add_interceptors("/api/users/new", ints_b, None)
+    builder.add(stallion.GET, "/api/users/new/settings", _NoOpFactory, None)
+    builder.add(stallion.GET, "/api/users/:id", _NoOpFactory, None)
+    let router = builder.build()
+
+    // /api/users/new/nonexistent: static child "new" reaches depth with
+    // [A, B] but misses. Param :id misses with [A]. Must keep [A, B].
+    match router.lookup(stallion.GET, "/api/users/new/nonexistent")
+    | let miss: _RouteMiss =>
+      match miss.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](2, ints.size(),
+          "miss should carry [A, B] from deeper static traversal, not [A]")
+      else
+        h.fail("expected interceptors on miss")
+      end
+    | let _: _RouteMatch =>
+      h.fail("expected miss for /api/users/new/nonexistent")
+    end
+
+class \nodoc\ iso _TestSharedParamNameConsistent is UnitTest
+  """
+  Multiple methods at the same param position with the same name works.
+
+  GET /users/:id and POST /users/:id share a param child — the name must
+  match. Mismatched names (e.g., :userId vs :id) would panic at startup.
+  """
+  fun name(): String => "router/shared param name consistent"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/users/:id", _NoOpFactory, None)
+    builder.add(stallion.POST, "/users/:id", _NoOpFactory, None)
+    let router = builder.build()
+
+    match router.lookup(stallion.GET, "/users/42")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("42", m.params("id")?)
+      else
+        h.fail("param 'id' not found on GET")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for GET /users/42")
+    end
+
+    match router.lookup(stallion.POST, "/users/42")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("42", m.params("id")?)
+      else
+        h.fail("param 'id' not found on POST")
+      end
+    | let _: _RouteMiss =>
+      h.fail("expected match for POST /users/42")
+    end
+
+class \nodoc\ iso _TestEmptyParamSegmentSkipped is UnitTest
+  """Empty param segment (/users//details) does not match the param child."""
+  fun name(): String => "router/empty param segment skipped"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/users/:id/details", _NoOpFactory, None)
+    let router = builder.build()
+
+    // Normal param — matches
+    match router.lookup(stallion.GET, "/users/42/details")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("42", m.params("id")?)
+      else
+        h.fail("param 'id' not found")
+      end
+    else
+      h.fail("expected match for /users/42/details")
+    end
+
+    // Empty segment — param child requires value_end > offset
+    match router.lookup(stallion.GET, "/users//details")
+    | let _: _RouteMatch =>
+      h.fail("empty param segment should not match")
+    | let _: _RouteMiss => None
+    | let _: _MethodNotAllowed => None
+    end
+
+class \nodoc\ iso _TestMethodNotAllowed is UnitTest
+  """Path exists but method doesn't → _MethodNotAllowed, not _RouteMiss."""
+  fun name(): String => "router/method not allowed"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.POST, "/api/users", _NoOpFactory, None)
+    let router = builder.build()
+
+    // GET to a POST-only path → 405
+    match router.lookup(stallion.GET, "/api/users")
+    | let na: _MethodNotAllowed => None
+    | let _: _RouteMatch =>
+      h.fail("should not match GET on POST-only route")
+    | let _: _RouteMiss =>
+      h.fail("should be 405, not 404 — path exists")
+    end
+
+    // Nonexistent path → 404
+    match router.lookup(stallion.GET, "/api/nonexistent")
+    | let _: _RouteMiss => None
+    | let _: _RouteMatch =>
+      h.fail("should not match nonexistent path")
+    | let _: _MethodNotAllowed =>
+      h.fail("should be 404, not 405 — path doesn't exist")
+    end
+
+class \nodoc\ iso _TestMethodNotAllowedAllowHeader is UnitTest
+  """_MethodNotAllowed carries the correct allowed methods list."""
+  fun name(): String => "router/method not allowed allow header"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    builder.add(stallion.POST, "/api/users", _NoOpFactory, None)
+    let router = builder.build()
+
+    // DELETE to a GET+POST path → 405 with Allow: GET, POST, HEAD
+    match router.lookup(stallion.DELETE, "/api/users")
+    | let na: _MethodNotAllowed =>
+      // Should have GET, POST, and HEAD (implicit from GET)
+      h.assert_eq[USize](3, na.allowed_methods.size())
+      var has_get = false
+      var has_post = false
+      var has_head = false
+      for m in na.allowed_methods.values() do
+        if m == "GET" then has_get = true end
+        if m == "POST" then has_post = true end
+        if m == "HEAD" then has_head = true end
+      end
+      h.assert_true(has_get, "Allow should include GET")
+      h.assert_true(has_post, "Allow should include POST")
+      h.assert_true(has_head, "Allow should include HEAD (implicit from GET)")
+    | let _: _RouteMatch =>
+      h.fail("should not match DELETE on GET+POST route")
+    | let _: _RouteMiss =>
+      h.fail("should be 405, not 404")
+    end
+
+class \nodoc\ iso _TestWildcardMethodIsolation is UnitTest
+  """Wildcard routes are method-isolated — POST wildcard doesn't match GET."""
+  fun name(): String => "router/wildcard method isolation"
+
+  fun apply(h: TestHelper) =>
+    let post_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "post")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.POST, "/files/*path", post_factory, None)
+    let router = builder.build()
+
+    // POST matches
+    match router.lookup(stallion.POST, "/files/readme.txt")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](post_factory, m.factory)
+      try
+        h.assert_eq[String]("readme.txt", m.params("path")?)
+      else
+        h.fail("wildcard param 'path' not found")
+      end
+    else
+      h.fail("expected POST match for /files/readme.txt")
+    end
+
+    // GET does not match — wildcard entries are method-keyed → 405
+    match router.lookup(stallion.GET, "/files/readme.txt")
+    | let na: _MethodNotAllowed =>
+      var has_post = false
+      for m in na.allowed_methods.values() do
+        if m == "POST" then has_post = true end
+      end
+      h.assert_true(has_post, "Allow should include POST")
+    | let _: _RouteMatch =>
+      h.fail("GET should not match POST-only wildcard")
+    | let _: _RouteMiss =>
+      h.fail("should be 405, not 404 — wildcard path exists for POST")
+    end
+
+class \nodoc\ iso _TestWildcardHeadFallback is UnitTest
+  """HEAD falls back to GET for wildcard routes."""
+  fun name(): String => "router/wildcard HEAD fallback"
+
+  fun apply(h: TestHelper) =>
+    let get_factory: HandlerFactory = {(ctx) =>
+      RequestHandler(consume ctx).respond(stallion.StatusOK, "get")
+    } val
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files/*path", get_factory, None)
+    let router = builder.build()
+
+    // HEAD falls back to GET wildcard
+    match router.lookup(stallion.HEAD, "/files/readme.txt")
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](get_factory, m.factory)
+      try
+        h.assert_eq[String]("readme.txt", m.params("path")?)
+      else
+        h.fail("wildcard param 'path' not found")
+      end
+    else
+      h.fail("HEAD should fall back to GET wildcard")
+    end
+
+class \nodoc\ iso _TestRoutesBeforeInterceptors is UnitTest
+  """
+  Routes registered before interceptors still get the interceptors.
+
+  `add_interceptors` may be called after `add` — the tree traversal in
+  `_ensure_path` must work on a tree that already has route nodes.
+  """
+  fun name(): String => "router/routes before interceptors"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let builder = _RouterBuilder
+    // Routes first
+    builder.add(stallion.GET, "/api/users", _NoOpFactory, None)
+    builder.add(stallion.GET, "/api/items", _NoOpFactory, None)
+    // Interceptors after
+    builder.add_interceptors("/api", interceptors, None)
+    let router = builder.build()
+
+    // Both routes should have the interceptor
+    match router.lookup(stallion.GET, "/api/users")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor)
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("/api/users should have interceptors")
+      end
+    else
+      h.fail("expected match for /api/users")
+    end
+
+    match router.lookup(stallion.GET, "/api/items")
+    | let m: _RouteMatch =>
+      match m.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor)
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("/api/items should have interceptors")
+      end
+    else
+      h.fail("expected match for /api/items")
+    end
+
+    // Miss under /api should also carry interceptors
+    match router.lookup(stallion.GET, "/api/nonexistent")
+    | let miss: _RouteMiss =>
+      match miss.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor)
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("miss should carry interceptors")
+      end
+    else
+      h.fail("expected miss for /api/nonexistent")
+    end
+
+class \nodoc\ iso _TestMethodNotAllowedCarriesInterceptors is UnitTest
+  """405 responses carry accumulated interceptors from the matched path."""
+  fun name(): String => "router/method not allowed carries interceptors"
+
+  fun apply(h: TestHelper) =>
+    let interceptor: RequestInterceptor val = _PassInterceptor
+    let interceptors: Array[RequestInterceptor val] val =
+      recover val [as RequestInterceptor val: interceptor] end
+    let resp_interceptor: ResponseInterceptor val = _NoOpResponseInterceptor
+    let resp_interceptors: Array[ResponseInterceptor val] val =
+      recover val [as ResponseInterceptor val: resp_interceptor] end
+
+    let builder = _RouterBuilder
+    builder.add_interceptors("/api", interceptors, resp_interceptors)
+    builder.add(stallion.POST, "/api/users", _NoOpFactory, None)
+    let router = builder.build()
+
+    // GET to POST-only path → 405 with /api's interceptors
+    match router.lookup(stallion.GET, "/api/users")
+    | let na: _MethodNotAllowed =>
+      match na.interceptors
+      | let ints: Array[RequestInterceptor val] val =>
+        h.assert_eq[USize](1, ints.size())
+        try
+          h.assert_true(ints(0)? is interceptor,
+            "405 should carry request interceptor from /api")
+        else
+          h.fail("interceptor access failed")
+        end
+      else
+        h.fail("405 should have request interceptors")
+      end
+      match na.response_interceptors
+      | let ris: Array[ResponseInterceptor val] val =>
+        h.assert_eq[USize](1, ris.size())
+        try
+          h.assert_true(ris(0)? is resp_interceptor,
+            "405 should carry response interceptor from /api")
+        else
+          h.fail("response interceptor access failed")
+        end
+      else
+        h.fail("405 should have response interceptors")
+      end
+    | let _: _RouteMatch =>
+      h.fail("should not match GET on POST-only route")
+    | let _: _RouteMiss =>
+      h.fail("should be 405, not 404")
+    end

--- a/hobby/application.pony
+++ b/hobby/application.pony
@@ -16,37 +16,43 @@ class iso Application
   actor Main
     new create(env: Env) =>
       let auth = lori.TCPListenAuth(env.root)
-      hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Hello!")
-        } val)
-        .>get("/greet/:name", {(ctx) =>
-          let handler = hobby.RequestHandler(consume ctx)
-          try
-            handler.respond(stallion.StatusOK,
-              "Hello, " + handler.param("name")? + "!")
-          else
-            handler.respond(stallion.StatusBadRequest, "Bad Request")
-          end
-        } val)
-        .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+      match
+        hobby.Application
+          .>get("/", {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Hello!")
+          } val)
+          .>get("/greet/:name", {(ctx) =>
+            let handler = hobby.RequestHandler(consume ctx)
+            try
+              handler.respond(stallion.StatusOK,
+                "Hello, " + handler.param("name")? + "!")
+            else
+              handler.respond(stallion.StatusBadRequest, "Bad Request")
+            end
+          } val)
+          .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+      | let err: hobby.ConfigError =>
+        env.err.print(err.message)
+      end
   ```
 
   Route methods are `fun ref` — automatic receiver recovery allows calling
   them on an `iso` receiver since all arguments are `val`. Use `.>` to chain
   route calls (it discards the method's return and passes the receiver
-  through). Call `.serve()` last — it consumes the Application and freezes
+  through). Call `.serve()` last — it consumes the Application and returns
   the routes.
   """
   embed _routes: Array[_RouteDefinition]
   embed _app_interceptors: Array[RequestInterceptor val]
   embed _app_response_interceptors: Array[ResponseInterceptor val]
+  embed _group_infos: Array[_GroupInfo]
 
   new iso create() =>
     _routes = Array[_RouteDefinition]
     _app_interceptors = Array[RequestInterceptor val]
     _app_response_interceptors = Array[ResponseInterceptor val]
+    _group_infos = Array[_GroupInfo]
 
   fun ref get(path: String, factory: HandlerFactory,
     interceptors: (Array[RequestInterceptor val] val | None) = None,
@@ -125,10 +131,12 @@ class iso Application
     """
     Add an application-level request interceptor.
 
-    Request interceptors run before the handler on every route. Application
+    Request interceptors run before the handler on every request. Application
     interceptors run before group interceptors, which run before per-route
     interceptors. The first interceptor that returns `InterceptRespond` rejects
     the request — the handler is never created.
+
+    App-level interceptors also run on 404 responses where no route matched.
     """
     _app_interceptors.push(interceptor)
 
@@ -150,22 +158,27 @@ class iso Application
     """
     Consume a route group, flattening its routes into this application.
 
-    The group's prefix, interceptors, and response interceptors are applied to
-    each of its routes. The group is consumed — no further registration on it
-    is possible.
+    The group's prefix is applied to each of its routes. Group-level
+    interceptors are preserved separately for tree building — they are
+    registered on path nodes, not concatenated onto routes. The group is
+    consumed — no further registration on it is possible.
     """
     let g_ref: RouteGroup ref = consume g
-    g_ref._flatten_into(_routes)
+    g_ref._collect_group_infos(_group_infos)
+    g_ref._flatten_routes_into(_routes)
 
   fun iso serve(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
     out: OutStream,
     handler_timeout: (U64 | None) = 30_000)
+    : ServeResult
   =>
     """
-    Freeze routes and start listening for HTTP connections.
+    Freeze routes, validate configuration, and start listening.
 
     Consumes the Application — no further route registration is possible
-    after this call.
+    after this call. Returns `Serving` on success or `ConfigError` if
+    a configuration error was detected (overlapping group prefixes,
+    invalid group prefix, conflicting param names).
 
     `handler_timeout` is the handler inactivity timeout in milliseconds.
     Defaults to 30 seconds. Pass `None` to disable the timeout. When a
@@ -173,6 +186,11 @@ class iso Application
     Gateway Timeout (or closes the connection for active streams).
     """
     let self: Application ref = consume this
+
+    // Validate group configuration before building
+    match _ValidateGroups(self._group_infos)
+    | let err: ConfigError => return err
+    end
 
     // Build app-level request interceptors as a val array (or None if empty)
     let app_interceptors: (Array[RequestInterceptor val] val | None) =
@@ -202,14 +220,25 @@ class iso Application
       end
 
     let builder = _RouterBuilder
+
+    // Register app-level interceptors on the root node
+    builder.add_interceptors("", app_interceptors, app_response_interceptors)
+
+    // Register group-level interceptors on their prefix nodes
+    for gi in self._group_infos.values() do
+      builder.add_interceptors(gi.prefix, gi.interceptors,
+        gi.response_interceptors)
+    end
+
+    // Register routes with per-route interceptors only
     for r in self._routes.values() do
-      let combined_interceptors =
-        _ConcatInterceptors(app_interceptors, r.interceptors)
-      let combined_response_interceptors =
-        _ConcatResponseInterceptors(app_response_interceptors,
-          r.response_interceptors)
-      builder.add(r.method, r.path, r.factory, combined_response_interceptors,
-        combined_interceptors)
+      builder.add(r.method, r.path, r.factory,
+        r.response_interceptors, r.interceptors)
+    end
+
+    // Check for tree-level errors (e.g., conflicting param names)
+    match builder.first_error()
+    | let err: ConfigError => return err
     end
     let router: _Router val = builder.build()
 
@@ -220,5 +249,5 @@ class iso Application
       0
     end
 
-    _Listener(auth, config, router, out, timeout_ns,
-      app_response_interceptors)
+    _Listener(auth, config, router, out, timeout_ns)
+    Serving

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -17,21 +17,25 @@ use lori = "lori"
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    hobby.Application
-      .>get("/", {(ctx) =>
-        hobby.RequestHandler(consume ctx)
-          .respond(stallion.StatusOK, "Hello!")
-      } val)
-      .>get("/greet/:name", {(ctx) =>
-        let handler = hobby.RequestHandler(consume ctx)
-        try
-          handler.respond(stallion.StatusOK,
-            "Hello, " + handler.param("name")? + "!")
-        else
-          handler.respond(stallion.StatusBadRequest, "Bad Request")
-        end
-      } val)
-      .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/", {(ctx) =>
+          hobby.RequestHandler(consume ctx)
+            .respond(stallion.StatusOK, "Hello!")
+        } val)
+        .>get("/greet/:name", {(ctx) =>
+          let handler = hobby.RequestHandler(consume ctx)
+          try
+            handler.respond(stallion.StatusOK,
+              "Hello, " + handler.param("name")? + "!")
+          else
+            handler.respond(stallion.StatusBadRequest, "Bad Request")
+          end
+        } val)
+        .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 ```
 
 ## Handler Factories
@@ -95,7 +99,7 @@ let auth: Array[hobby.RequestInterceptor val] val =
 app.>get("/private", private_factory where interceptors = auth)
 ```
 
-Application-level interceptors run on every route:
+Application-level interceptors run on every request, including 404s:
 
 ```pony
 app.>add_request_interceptor(RequiredHeadersInterceptor(
@@ -199,9 +203,13 @@ actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
     let root = FilePath(FileAuth(env.root), "./public")
-    hobby.Application
-      .>get("/static/*filepath", hobby.ServeFiles(root))
-      .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    match
+      hobby.Application
+        .>get("/static/*filepath", hobby.ServeFiles(root))
+        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+    | let err: hobby.ConfigError =>
+      env.err.print(err.message)
+    end
 ```
 
 Routes must use `*filepath` as the wildcard parameter name. When a request
@@ -211,11 +219,12 @@ resolves to a directory, `ServeFiles` automatically serves `index.html`.
 
 Users import up to four packages:
 
-- **`hobby`**: Application, BodyNotNeeded, ContentTypes, CookieSigningKey,
-  HandlerContext, HandlerFactory, HandlerReceiver, InterceptPass,
-  InterceptRespond, InterceptResult, InvalidSignature, MalformedSignedValue,
-  RequestHandler, RequestInterceptor, ResponseContext, ResponseInterceptor,
-  RouteGroup, ServeFiles, SignedCookie, SignedCookieError, StreamingStarted
+- **`hobby`**: Application, BodyNotNeeded, ConfigError, ContentTypes,
+  CookieSigningKey, HandlerContext, HandlerFactory, HandlerReceiver,
+  InterceptPass, InterceptRespond, InterceptResult, InvalidSignature,
+  MalformedSignedValue, RequestHandler, RequestInterceptor, ResponseContext,
+  ResponseInterceptor, RouteGroup, ServeFiles, ServeResult, Serving,
+  SignedCookie, SignedCookieError, StreamingStarted
 - **`stallion`**: HTTP vocabulary (Status codes, Method, Headers, ServerConfig,
   ChunkedNotSupported)
 - **`lori`**: `TCPListenAuth(env.root)` for network access

--- a/hobby/route_group.pony
+++ b/hobby/route_group.pony
@@ -28,6 +28,7 @@ class iso RouteGroup
   let _interceptors: (Array[RequestInterceptor val] val | None)
   let _response_interceptors: (Array[ResponseInterceptor val] val | None)
   embed _routes: Array[_RouteDefinition]
+  embed _group_infos: Array[_GroupInfo]
 
   new iso create(prefix: String,
     interceptors: (Array[RequestInterceptor val] val | None) = None,
@@ -36,15 +37,18 @@ class iso RouteGroup
     """
     Create a route group with a path prefix and optional interceptors.
 
-    The prefix is prepended to every route path in the group. Request
-    interceptors, if provided, run before each route's own interceptors.
-    Response interceptors, if provided, run before each route's own response
-    interceptors.
+    The prefix must be a static path segment — no `:param` or `*wildcard`
+    characters. This is validated at `serve()` time and reported as a
+    `ConfigError`. The prefix is prepended to every route path in the group.
+    Request interceptors, if provided, run before each route's own
+    interceptors. Response interceptors, if provided, run before each
+    route's own response interceptors.
     """
     _prefix = prefix
     _interceptors = interceptors
     _response_interceptors = response_interceptors
     _routes = Array[_RouteDefinition]
+    _group_infos = Array[_GroupInfo]
 
   fun ref get(path: String, factory: HandlerFactory,
     interceptors: (Array[RequestInterceptor val] val | None) = None,
@@ -124,20 +128,48 @@ class iso RouteGroup
     Consume a nested route group, flattening its routes into this group.
 
     The inner group's prefix is appended to this group's prefix, and the inner
-    group's interceptors are appended after this group's interceptors. The inner
+    group's interceptors are preserved separately for tree building. The inner
     group is consumed — no further registration on it is possible.
     """
     let inner_ref: RouteGroup ref = consume inner
-    inner_ref._flatten_into(_routes)
+    inner_ref._collect_group_infos(_group_infos, _prefix)
+    inner_ref._flatten_routes_into(_routes, _prefix)
 
-  fun box _flatten_into(target: Array[_RouteDefinition] ref) =>
+  fun box _flatten_routes_into(target: Array[_RouteDefinition] ref,
+    outer_prefix: String = "")
+  =>
+    """
+    Flatten routes into target, joining paths with outer prefix.
+
+    Per-route interceptors are passed through unchanged — no concatenation
+    with group interceptors. Group interceptors are handled separately via
+    `_collect_group_infos()` and registered on tree nodes.
+    """
+    let full_prefix = _JoinPath(outer_prefix, _prefix)
     for r in _routes.values() do
-      let joined_path = _JoinPath(_prefix, r.path)
-      let combined_interceptors =
-        _ConcatInterceptors(_interceptors, r.interceptors)
-      let combined_response_interceptors =
-        _ConcatResponseInterceptors(_response_interceptors,
-          r.response_interceptors)
+      let joined_path = _JoinPath(full_prefix, r.path)
       target.push(_RouteDefinition(r.method, joined_path, r.factory,
-        combined_response_interceptors, combined_interceptors))
+        r.response_interceptors, r.interceptors))
+    end
+
+  fun box _collect_group_infos(target: Array[_GroupInfo] ref,
+    outer_prefix: String = "")
+  =>
+    """
+    Collect this group's info and any nested group infos into target.
+
+    Prefixes are joined through all nesting levels. Only emits a `_GroupInfo`
+    if this group has interceptors.
+    """
+    let full_prefix = _JoinPath(outer_prefix, _prefix)
+    if (_interceptors isnt None) or (_response_interceptors isnt None) then
+      target.push(_GroupInfo(full_prefix, _interceptors,
+        _response_interceptors))
+    end
+    // Re-prefix nested group infos with our outer prefix, since they were
+    // collected relative to this group's prefix, not the full path.
+    for gi in _group_infos.values() do
+      let adjusted_prefix = _JoinPath(outer_prefix, gi.prefix)
+      target.push(_GroupInfo(adjusted_prefix, gi.interceptors,
+        gi.response_interceptors))
     end

--- a/hobby/serve_result.pony
+++ b/hobby/serve_result.pony
@@ -1,0 +1,28 @@
+primitive Serving
+  """
+  Returned by `Application.serve()` when the server started successfully.
+
+  The listener is running and accepting connections.
+  """
+
+class val ConfigError
+  """
+  Returned by `Application.serve()` when a configuration error prevented
+  the server from starting.
+
+  Contains a human-readable description of the error. Common causes:
+  - Overlapping group prefixes (two groups with the same prefix)
+  - Empty group prefix (use `add_request_interceptor()` instead)
+  - Special characters in group prefix (`:` or `*`)
+  - Conflicting param names at the same path position across methods
+  """
+  let message: String
+
+  new val create(message': String) =>
+    message = message'
+
+type ServeResult is (Serving | ConfigError)
+  """
+  The result of `Application.serve()`: either the server started
+  (`Serving`) or a configuration error was detected (`ConfigError`).
+  """


### PR DESCRIPTION
Replace the per-method tree router with a single shared path tree where interceptors are path-scoped and handlers are method-keyed at leaf nodes.

Previously, interceptors only ran on requests that matched a route. Group interceptors didn't run on 404s because the per-method tree had no path context for failed lookups — only app-level response interceptors ran on 404s, passed through a side channel on `_Listener`.

Now the router uses a single tree. Interceptors accumulate from root to leaf during traversal. On a 404, the deepest reached node's accumulated interceptors run. An auth interceptor on `/api` rejects unauthenticated requests to `/api/nonexistent` with 401 instead of leaking API structure with 404. A CORS response interceptor on `/api` adds headers to error responses under `/api`.

The router distinguishes 404 (path doesn't exist) from 405 (path exists, method not allowed). A 405 response includes an `Allow` header listing supported methods. HEAD is implicitly allowed when GET is registered. Lookup tries all branches in priority order (static > param > wildcard) before declaring failure — a 405 from a higher-priority branch doesn't block a match from a lower-priority branch.

Interceptors are segment-scoped: interceptors on `/api` don't leak to `/api-docs` (a sibling route sharing a character prefix). `_TreeNode` stores both parent-level and accumulated interceptors to enforce this at the radix tree level.

`serve()` now returns `ServeResult` — either `Serving` on success or `ConfigError` with a descriptive message. Configuration errors (overlapping group prefixes, empty/root group prefix, special characters in group prefix, conflicting param names) are detected at `serve()` time and reported as data instead of panicking.

Per-method group interceptors (two groups with the same prefix but different methods) are no longer possible — use per-route interceptors instead. Registering two groups with the same prefix produces a `ConfigError`.

HEAD→GET fallback now happens inside the router in a single traversal instead of a second `_Connection` lookup.

Design: #58