### PR TITLE
Replace radix tree with segment-level trie

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Users interact with these types:
 - **`_HandlerTimeoutNotify`** (`class iso is TimerNotify`): Sends `_handler_timeout(token)` to `_Connection` on each interval fire.
 - **`_Router`** (`class val`): Immutable single shared path tree router. Handlers are keyed by HTTP method at leaf nodes. Interceptors are path-scoped on shared nodes.
 - **`_RouterBuilder`** (`class ref`): Mutable builder. `add()` registers routes, `add_interceptors()` tags path nodes with group/app interceptors. `build()` freezes into `_Router`.
-- **`_BuildNode`** / **`_TreeNode`** (`class ref` / `class val`): Mutable build-time and immutable lookup-time radix tree nodes. Each node carries path-level interceptors and method-keyed handler entries.
+- **`_BuildNode`** / **`_TreeNode`** (`class ref` / `class val`): Mutable build-time and immutable lookup-time segment trie nodes. Each node represents one path segment. Children are keyed by full segment name (`Map[String, ...]`). Each node carries path-level interceptors and method-keyed handler entries.
 - **`_MethodEntry`** (`class val`): Handler factory + final pre-computed interceptor arrays for a specific HTTP method at a path node.
 - **`_BuildMethodEntry`** (`class ref`): Mutable method entry during construction, before freeze-time interceptor concatenation.
 - **`_RouteMatch`** (`class val`): Successful lookup result — factory, interceptors, params.
@@ -89,17 +89,19 @@ Users interact with these types:
 - **Factory returns `(HandlerReceiver tag | None)`**: Inline handlers return None; async handlers return the actor's tag for dispose/throttle signals. No timing gap for lifecycle signals.
 - **Response buffering for response interceptors**: Responses are buffered in `_BufferedResponse` before going to the wire. Response interceptors modify status, headers, and body via `ResponseContext`. Content-Length is computed automatically by `_build()` from the final body after all interceptors run. For streaming, interceptors run but mutations are no-ops (headers/status already on wire).
 - **Route methods are `fun ref`**: Auto receiver recovery handles calling them on the `iso` Application since all arguments are `val`. `serve()` is `fun iso` and uses `consume this`.
-- **Single shared path tree**: One radix tree for all HTTP methods. Handlers are keyed by method at leaf nodes. Interceptors live on shared path nodes and are method-independent. Replaces the old per-method tree map.
+- **Single shared path tree**: One segment trie for all HTTP methods. Handlers are keyed by method at leaf nodes. Interceptors live on shared path nodes and are method-independent.
+- **Eager segment splitting**: `_SplitSegments` splits the normalized path into an `Array[String] val` once, and the trie walks it by index. Skips empty segments, normalizing double slashes.
 - **Build/lookup separation**: Mutable `_BuildNode ref` tree for construction, frozen into immutable `_TreeNode val` tree for lookup. `freeze()` pre-computes accumulated interceptor arrays from root to each node, so lookup is zero-allocation.
 - **Lookup priority: static > param > wildcard**: During lookup, static children are tried first, then the param child, then the wildcard. If a higher-priority branch fails (returns miss or method-not-allowed), lookup falls back to the next branch. A match from any branch is returned immediately. This priority means `/users/new` (static) beats `/users/:id` (param), and `/files/:id` (param) beats `/files/*path` (wildcard).
 - **Trailing slash normalization**: `/users/` and `/users` match the same route.
+- **Double slash normalization**: `_SplitSegments` skips empty segments, so `//` collapses to `/`. Matches the security consensus (nginx, Apache, Go, Rails, Phoenix all normalize).
 - **Group info preservation**: Route groups are flattened into routes when consumed by `group()`, but group metadata (prefix + interceptors) is preserved separately as `_GroupInfo` entries. `Application.serve()` registers group interceptors on tree path nodes via `add_interceptors()`, and registers routes with per-route interceptors only via `add()`.
 - **Overlapping group prefix rejection**: Two groups registering interceptors on the same prefix is a configuration error detected at `serve()` time via `_ValidateGroups`, returned as `ConfigError`.
-- **Segment-boundary scoping**: A node's own interceptors only propagate to children at segment boundaries (child key `'/'`) and param children, not to children sharing a character prefix (e.g., `/api` interceptors don't leak to `/api-docs`). `_TreeNode` stores both parent-level and accumulated interceptors; `_RouteMiss` uses parent interceptors when the remaining path starts with a non-`'/'` character.
+- **Segment-level interceptor scoping**: In a segment trie, every child is at a segment boundary. Interceptors propagate unconditionally from parent to all children. `/api` and `/api-docs` are distinct children of the root — no leakage possible by construction.
 - **Interval-based handler timeout**: Uses a repeating timer that checks a `_last_handler_activity` timestamp rather than cancel+recreate on every chunk. Avoids per-chunk timer allocation overhead during streaming.
 - **Pipelined request buffering**: Requests arriving during `_HandlerInProgress` or `_Streaming` are buffered and drained when the handler completes.
 - **HEAD via split handling**: `RequestHandler.start_streaming()` returns `BodyNotNeeded` for HEAD (local check). `_Connection` uses `is_head` when building buffered responses for the wire (suppresses body, preserves Content-Length).
-- **HEAD→GET fallback**: When no explicit HEAD handler exists at a leaf, `_resolve_method` in `_TreeNode` checks the HEAD key first then falls back to GET — single traversal, no second lookup.
+- **HEAD→GET fallback**: When no explicit HEAD handler exists at a leaf, `_resolve_or_405` in `_TreeNode` checks the HEAD key first then falls back to GET — single traversal, no second lookup.
 - **Backpressure forwarding**: `_Connection` forwards `on_throttled()`/`on_unthrottled()` to the handler actor when one is registered.
 - **Directory index auto-serving**: When a request resolves to a directory, `ServeFiles` tries `index.html`. Content type is derived from the resolved filesystem path.
 - **Request interceptors run before the handler**: Interceptors execute in `_Connection._dispatch` after route lookup. An interceptor short-circuit sends the response (with response interceptors applied) without creating the handler.
@@ -140,7 +142,7 @@ hobby/
   _handler_timeout.pony       - Handler timeout timer notify (internal)
   _connection.pony             - Connection actor (internal)
   _listener.pony               - Listener actor (internal)
-  _router.pony                 - Router + radix tree (internal)
+  _router.pony                 - Router + segment trie (internal)
   _route_match.pony            - Route match + route miss result types (internal)
   _route_definition.pony       - Route definition for building (internal)
   _method_entry.pony           - Per-method handler entry at tree leaf (internal)
@@ -150,7 +152,7 @@ hobby/
   _serve_files_handler.pony    - ServeFiles handler actor (internal)
   _http_date.pony              - RFC 7231 HTTP-date formatting (internal)
   _etag.pony                   - Weak ETag computation and matching (internal)
-  _flatten.pony                - Path joining, array concatenation, overlap detection, prefix validation (internal)
+  _flatten.pony                - Segment splitting, path joining, array concatenation, overlap detection, prefix validation (internal)
   _mort.pony                   - _Unreachable primitive (internal)
   _test.pony                   - Test runner
   _test_router.pony            - Router property-based + example tests

--- a/hobby/_flatten.pony
+++ b/hobby/_flatten.pony
@@ -1,3 +1,70 @@
+primitive _SplitSegments
+  """
+  Split a normalized path into an array of path segments.
+
+  Strips the leading slash and splits on `/`, skipping empty segments
+  (which normalizes double slashes). `/api/users/:id` → `["api", "users",
+  ":id"]`. `/` → `[]`. `/api//users` → `["api", "users"]`.
+  """
+  fun apply(path: String): Array[String] val =>
+    if path.size() <= 1 then
+      return recover val Array[String] end
+    end
+    recover val
+      let segments = Array[String]
+      var start: USize = 1  // skip leading '/'
+      try
+        while start < path.size() do
+          // Find next '/'
+          var end_pos = start
+          while (end_pos < path.size()) and (path(end_pos)? != '/') do
+            end_pos = end_pos + 1
+          end
+          if end_pos > start then
+            segments.push(path.trim(start, end_pos))
+          end
+          start = end_pos + 1
+        end
+      else
+        _Unreachable()
+      end
+      segments
+    end
+
+primitive _JoinRemainingSegments
+  """
+  Join segments from a start index onward with `/` separators.
+
+  Used to reconstruct the captured value for wildcard parameters.
+  """
+  fun apply(segments: Array[String] val, from: USize,
+    size_hint: USize = 0): String
+  =>
+    if from >= segments.size() then
+      return ""
+    end
+    try
+      if (from + 1) == segments.size() then
+        return segments(from)?
+      end
+    else
+      _Unreachable()
+    end
+    recover val
+      let s = String(size_hint)
+      var i = from
+      try
+        while i < segments.size() do
+          if i > from then s.push('/') end
+          s.append(segments(i)?)
+          i = i + 1
+        end
+      else
+        _Unreachable()
+      end
+      s
+    end
+
 primitive _JoinPath
   """
   Join a group prefix with a route path.

--- a/hobby/_router.pony
+++ b/hobby/_router.pony
@@ -30,8 +30,9 @@ class ref _RouterBuilder
     """
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
-    _root.insert(normalized, method_key, factory, response_interceptors,
-      interceptors, _errors)
+    let segments = _SplitSegments(normalized)
+    _root._insert_segments(segments, 0, method_key, factory,
+      response_interceptors, interceptors, _errors)
 
   fun ref add_interceptors(path: String,
     interceptors: (Array[RequestInterceptor val] val | None),
@@ -54,7 +55,8 @@ class ref _RouterBuilder
       return
     end
     let normalized = _NormalizePath(path)
-    _root._ensure_path(normalized, 0, interceptors, response_interceptors)
+    let segments = _SplitSegments(normalized)
+    _root._ensure_path(segments, 0, interceptors, response_interceptors)
 
   fun ref build(): _Router val =>
     """Freeze the builder into an immutable router."""
@@ -78,7 +80,7 @@ class ref _RouterBuilder
 
 class val _Router
   """
-  Immutable radix tree router with a single shared path tree.
+  Immutable segment trie router with a single shared path tree.
 
   Handlers are keyed by HTTP method at leaf nodes. Interceptors live on
   shared path nodes and are method-independent. `lookup()` finds the matching
@@ -103,7 +105,8 @@ class val _Router
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
     let is_head = method is stallion.HEAD
-    _root.lookup(normalized, method_key, is_head)
+    let segments = _SplitSegments(normalized)
+    _root.lookup(segments, method_key, is_head, normalized.size())
 
 primitive _NormalizePath
   """Strip trailing slash (except root `/`)."""
@@ -121,28 +124,27 @@ primitive _NormalizePath
 
 class ref _BuildNode
   """
-  Mutable radix tree node for route construction.
+  Mutable segment trie node for route construction.
 
   Used by `_RouterBuilder` during route registration, then frozen into a
-  `_TreeNode val` for immutable lookup. Each node carries:
+  `_TreeNode val` for immutable lookup. Each node represents one path
+  segment. Children are keyed by full segment name. Each node carries:
   - Path-level interceptors (from groups or app-level registration)
   - Method-keyed handler entries (from route registration)
-  - Static children and param/wildcard children for tree structure
+  - Static children, param child, and wildcard entries for tree structure
   """
-  var _prefix: String = ""
   var _interceptors: (Array[RequestInterceptor val] val | None) = None
-  var _response_interceptors: (Array[ResponseInterceptor val] val | None) = None
+  var _response_interceptors:
+    (Array[ResponseInterceptor val] val | None) = None
   var _param_name: String = ""
-  embed _children: Map[U8, _BuildNode ref] = Map[U8, _BuildNode ref]
+  embed _children: Map[String, _BuildNode ref] =
+    Map[String, _BuildNode ref]
   var _param_child: (_BuildNode ref | None) = None
   embed _method_entries: Map[String, _BuildMethodEntry ref] =
     Map[String, _BuildMethodEntry ref]
   embed _wildcard_entries: Map[String, _BuildMethodEntry ref] =
     Map[String, _BuildMethodEntry ref]
   var _wildcard_name: String = ""
-
-  new create(prefix: String = "") =>
-    _prefix = prefix
 
   fun ref _set_interceptors(
     interceptors: (Array[RequestInterceptor val] val | None),
@@ -161,182 +163,79 @@ class ref _BuildNode
       _ConcatResponseInterceptors(_response_interceptors,
         response_interceptors)
 
-  fun ref insert(path: String, method: String, factory: HandlerFactory,
+  fun ref _insert_segments(segments: Array[String] val, idx: USize,
+    method: String, factory: HandlerFactory,
     response_interceptors: (Array[ResponseInterceptor val] val | None),
     interceptors: (Array[RequestInterceptor val] val | None),
     errors: Array[String] ref)
   =>
-    """Insert a route path into this subtree."""
-    _insert(path, 0, method, factory, response_interceptors, interceptors,
-      errors)
-
-  fun ref _ensure_path(path: String, offset: USize,
-    interceptors: (Array[RequestInterceptor val] val | None),
-    response_interceptors: (Array[ResponseInterceptor val] val | None))
-  =>
-    """
-    Traverse or create nodes to reach the given path and set interceptors.
-
-    Uses the same prefix-matching logic as insert to handle post-split node
-    structure correctly.
-    """
-    if offset >= path.size() then
-      _set_interceptors(interceptors, response_interceptors)
-      return
-    end
-
-    try
-      let c = path(offset)?
-      // Only handle static paths for group interceptors (no : or * in group prefixes)
-      match try _children(c)? end
-      | let child: _BuildNode ref =>
-        let common = _Paths.common_prefix_len(child._prefix,
-          path.trim(offset))
-        if common == child._prefix.size() then
-          child._ensure_path(path, offset + common, interceptors,
-            response_interceptors)
-        else
-          // Split the child node at the divergence point
-          let new_parent = _BuildNode(child._prefix.trim(0, common))
-          let old_suffix = child._prefix.trim(common)
-          child._prefix = old_suffix
-          try
-            new_parent._children(old_suffix(0)?) = child
-          else
-            _Unreachable()
-          end
-          if (offset + common) >= path.size() then
-            new_parent._set_interceptors(interceptors, response_interceptors)
-          else
-            new_parent._ensure_path(path, offset + common, interceptors,
-              response_interceptors)
-          end
-          _children(c) = new_parent
-        end
-      else
-        // No existing child — create the path
-        let remaining = path.trim(offset)
-        let child = _BuildNode(remaining)
-        child._set_interceptors(interceptors, response_interceptors)
-        _children(c) = child
-      end
-    else
-      _Unreachable()
-    end
-
-  fun ref _insert(path: String, offset: USize, method: String,
-    factory: HandlerFactory,
-    response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None),
-    errors: Array[String] ref)
-  =>
-    if offset >= path.size() then
+    """Insert a route by walking the segment array."""
+    if idx >= segments.size() then
       _method_entries(method) = _BuildMethodEntry(factory,
         interceptors, response_interceptors)
       return
     end
 
-    try
-      let c = path(offset)?
-      if c == ':' then
-        _insert_param(path, offset, method, factory, response_interceptors,
-          interceptors, errors)
-      elseif c == '*' then
-        _wildcard_entries(method) = _BuildMethodEntry(factory,
-          interceptors, response_interceptors)
-        _wildcard_name = path.trim(offset + 1)
+    let segment = try segments(idx)? else _Unreachable(); return end
+    let first = try segment(0)? else _Unreachable(); return end
+
+    if first == ':' then
+      let name = segment.trim(1)
+      let child = match _param_child
+      | let existing: _BuildNode ref => existing
       else
-        _insert_static(path, offset, method, factory, response_interceptors,
-          interceptors, errors)
+        let c: _BuildNode ref = _BuildNode
+        _param_child = c
+        c
       end
+      if (child._param_name.size() > 0) and (child._param_name != name) then
+        errors.push(
+          "Conflicting param names at the same path position: ':" +
+          child._param_name + "' vs ':" + name +
+          "'. All methods at the same path must use the same " +
+          "param name.")
+      end
+      child._param_name = name
+      child._insert_segments(segments, idx + 1, method, factory,
+        response_interceptors, interceptors, errors)
+    elseif first == '*' then
+      _wildcard_entries(method) = _BuildMethodEntry(factory,
+        interceptors, response_interceptors)
+      _wildcard_name = segment.trim(1)
     else
-      _Unreachable()
+      let child = try _children(segment)? else
+        let c: _BuildNode ref = _BuildNode
+        _children(segment) = c
+        c
+      end
+      child._insert_segments(segments, idx + 1, method, factory,
+        response_interceptors, interceptors, errors)
     end
 
-  fun ref _insert_param(path: String, offset: USize, method: String,
-    factory: HandlerFactory,
-    response_interceptors: (Array[ResponseInterceptor val] val | None),
+  fun ref _ensure_path(segments: Array[String] val, idx: USize,
     interceptors: (Array[RequestInterceptor val] val | None),
-    errors: Array[String] ref)
+    response_interceptors: (Array[ResponseInterceptor val] val | None))
   =>
-    let name_end = _Paths.find_char(path, '/', offset + 1)
-    let name = path.trim(offset + 1, name_end)
-    let child = match _param_child
-    | let existing: _BuildNode ref => existing
-    else
-      let c = _BuildNode
-      _param_child = c
+    """
+    Traverse or create nodes to reach the given path and set interceptors.
+    """
+    if idx >= segments.size() then
+      _set_interceptors(interceptors, response_interceptors)
+      return
+    end
+
+    let segment = try segments(idx)? else _Unreachable(); return end
+    let child = try _children(segment)? else
+      let c: _BuildNode ref = _BuildNode
+      _children(segment) = c
       c
     end
-    if (child._param_name.size() > 0) and (child._param_name != name) then
-      errors.push(
-        "Conflicting param names at the same path position: ':" +
-        child._param_name + "' vs ':" + name +
-        "'. All methods at the same path must use the same param name.")
-    end
-    child._param_name = name
-    if name_end >= path.size() then
-      child._method_entries(method) = _BuildMethodEntry(factory,
-        interceptors, response_interceptors)
-    else
-      child._insert(path, name_end, method, factory, response_interceptors,
-        interceptors, errors)
-    end
-
-  fun ref _insert_static(path: String, offset: USize, method: String,
-    factory: HandlerFactory,
-    response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None),
-    errors: Array[String] ref)
-  =>
-    try
-      let c = path(offset)?
-      match try _children(c)? end
-      | let child: _BuildNode ref =>
-        let common = _Paths.common_prefix_len(child._prefix,
-          path.trim(offset))
-        if common == child._prefix.size() then
-          child._insert(path, offset + common, method, factory,
-            response_interceptors, interceptors, errors)
-        else
-          // Split the child node at the divergence point
-          let new_parent = _BuildNode(child._prefix.trim(0, common))
-          let old_suffix = child._prefix.trim(common)
-          child._prefix = old_suffix
-          try
-            new_parent._children(old_suffix(0)?) = child
-          else
-            _Unreachable()
-          end
-          // Route through _insert so special characters (`:`, `*`) in the
-          // remaining suffix are parsed instead of stored as literal prefix.
-          new_parent._insert(path, offset + common, method, factory,
-            response_interceptors, interceptors, errors)
-          _children(c) = new_parent
-        end
-      else
-        // No existing child for this character
-        let remaining = path.trim(offset)
-        let special = _Paths.find_special(remaining)
-        if special < remaining.size() then
-          let child = _BuildNode(remaining.trim(0, special))
-          child._insert(path, offset + special, method, factory,
-            response_interceptors, interceptors, errors)
-          _children(c) = child
-        else
-          let child = _BuildNode(remaining)
-          child._method_entries(method) = _BuildMethodEntry(factory,
-            interceptors, response_interceptors)
-          _children(c) = child
-        end
-      end
-    else
-      _Unreachable()
-    end
+    child._ensure_path(segments, idx + 1, interceptors,
+      response_interceptors)
 
   fun box freeze(
-    parent_interceptors: (Array[RequestInterceptor val] val | None),
-    parent_response_interceptors:
+    accumulated_interceptors: (Array[RequestInterceptor val] val | None),
+    accumulated_response_interceptors:
       (Array[ResponseInterceptor val] val | None))
     : _TreeNode val
   =>
@@ -347,31 +246,26 @@ class ref _BuildNode
     Per-route interceptors in method entries are concatenated with the
     accumulated path interceptors at freeze time, so lookup is zero-allocation.
     """
-    // Accumulate this node's interceptors with parent's
-    let accumulated_interceptors =
-      _ConcatInterceptors(parent_interceptors, _interceptors)
-    let accumulated_response_interceptors =
-      _ConcatResponseInterceptors(parent_response_interceptors,
+    // Accumulate this node's interceptors with ancestors'
+    let new_accumulated =
+      _ConcatInterceptors(accumulated_interceptors, _interceptors)
+    let new_accumulated_response =
+      _ConcatResponseInterceptors(accumulated_response_interceptors,
         _response_interceptors)
 
-    // Freeze children — only propagate this node's interceptors to sub-path
-    // children (key == '/'). Children at other keys share a character prefix
-    // but are in different path segments (e.g., /api-docs is not under /api).
-    let frozen_children: Array[(U8, _TreeNode val)] iso =
-      recover iso Array[(U8, _TreeNode val)] end
+    // Freeze children — all children unconditionally receive this node's
+    // accumulated interceptors (every child is at a segment boundary).
+    let frozen_children: Map[String, _TreeNode val] iso =
+      recover iso Map[String, _TreeNode val] end
     for (key, child) in _children.pairs() do
-      if key == '/' then
-        frozen_children.push((key, child.freeze(accumulated_interceptors,
-          accumulated_response_interceptors)))
-      else
-        frozen_children.push((key, child.freeze(parent_interceptors,
-          parent_response_interceptors)))
-      end
+      frozen_children(key) =
+        child.freeze(new_accumulated, new_accumulated_response)
     end
-    // Param child is always a sub-segment — gets full accumulated
+
+    // Param child gets full accumulated
     let frozen_param: (_TreeNode val | None) = match _param_child
     | let child: _BuildNode box =>
-      child.freeze(accumulated_interceptors, accumulated_response_interceptors)
+      child.freeze(new_accumulated, new_accumulated_response)
     else
       None
     end
@@ -382,9 +276,9 @@ class ref _BuildNode
       recover iso Map[String, _MethodEntry val] end
     for (method, entry) in _method_entries.pairs() do
       let final_interceptors =
-        _ConcatInterceptors(accumulated_interceptors, entry.interceptors)
+        _ConcatInterceptors(new_accumulated, entry.interceptors)
       let final_response_interceptors =
-        _ConcatResponseInterceptors(accumulated_response_interceptors,
+        _ConcatResponseInterceptors(new_accumulated_response,
           entry.response_interceptors)
       frozen_method_entries(method) = _MethodEntry(entry.factory,
         final_interceptors, final_response_interceptors)
@@ -394,17 +288,16 @@ class ref _BuildNode
       recover iso Map[String, _MethodEntry val] end
     for (method, entry) in _wildcard_entries.pairs() do
       let final_interceptors =
-        _ConcatInterceptors(accumulated_interceptors, entry.interceptors)
+        _ConcatInterceptors(new_accumulated, entry.interceptors)
       let final_response_interceptors =
-        _ConcatResponseInterceptors(accumulated_response_interceptors,
+        _ConcatResponseInterceptors(new_accumulated_response,
           entry.response_interceptors)
       frozen_wildcard_entries(method) = _MethodEntry(entry.factory,
         final_interceptors, final_response_interceptors)
     end
 
-    _TreeNode._create(_prefix,
-      parent_interceptors, parent_response_interceptors,
-      accumulated_interceptors, accumulated_response_interceptors,
+    _TreeNode._create(
+      new_accumulated, new_accumulated_response,
       _param_name, consume frozen_children, frozen_param,
       consume frozen_method_entries, consume frozen_wildcard_entries,
       _wildcard_name)
@@ -434,56 +327,40 @@ class ref _BuildMethodEntry
 
 class val _TreeNode
   """
-  Immutable radix tree node for route lookup.
+  Immutable segment trie node for route lookup.
 
-  Produced by freezing a `_BuildNode`. Each node stores two levels of
-  pre-computed interceptors: parent-level (from ancestors only) and
-  accumulated (parent + own). This separation is needed because
-  interceptors are segment-scoped — a node's own interceptors only apply
-  to sub-paths (children at '/'), not to sibling routes that share a
-  character prefix (children at other keys like '-').
+  Produced by freezing a `_BuildNode`. Each node stores pre-computed
+  accumulated interceptors (from root through this node). In a segment
+  trie, every child is at a segment boundary, so the accumulated
+  interceptors propagate unconditionally to all children.
 
   Method entries store final interceptor arrays (accumulated + per-route,
   concatenated at freeze time). Lookup is zero-allocation for both hits
   and misses.
   """
-  let _prefix: String
-  // Interceptors from ancestor nodes only — for misses on sibling paths
-  let _parent_interceptors:
-    (Array[RequestInterceptor val] val | None)
-  let _parent_response_interceptors:
-    (Array[ResponseInterceptor val] val | None)
-  // Interceptors accumulated through this node — for sub-path matches/misses
   let _accumulated_interceptors:
     (Array[RequestInterceptor val] val | None)
   let _accumulated_response_interceptors:
     (Array[ResponseInterceptor val] val | None)
   let _param_name: String
-  let _children: Array[(U8, _TreeNode val)] val
+  let _children: Map[String, _TreeNode val] val
   let _param_child: (_TreeNode val | None)
   let _method_entries: Map[String, _MethodEntry val] val
   let _wildcard_entries: Map[String, _MethodEntry val] val
   let _wildcard_name: String
 
-  new val _create(prefix: String,
-    parent_interceptors':
-      (Array[RequestInterceptor val] val | None),
-    parent_response_interceptors':
-      (Array[ResponseInterceptor val] val | None),
+  new val _create(
     accumulated_interceptors':
       (Array[RequestInterceptor val] val | None),
     accumulated_response_interceptors':
       (Array[ResponseInterceptor val] val | None),
     param_name: String,
-    children: Array[(U8, _TreeNode val)] iso,
+    children: Map[String, _TreeNode val] iso,
     param_child: (_TreeNode val | None),
     method_entries: Map[String, _MethodEntry val] iso,
     wildcard_entries: Map[String, _MethodEntry val] iso,
     wildcard_name: String)
   =>
-    _prefix = prefix
-    _parent_interceptors = parent_interceptors'
-    _parent_response_interceptors = parent_response_interceptors'
     _accumulated_interceptors = accumulated_interceptors'
     _accumulated_response_interceptors = accumulated_response_interceptors'
     _param_name = param_name
@@ -493,11 +370,12 @@ class val _TreeNode
     _wildcard_entries = consume wildcard_entries
     _wildcard_name = wildcard_name
 
-  fun lookup(path: String, method_key: String, is_head: Bool):
+  fun lookup(segments: Array[String] val, method_key: String,
+    is_head: Bool, path_size: USize):
     (_RouteMatch | _RouteMiss | _MethodNotAllowed)
   =>
     """Find a matching route for the given path and method."""
-    match _lookup(path, 0, method_key, is_head)
+    match _lookup(segments, 0, method_key, is_head, path_size)
     | (let entry: _MethodEntry val, let p: Array[(String, String)] val) =>
       let frozen: Map[String, String] val = recover val
         let m = Map[String, String]
@@ -512,8 +390,8 @@ class val _TreeNode
     | let na: _MethodNotAllowed => na
     end
 
-  fun _lookup(path: String, offset: USize, method_key: String,
-    is_head: Bool):
+  fun _lookup(segments: Array[String] val, idx: USize,
+    method_key: String, is_head: Bool, path_size: USize):
     ((_MethodEntry val, Array[(String, String)] val) |
       _RouteMiss | _MethodNotAllowed)
   =>
@@ -525,7 +403,7 @@ class val _TreeNode
     Params are built bottom-up: the leaf returns an empty val array, and each
     param level prepends its parameter to the child's val result.
     """
-    if offset >= path.size() then
+    if idx >= segments.size() then
       match _resolve_or_405(method_key, is_head, _method_entries)
       | let entry: _MethodEntry val =>
         return (entry, _EmptyParams())
@@ -545,25 +423,20 @@ class val _TreeNode
 
     // Try static children first (highest priority)
     try
-      let c = path(offset)?
-      for (key, child) in _children.values() do
-        if key == c then
-          if _Paths.starts_with(path, offset, child._prefix) then
-            match child._lookup(path, offset + child._prefix.size(),
-              method_key, is_head)
-            | (let entry: _MethodEntry val,
-               let p: Array[(String, String)] val) =>
-              return (entry, p)
-            | let na: _MethodNotAllowed =>
-              // Save but continue — a lower-priority branch may match
-              if method_not_allowed is None then
-                method_not_allowed = na
-              end
-            | let miss: _RouteMiss =>
-              deepest_miss = miss
-            end
+      let segment = segments(idx)?
+      try
+        let child = _children(segment)?
+        match child._lookup(segments, idx + 1, method_key, is_head,
+          path_size)
+        | (let entry: _MethodEntry val,
+           let p: Array[(String, String)] val) =>
+          return (entry, p)
+        | let na: _MethodNotAllowed =>
+          if method_not_allowed is None then
+            method_not_allowed = na
           end
-          break
+        | let miss: _RouteMiss =>
+          deepest_miss = miss
         end
       end
     else
@@ -573,43 +446,48 @@ class val _TreeNode
     // Try parameter child (second priority)
     match _param_child
     | let child: _TreeNode val =>
-      let value_end = _Paths.find_char(path, '/', offset)
-      if value_end > offset then
-        let value = path.trim(offset, value_end)
-        match child._lookup(path, value_end, method_key, is_head)
-        | (let entry: _MethodEntry val,
-           let child_params: Array[(String, String)] val) =>
-          let with_param: Array[(String, String)] val = recover val
-            let a = Array[(String, String)]
-            a.push((child._param_name, value))
-            for (k, v) in child_params.values() do
-              a.push((k, v))
+      try
+        let segment = segments(idx)?
+        // _SplitSegments never produces empty segments, but guard defensively
+        if segment.size() > 0 then
+          match child._lookup(segments, idx + 1, method_key, is_head,
+            path_size)
+          | (let entry: _MethodEntry val,
+             let child_params: Array[(String, String)] val) =>
+            let with_param: Array[(String, String)] val = recover val
+              let a = Array[(String, String)]
+              a.push((child._param_name, segment))
+              for (k, v) in child_params.values() do
+                a.push((k, v))
+              end
+              a
             end
-            a
-          end
-          return (entry, with_param)
-        | let na: _MethodNotAllowed =>
-          if method_not_allowed is None then
-            method_not_allowed = na
-          end
-        | let miss: _RouteMiss =>
-          // Keep whichever miss traversed deeper (has richer interceptors).
-          match deepest_miss
-          | let prev: _RouteMiss =>
-            if miss._interceptor_count() > prev._interceptor_count() then
+            return (entry, with_param)
+          | let na: _MethodNotAllowed =>
+            if method_not_allowed is None then
+              method_not_allowed = na
+            end
+          | let miss: _RouteMiss =>
+            // Keep whichever miss traversed deeper (has richer interceptors).
+            match deepest_miss
+            | let prev: _RouteMiss =>
+              if miss._interceptor_count() > prev._interceptor_count() then
+                deepest_miss = miss
+              end
+            else
               deepest_miss = miss
             end
-          else
-            deepest_miss = miss
           end
         end
+      else
+        _Unreachable()
       end
     end
 
     // Try wildcard (lowest priority)
     match _resolve_or_405(method_key, is_head, _wildcard_entries)
     | let entry: _MethodEntry val =>
-      let remainder = path.trim(offset)
+      let remainder = _JoinRemainingSegments(segments, idx, path_size)
       let wildcard_params: Array[(String, String)] val = recover val
         let a = Array[(String, String)]
         a.push((_wildcard_name, remainder))
@@ -629,21 +507,11 @@ class val _TreeNode
     | let na: _MethodNotAllowed => return na
     end
 
-    // Interceptor selection for the miss depends on whether the remaining
-    // path is a sub-path (starts with '/') or a sibling route sharing a
-    // character prefix (starts with non-'/'). Sub-paths get accumulated
-    // interceptors; siblings get parent-only interceptors.
     match deepest_miss
     | let miss: _RouteMiss => miss
     else
-      let at_segment_boundary = try path(offset)? == '/' else true end
-      if at_segment_boundary then
-        _RouteMiss(_accumulated_response_interceptors,
-          _accumulated_interceptors)
-      else
-        _RouteMiss(_parent_response_interceptors,
-          _parent_interceptors)
-      end
+      _RouteMiss(_accumulated_response_interceptors,
+        _accumulated_interceptors)
     end
 
   fun _resolve_or_405(method_key: String, is_head: Bool,
@@ -693,67 +561,6 @@ class val _TreeNode
 // --- Shared constants ---
 
 primitive _EmptyParams
-  """Empty params array for leaf returns — avoids allocation at each recursion level."""
+  """Empty params array returned at leaf nodes. Intermediate recursion levels don't allocate params — only the leaf does."""
   fun apply(): Array[(String, String)] val =>
     recover val Array[(String, String)] end
-
-// --- Path utilities ---
-
-primitive _Paths
-  fun find_char(s: String box, c: U8, from: USize = 0): USize =>
-    """Find the first occurrence of `c` in `s` starting at `from`."""
-    var i = from
-    try
-      while i < s.size() do
-        if s(i)? == c then return i end
-        i = i + 1
-      end
-    else
-      _Unreachable()
-    end
-    s.size()
-
-  fun find_special(s: String box): USize =>
-    """Find the first `:` or `*` in `s`."""
-    var i: USize = 0
-    try
-      while i < s.size() do
-        let c = s(i)?
-        if (c == ':') or (c == '*') then return i end
-        i = i + 1
-      end
-    else
-      _Unreachable()
-    end
-    s.size()
-
-  fun common_prefix_len(a: String box, b: String box): USize =>
-    var i: USize = 0
-    let limit = a.size().min(b.size())
-    try
-      while i < limit do
-        if a(i)? != b(i)? then break end
-        i = i + 1
-      end
-    else
-      _Unreachable()
-    end
-    i
-
-  fun starts_with(path: String box, offset: USize,
-    prefix: String box): Bool
-  =>
-    """Check if `path` at `offset` starts with `prefix`."""
-    if (offset + prefix.size()) > path.size() then
-      return false
-    end
-    var i: USize = 0
-    try
-      while i < prefix.size() do
-        if path(offset + i)? != prefix(i)? then return false end
-        i = i + 1
-      end
-    else
-      _Unreachable()
-    end
-    true

--- a/hobby/_test_router.pony
+++ b/hobby/_test_router.pony
@@ -18,14 +18,6 @@ primitive \nodoc\ _TestRouterList
     test(_TestOverlappingPrefixes)
     test(_TestWildcardSingleSegment)
     test(_TestTrailingSlashNormalization)
-    test(_TestSplitThenParam)
-    test(_TestSplitThenWildcard)
-    test(_TestSplitThenMultipleParams)
-    test(_TestSplitParamThenStatic)
-    test(_TestSplitAtSegmentBoundary)
-    test(_TestSplitMidSegmentParam)
-    test(_TestDeepNestedParamSharedPrefix)
-    test(_TestStaticPrefixFallsBackToParam)
     test(Property1UnitTest[
       (Array[USize] val, Array[USize] val)](
       _PropertyInsertionOrderInvariance))
@@ -54,7 +46,11 @@ primitive \nodoc\ _TestRouterList
     test(_Test405FallsBackToLowerPriorityMatch)
     test(_Test405FallsBackStaticToParam)
     test(_Test405AllowHeaderScopedToEntryType)
-    test(_TestEmptyParamSegmentSkipped)
+    test(_TestDoubleSlashNormalization)
+    test(_TestWildcardDoubleSlashNormalization)
+    test(_TestSplitSegmentsEdgeCases)
+    test(Property1UnitTest[String](_PropertySplitJoinRoundTrip))
+    test(_TestJoinRemainingSegments)
     test(_TestRoutesBeforeInterceptors)
     test(_TestMethodNotAllowedCarriesInterceptors)
 
@@ -389,339 +385,6 @@ class \nodoc\ iso _TestTrailingSlashNormalization is UnitTest
     | let _: _RouteMatch => None
     | let _: _RouteMiss =>
       h.fail("expected match for /users/ (trailing slash)")
-    end
-
-class \nodoc\ iso _TestSplitThenParam is UnitTest
-  """
-  Param route added after a static route with shared prefix is parsed.
-
-  Regression: _insert_static stored the remaining suffix as a literal prefix
-  instead of routing through _insert, so `:id` was never parsed as a param.
-  """
-  fun name(): String => "router/split then param"
-
-  fun apply(h: TestHelper) =>
-    let login_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "login")
-    } val
-    let user_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "user")
-    } val
-    let builder = _RouterBuilder
-    // Static route first — creates a single node with long prefix
-    builder.add(stallion.POST, "/a/b/c/login", login_factory, None)
-    // Param route second — triggers split; remaining suffix contains `:id`
-    builder.add(stallion.POST, "/a/b/c/user/:id/filter", user_factory, None)
-    let router = builder.build()
-
-    // The static route still works
-    match router.lookup(stallion.POST, "/a/b/c/login")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](login_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /a/b/c/login")
-    end
-
-    // The param route works and extracts the parameter
-    match router.lookup(stallion.POST, "/a/b/c/user/42/filter")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](user_factory, m.factory)
-      try
-        h.assert_eq[String]("42", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /a/b/c/user/42/filter")
-    end
-
-class \nodoc\ iso _TestSplitThenWildcard is UnitTest
-  """Wildcard route added after a static route with shared prefix is parsed."""
-  fun name(): String => "router/split then wildcard"
-
-  fun apply(h: TestHelper) =>
-    let exact_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "exact")
-    } val
-    let catch_all_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "catch-all")
-    } val
-    let builder = _RouterBuilder
-    // Static route first
-    builder.add(stallion.GET, "/static/page", exact_factory, None)
-    // Wildcard route second — triggers split; remaining suffix contains `*`
-    builder.add(stallion.GET, "/static/*rest", catch_all_factory, None)
-    let router = builder.build()
-
-    match router.lookup(stallion.GET, "/static/page")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](exact_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /static/page")
-    end
-
-    match router.lookup(stallion.GET, "/static/other/deep/path")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](catch_all_factory, m.factory)
-      try
-        h.assert_eq[String]("other/deep/path", m.params("rest")?)
-      else
-        h.fail("wildcard param 'rest' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /static/other/deep/path")
-    end
-
-class \nodoc\ iso _TestSplitThenMultipleParams is UnitTest
-  """Multiple params in the suffix after a split are all parsed correctly."""
-  fun name(): String => "router/split then multiple params"
-
-  fun apply(h: TestHelper) =>
-    let static_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
-    } val
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "params")
-    } val
-    let builder = _RouterBuilder
-    builder.add(stallion.GET, "/api/v1/health", static_factory, None)
-    builder.add(stallion.GET, "/api/v1/:resource/:id", param_factory, None)
-    let router = builder.build()
-
-    match router.lookup(stallion.GET, "/api/v1/health")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](static_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /api/v1/health")
-    end
-
-    match router.lookup(stallion.GET, "/api/v1/users/99")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
-      try
-        h.assert_eq[String]("users", m.params("resource")?)
-      else
-        h.fail("param 'resource' not found")
-      end
-      try
-        h.assert_eq[String]("99", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /api/v1/users/99")
-    end
-
-class \nodoc\ iso _TestSplitParamThenStatic is UnitTest
-  """Param route first, then static with shared prefix — both resolve."""
-  fun name(): String => "router/split param then static"
-
-  fun apply(h: TestHelper) =>
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
-    let static_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
-    } val
-    let builder = _RouterBuilder
-    // Param route first
-    builder.add(stallion.POST, "/a/b/c/user/:id/filter", param_factory, None)
-    // Static route second — triggers split from the other direction
-    builder.add(stallion.POST, "/a/b/c/login", static_factory, None)
-    let router = builder.build()
-
-    match router.lookup(stallion.POST, "/a/b/c/login")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](static_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /a/b/c/login")
-    end
-
-    match router.lookup(stallion.POST, "/a/b/c/user/42/filter")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
-      try
-        h.assert_eq[String]("42", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /a/b/c/user/42/filter")
-    end
-
-class \nodoc\ iso _TestSplitAtSegmentBoundary is UnitTest
-  """Split where common prefix ends exactly at a `/` boundary."""
-  fun name(): String => "router/split at segment boundary"
-
-  fun apply(h: TestHelper) =>
-    let list_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "list")
-    } val
-    let detail_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "detail")
-    } val
-    let builder = _RouterBuilder
-    builder.add(stallion.GET, "/items/list", list_factory, None)
-    builder.add(stallion.GET, "/items/:id", detail_factory, None)
-    let router = builder.build()
-
-    match router.lookup(stallion.GET, "/items/list")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](list_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /items/list")
-    end
-
-    match router.lookup(stallion.GET, "/items/42")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](detail_factory, m.factory)
-      try
-        h.assert_eq[String]("42", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /items/42")
-    end
-
-class \nodoc\ iso _TestSplitMidSegmentParam is UnitTest
-  """
-  Split where divergence is mid-segment, and the new suffix starts with
-  static text before reaching a param.
-  """
-  fun name(): String => "router/split mid-segment param"
-
-  fun apply(h: TestHelper) =>
-    let index_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "index")
-    } val
-    let item_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "item")
-    } val
-    let builder = _RouterBuilder
-    // "index" and "item" share "i" then diverge mid-segment
-    builder.add(stallion.GET, "/prefix/index", index_factory, None)
-    builder.add(stallion.GET, "/prefix/item/:id", item_factory, None)
-    let router = builder.build()
-
-    match router.lookup(stallion.GET, "/prefix/index")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](index_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /prefix/index")
-    end
-
-    match router.lookup(stallion.GET, "/prefix/item/7")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](item_factory, m.factory)
-      try
-        h.assert_eq[String]("7", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /prefix/item/7")
-    end
-
-class \nodoc\ iso _TestDeepNestedParamSharedPrefix is UnitTest
-  """Deeply nested param routes sharing a long common prefix all resolve."""
-  fun name(): String => "router/deep nested param shared prefix"
-
-  fun apply(h: TestHelper) =>
-    let fa: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "a")
-    } val
-    let fb: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "b")
-    } val
-    let fc: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "c")
-    } val
-    let builder = _RouterBuilder
-    builder.add(stallion.GET, "/x/y/z/alpha", fa, None)
-    builder.add(stallion.GET, "/x/y/z/a/:id", fb, None)
-    builder.add(stallion.GET, "/x/y/z/a/:id/sub/:sid", fc, None)
-    let router = builder.build()
-
-    match router.lookup(stallion.GET, "/x/y/z/alpha")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](fa, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /x/y/z/alpha")
-    end
-
-    match router.lookup(stallion.GET, "/x/y/z/a/10")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](fb, m.factory)
-      try
-        h.assert_eq[String]("10", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /x/y/z/a/10")
-    end
-
-    match router.lookup(stallion.GET, "/x/y/z/a/10/sub/20")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](fc, m.factory)
-      try
-        h.assert_eq[String]("10", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-      try
-        h.assert_eq[String]("20", m.params("sid")?)
-      else
-        h.fail("param 'sid' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected match for /x/y/z/a/10/sub/20")
-    end
-
-class \nodoc\ iso _TestStaticPrefixFallsBackToParam is UnitTest
-  """
-  When a static child's prefix matches as a prefix of the remaining path
-  but the subtree doesn't match, lookup falls back to the param child.
-
-  Regression: _RouteMiss from a static child must not block param fallback.
-  `/users/new` and `/users/:id` — a lookup for `/users/newsletter` enters
-  the `new` static child (since "newsletter" starts with "new") but fails.
-  The param child `:id` should still match.
-  """
-  fun name(): String => "router/static prefix falls back to param"
-
-  fun apply(h: TestHelper) =>
-    let static_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
-    } val
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
-    let builder = _RouterBuilder
-    builder.add(stallion.GET, "/users/new", static_factory, None)
-    builder.add(stallion.GET, "/users/:id", param_factory, None)
-    let router = builder.build()
-
-    // Exact static match still works
-    match router.lookup(stallion.GET, "/users/new")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](static_factory, m.factory)
-    | let _: _RouteMiss =>
-      h.fail("expected match for /users/new")
-    end
-
-    // "newsletter" starts with "new" — must fall back to param
-    match router.lookup(stallion.GET, "/users/newsletter")
-    | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
-      try
-        h.assert_eq[String]("newsletter", m.params("id")?)
-      else
-        h.fail("param 'id' not found")
-      end
-    | let _: _RouteMiss =>
-      h.fail("expected param match for /users/newsletter (backtrack from static)")
     end
 
 class \nodoc\ iso _TestParamPriorityOverWildcard is UnitTest
@@ -1346,9 +1009,9 @@ class \nodoc\ iso _TestInterceptorSegmentBoundary is UnitTest
   """
   Group interceptors at /api must NOT leak to /api-docs.
 
-  A radix tree node for /api has children at '/' (sub-paths like /api/users)
-  and '-' (sibling routes like /api-docs). Only sub-path children should
-  inherit the group's interceptors.
+  In the segment trie, `/api` and `/api-docs` are distinct children of the
+  root node (`"api"` vs `"api-docs"`). Interceptors registered on the `/api`
+  node propagate only to its children, not to sibling segments.
   """
   fun name(): String => "router/interceptor segment boundary"
 
@@ -1560,9 +1223,12 @@ class \nodoc\ iso _TestSharedParamNameConsistent is UnitTest
       h.fail("expected match for POST /users/42")
     end
 
-class \nodoc\ iso _TestEmptyParamSegmentSkipped is UnitTest
-  """Empty param segment (/users//details) does not match the param child."""
-  fun name(): String => "router/empty param segment skipped"
+class \nodoc\ iso _TestDoubleSlashNormalization is UnitTest
+  """
+  Double slashes are normalized: `/users//42/details` matches
+  `/users/:id/details` with `id` = `"42"`.
+  """
+  fun name(): String => "router/double slash normalization"
 
   fun apply(h: TestHelper) =>
     let builder = _RouterBuilder
@@ -1581,12 +1247,67 @@ class \nodoc\ iso _TestEmptyParamSegmentSkipped is UnitTest
       h.fail("expected match for /users/42/details")
     end
 
-    // Empty segment — param child requires value_end > offset
+    // Double slash normalized: /users//42/details → segments
+    // ["users", "42", "details"]
+    match router.lookup(stallion.GET, "/users//42/details")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("42", m.params("id")?)
+      else
+        h.fail("param 'id' not found")
+      end
+    else
+      h.fail("expected match for /users//42/details (double slash normalized)")
+    end
+
+    // /users//details is 2 segments ["users", "details"] — misses the
+    // 3-segment route /users/:id/details
     match router.lookup(stallion.GET, "/users//details")
-    | let _: _RouteMatch =>
-      h.fail("empty param segment should not match")
     | let _: _RouteMiss => None
+    | let _: _RouteMatch =>
+      h.fail("/users//details should miss (only 2 segments)")
     | let _: _MethodNotAllowed => None
+    end
+
+class \nodoc\ iso _TestWildcardDoubleSlashNormalization is UnitTest
+  """
+  Wildcard captures normalize double slashes in the captured value.
+
+  A request for `/files/a//b/c` produces a wildcard value of `"a/b/c"`,
+  not `"a//b/c"`, because `_SplitSegments` skips empty segments before
+  the wildcard remainder is reconstructed.
+  """
+  fun name(): String => "router/wildcard double slash normalization"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files/*path", _NoOpFactory, None)
+    let router = builder.build()
+
+    // Double slash in wildcard portion — normalized in captured value
+    match router.lookup(stallion.GET, "/files/a//b/c")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("a/b/c", m.params("path")?,
+          "wildcard should normalize double slash to single")
+      else
+        h.fail("wildcard param 'path' not found")
+      end
+    else
+      h.fail("expected match for /files/a//b/c")
+    end
+
+    // Triple slash
+    match router.lookup(stallion.GET, "/files/x///y")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("x/y", m.params("path")?,
+          "wildcard should normalize triple slash")
+      else
+        h.fail("wildcard param 'path' not found")
+      end
+    else
+      h.fail("expected match for /files/x///y")
     end
 
 class \nodoc\ iso _TestMethodNotAllowed is UnitTest
@@ -1711,6 +1432,132 @@ class \nodoc\ iso _TestWildcardHeadFallback is UnitTest
     else
       h.fail("HEAD should fall back to GET wildcard")
     end
+
+// --- _SplitSegments / _JoinRemainingSegments tests ---
+
+class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
+  """
+  `_SplitSegments` edge cases: root, empty, single segment, double slashes,
+  triple slashes, param/wildcard markers, and registration-path normalization.
+  """
+  fun name(): String => "router/split segments edge cases"
+
+  fun apply(h: TestHelper) =>
+    // Root path → empty
+    let root = _SplitSegments("/")
+    h.assert_eq[USize](0, root.size(), "/ should produce 0 segments")
+
+    // Empty string → empty
+    let empty = _SplitSegments("")
+    h.assert_eq[USize](0, empty.size(), "empty should produce 0 segments")
+
+    // Single segment
+    let single = _SplitSegments("/users")
+    h.assert_eq[USize](1, single.size())
+    try
+      h.assert_eq[String]("users", single(0)?)
+    else
+      h.fail("single segment access failed")
+    end
+
+    // Multi-segment
+    let multi = _SplitSegments("/api/v1/users")
+    h.assert_eq[USize](3, multi.size())
+    try
+      h.assert_eq[String]("api", multi(0)?)
+      h.assert_eq[String]("v1", multi(1)?)
+      h.assert_eq[String]("users", multi(2)?)
+    else
+      h.fail("multi segment access failed")
+    end
+
+    // Double slash → empty segment skipped
+    let double = _SplitSegments("/api//users")
+    h.assert_eq[USize](2, double.size(),
+      "double slash should collapse to 2 segments")
+    try
+      h.assert_eq[String]("api", double(0)?)
+      h.assert_eq[String]("users", double(1)?)
+    else
+      h.fail("double slash segment access failed")
+    end
+
+    // Triple slash
+    let triple = _SplitSegments("/a///b")
+    h.assert_eq[USize](2, triple.size(),
+      "triple slash should collapse to 2 segments")
+    try
+      h.assert_eq[String]("a", triple(0)?)
+      h.assert_eq[String]("b", triple(1)?)
+    else
+      h.fail("triple slash segment access failed")
+    end
+
+    // Param and wildcard markers are preserved as segment content
+    let params = _SplitSegments("/users/:id/posts/*rest")
+    h.assert_eq[USize](4, params.size())
+    try
+      h.assert_eq[String](":id", params(1)?)
+      h.assert_eq[String]("*rest", params(3)?)
+    else
+      h.fail("param/wildcard segment access failed")
+    end
+
+class \nodoc\ iso _PropertySplitJoinRoundTrip is Property1[String]
+  """
+  Splitting a static path into segments and joining them all back produces
+  the original path without the leading slash.
+  """
+  fun name(): String => "router/property/split join round-trip"
+
+  fun gen(): Generator[String] => _GenStaticPath()
+
+  fun property(path: String, h: PropertyHelper) =>
+    let segments = _SplitSegments(path)
+    let rejoined = _JoinRemainingSegments(segments, 0)
+    // _SplitSegments strips the leading '/'; _JoinRemainingSegments
+    // does not add it back. So "/" + rejoined == path.
+    h.assert_eq[String](path, "/" + rejoined)
+
+class \nodoc\ iso _TestJoinRemainingSegments is UnitTest
+  """
+  `_JoinRemainingSegments` edge cases: past-end index, single segment,
+  multiple segments, and mid-array start.
+  """
+  fun name(): String => "router/join remaining segments"
+
+  fun apply(h: TestHelper) =>
+    let segments: Array[String] val =
+      recover val ["api"; "v1"; "users"; "42"] end
+
+    // from >= size → empty string
+    h.assert_eq[String]("",
+      _JoinRemainingSegments(segments, 10),
+      "past-end should return empty")
+    h.assert_eq[String]("",
+      _JoinRemainingSegments(segments, 4),
+      "at-size should return empty")
+
+    // Empty array → empty string
+    let empty: Array[String] val = recover val Array[String] end
+    h.assert_eq[String]("",
+      _JoinRemainingSegments(empty, 0),
+      "empty array should return empty")
+
+    // Single remaining segment (fast path, no allocation)
+    h.assert_eq[String]("42",
+      _JoinRemainingSegments(segments, 3),
+      "single remaining should return that segment")
+
+    // Multiple remaining segments
+    h.assert_eq[String]("v1/users/42",
+      _JoinRemainingSegments(segments, 1),
+      "join from index 1")
+
+    // All segments from start
+    h.assert_eq[String]("api/v1/users/42",
+      _JoinRemainingSegments(segments, 0),
+      "join all segments")
 
 class \nodoc\ iso _TestRoutesBeforeInterceptors is UnitTest
   """

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -77,7 +77,7 @@ Register the factory: `.>get("/data", {(ctx)(db) => MyHandler(consume ctx, db)} 
 
 ## Routing
 
-Routes use a radix tree with two kinds of dynamic segments:
+Routes use a segment trie with two kinds of dynamic segments:
 
 - **Named parameters** (`:name`): match a single path segment.
   `/users/:id` matches `/users/42` but not `/users/42/posts`.


### PR DESCRIPTION
The character-level radix tree created a class of bugs around segment boundary semantics — interceptor leakage across prefixes (#59 fixes), intricate node-splitting logic, and backtracking failures. A segment trie keyed by full path segments eliminates these structurally: each node IS a segment, so boundary checks are the tree structure itself.

**What changed:**
- `_BuildNode`/`_TreeNode` children keyed by full segment string (`Map[String, ...]`) instead of first character (`Map[U8, ...]`)
- `_SplitSegments` splits paths into segments once upfront; trie walks by index
- `_Paths` primitive removed entirely (4 character-level utility methods no longer needed)
- `_parent_interceptors`/`_parent_response_interceptors` fields removed — structurally unnecessary when every child is at a segment boundary
- `freeze()` propagates interceptors unconditionally to all children (no `key == '/'` conditional)
- Double slashes normalized (`/users//42` → `/users/42`), matching nginx/Apache/Go/Rails/Phoenix
- 8 radix-specific tests removed (split/backtrack scenarios that can't occur in a segment trie)
- Net -452 lines

**Tradeoff:** One `Array[String] val` allocation per request for segment splitting, negligible next to HTTP parsing and handler execution.

**Parked items from code review** (for Sean to weigh in on):
- Tests reviewer suggested adding direct unit tests for `_SplitSegments` and `_JoinRemainingSegments`. Currently tested indirectly through every router test. Worth adding dedicated tests, or is indirect coverage sufficient?

Closes #62