### PR TITLE
Add pony-lint CI workflows and fix all violations

### DIFF
--- a/.github/workflows/lint-against-pony-lint-latest.yml
+++ b/.github/workflows/lint-against-pony-lint-latest.yml
@@ -1,0 +1,31 @@
+name: Lint against pony-lint latest
+
+on:
+  repository_dispatch:
+    types:
+      - shared-docker-builders-updated
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint against pony-lint main
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -1,0 +1,24 @@
+name: pony-lint
+
+on:
+  pull_request:
+    paths:
+      - '**/*.pony'
+
+concurrency:
+  group: pony-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  pony-lint:
+    name: Lint Pony source
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ hobby/
   _buffered_response.pony     - Response buffer for response interceptors (internal)
   _run_request_interceptors.pony - Request interceptor execution (internal)
   _run_response_interceptors.pony - Response interceptor execution (internal)
-  _handler_timeout.pony       - Handler timeout timer notify (internal)
+  _handler_timeout_notify.pony - Handler timeout timer notify (internal)
   _connection.pony             - Connection actor (internal)
   _listener.pony               - Listener actor (internal)
   _router.pony                 - Router + segment trie (internal)
@@ -151,9 +151,9 @@ hobby/
   _file_target.pony            - File target trait (internal)
   _serve_files_handler.pony    - ServeFiles handler actor (internal)
   _http_date.pony              - RFC 7231 HTTP-date formatting (internal)
-  _etag.pony                   - Weak ETag computation and matching (internal)
+  _e_tag.pony                  - Weak ETag computation and matching (internal)
   _flatten.pony                - Segment splitting, path joining, array concatenation, overlap detection, prefix validation (internal)
-  _mort.pony                   - _Unreachable primitive (internal)
+  _unreachable.pony            - _Unreachable primitive (internal)
   _test.pony                   - Test runner
   _test_router.pony            - Router property-based + example tests
   _test_route_group.pony       - Route group unit + property tests

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 BUILD_DOCS_WITH := corral run -- pony-doc
+LINT_WITH := corral run -- pony-lint
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -75,6 +76,10 @@ $(docs_dir): $(SOURCE_FILES)
 
 docs: $(docs_dir)
 
+lint:
+	$(GET_DEPENDENCIES_WITH)
+	$(LINT_WITH) .
+
 TAGS:
 	ctags --recurse=yes $(SRC_DIR)
 
@@ -83,4 +88,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all examples clean integration-tests TAGS test unit-tests test-one
+.PHONY: all examples clean integration-tests lint TAGS test unit-tests test-one

--- a/examples/async-handler/async_handler.pony
+++ b/examples/async-handler/async_handler.pony
@@ -1,0 +1,5 @@
+"""
+
+Async handler example.
+"""
+

--- a/examples/async-handler/main.pony
+++ b/examples/async-handler/main.pony
@@ -6,6 +6,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Async handler example.
 
   Demonstrates actor-based handlers that do async work before responding.
@@ -21,29 +22,39 @@ actor Main
     curl http://localhost:8080/
     curl http://localhost:8080/slow
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
     let slow = SlowService
     match
       hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Hello from Hobby!")
-        } val)
-        .>get("/slow", {(ctx)(slow) =>
-          SlowHandler(consume ctx, slow)
-        } val)
+        .> get(
+          "/",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Hello from Hobby!")
+          } val)
+        .> get(
+          "/slow",
+          {(ctx)(slow) =>
+            SlowHandler(consume ctx, slow)
+          } val)
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
     end
 
 actor SlowService
-  """Simulates an async service via self-directed message."""
+  """
+  Simulates an async service via self-directed message.
+  """
   be query(requester: SlowHandler tag) =>
     requester.result("done after async work")
 
 actor SlowHandler is hobby.HandlerReceiver
+  """
+  Handles a request by delegating to a SlowService for async work.
+  """
   embed _handler: hobby.RequestHandler
 
   new create(ctx: hobby.HandlerContext iso, service: SlowService tag) =>

--- a/examples/custom-content-types/custom_content_types.pony
+++ b/examples/custom-content-types/custom_content_types.pony
@@ -1,0 +1,5 @@
+"""
+
+Custom content types example.
+"""
+

--- a/examples/custom-content-types/main.pony
+++ b/examples/custom-content-types/main.pony
@@ -7,6 +7,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Custom content type mapping example.
 
   Starts an HTTP server on 0.0.0.0:8080 that serves files from `public/`
@@ -23,10 +24,13 @@ actor Main
     curl -I http://localhost:8080/static/photo.avif
     curl -I http://localhost:8080/static/index.html
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    let root = FilePath(FileAuth(env.root),
-      "examples/custom-content-types/public")
+    let root =
+      FilePath(
+        FileAuth(env.root),
+        "examples/custom-content-types/public")
 
     // Add custom content types for .webp and .avif image formats
     let types = hobby.ContentTypes
@@ -35,7 +39,8 @@ actor Main
 
     match
       hobby.Application
-        .>get("/static/*filepath",
+        .> get(
+          "/static/*filepath",
           hobby.ServeFiles(root where content_types = types))
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>

--- a/examples/hello/hello.pony
+++ b/examples/hello/hello.pony
@@ -1,0 +1,5 @@
+"""
+
+Hello world example.
+"""
+

--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -16,24 +16,34 @@ actor Main
     curl http://localhost:8080/
     curl http://localhost:8080/greet/World
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
     match
       hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Hello from Hobby!")
-        } val)
-        .>get("/greet/:name", {(ctx) =>
-          let handler = hobby.RequestHandler(consume ctx)
-          try
-            let name = handler.param("name")?
-            handler.respond(stallion.StatusOK, "Hello, " + name + "!")
-          else
-            handler.respond(stallion.StatusBadRequest, "Bad Request")
-          end
-        } val)
-        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+        .> get(
+          "/",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Hello from Hobby!")
+          } val)
+        .> get(
+          "/greet/:name",
+          {(ctx) =>
+            let handler = hobby.RequestHandler(consume ctx)
+            try
+              let name = handler.param("name")?
+              handler.respond(
+                stallion.StatusOK, "Hello, " + name + "!")
+            else
+              handler.respond(
+                stallion.StatusBadRequest, "Bad Request")
+            end
+          } val)
+        .serve(
+          auth,
+          stallion.ServerConfig("0.0.0.0", "8080"),
+          env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
     end

--- a/examples/request-interceptors/main.pony
+++ b/examples/request-interceptors/main.pony
@@ -4,6 +4,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Demonstrates request interceptors for synchronous request short-circuiting.
 
   Interceptors run before the handler is created. An interceptor returns
@@ -17,6 +18,7 @@ actor Main
   - GET /admin         → requires X-Admin and Authorization headers
 
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
 
@@ -25,7 +27,7 @@ actor Main
 
     let upload_interceptors: Array[hobby.RequestInterceptor val] val =
       recover val
-        [as hobby.RequestInterceptor val:
+        [ as hobby.RequestInterceptor val:
           AuthInterceptor
           ContentTypeInterceptor("application/json")
           MaxBodySizeInterceptor(1_048_576)]
@@ -33,7 +35,7 @@ actor Main
 
     let admin_interceptors: Array[hobby.RequestInterceptor val] val =
       recover val
-        [as hobby.RequestInterceptor val:
+        [ as hobby.RequestInterceptor val:
           AuthInterceptor
           RequiredHeadersInterceptor(
             recover val ["x-admin"] end)]
@@ -41,27 +43,40 @@ actor Main
 
     match
       hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Hello from Hobby!")
-        } val)
-        .>get("/api/:id", {(ctx) =>
-          let handler = hobby.RequestHandler(consume ctx)
-          try
-            let id = handler.param("id")?
-            handler.respond(stallion.StatusOK, "Resource: " + id)
-          else
-            handler.respond(stallion.StatusBadRequest, "Bad Request")
-          end
-        } val where interceptors = auth_interceptor)
-        .>post("/api/upload", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Upload accepted")
-        } val where interceptors = upload_interceptors)
-        .>get("/admin", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Admin dashboard")
-        } val where interceptors = admin_interceptors)
+        .> get(
+          "/",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Hello from Hobby!")
+          } val)
+        .> get(
+          "/api/:id",
+          {(ctx) =>
+            let handler = hobby.RequestHandler(consume ctx)
+            try
+              let id = handler.param("id")?
+              handler.respond(
+                stallion.StatusOK, "Resource: " + id)
+            else
+              handler.respond(
+                stallion.StatusBadRequest, "Bad Request")
+            end
+          } val
+          where interceptors = auth_interceptor)
+        .> post(
+          "/api/upload",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Upload accepted")
+          } val
+          where interceptors = upload_interceptors)
+        .> get(
+          "/admin",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Admin dashboard")
+          } val
+          where interceptors = admin_interceptors)
         .serve(auth, stallion.ServerConfig("localhost", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
@@ -69,12 +84,14 @@ actor Main
 
 class val AuthInterceptor is hobby.RequestInterceptor
   """
+
   Rejects requests that lack an Authorization header.
 
   This is a cheap synchronous check — it only verifies the header is present,
   not that the credentials are valid. Real credential validation requires
   async work and belongs in the handler actor.
   """
+
   fun apply(request: stallion.Request box): hobby.InterceptResult =>
     match request.headers.get("authorization")
     | let _: String => hobby.InterceptPass
@@ -84,8 +101,10 @@ class val AuthInterceptor is hobby.RequestInterceptor
 
 class val ContentTypeInterceptor is hobby.RequestInterceptor
   """
+
   Rejects requests whose Content-Type header doesn't match the expected value.
   """
+
   let _expected: String
 
   new val create(expected: String) => _expected = expected
@@ -94,14 +113,17 @@ class val ContentTypeInterceptor is hobby.RequestInterceptor
     match request.headers.get("content-type")
     | let ct: String if ct == _expected => hobby.InterceptPass
     else
-      hobby.InterceptRespond(stallion.StatusUnsupportedMediaType,
+      hobby.InterceptRespond(
+        stallion.StatusUnsupportedMediaType,
         "Unsupported Media Type")
     end
 
 class val MaxBodySizeInterceptor is hobby.RequestInterceptor
   """
+
   Rejects requests whose Content-Length exceeds a maximum size in bytes.
   """
+
   let _max: USize
 
   new val create(max: USize) => _max = max
@@ -111,7 +133,8 @@ class val MaxBodySizeInterceptor is hobby.RequestInterceptor
     | let cl: String =>
       try
         if cl.usize()? > _max then
-          return hobby.InterceptRespond(stallion.StatusPayloadTooLarge,
+          return hobby.InterceptRespond(
+            stallion.StatusPayloadTooLarge,
             "Payload Too Large")
         end
       end
@@ -120,8 +143,10 @@ class val MaxBodySizeInterceptor is hobby.RequestInterceptor
 
 class val RequiredHeadersInterceptor is hobby.RequestInterceptor
   """
+
   Rejects requests that are missing any of the required headers.
   """
+
   let _headers: Array[String] val
 
   new val create(headers: Array[String] val) => _headers = headers
@@ -129,7 +154,8 @@ class val RequiredHeadersInterceptor is hobby.RequestInterceptor
   fun apply(request: stallion.Request box): hobby.InterceptResult =>
     for h in _headers.values() do
       if request.headers.get(h) is None then
-        return hobby.InterceptRespond(stallion.StatusBadRequest,
+        return hobby.InterceptRespond(
+          stallion.StatusBadRequest,
           "Missing required header: " + h)
       end
     end

--- a/examples/request-interceptors/request_interceptors.pony
+++ b/examples/request-interceptors/request_interceptors.pony
@@ -1,0 +1,5 @@
+"""
+
+Request interceptors example.
+"""
+

--- a/examples/response-interceptors/main.pony
+++ b/examples/response-interceptors/main.pony
@@ -6,6 +6,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Response interceptors example.
 
   Demonstrates three response interceptor patterns:
@@ -28,6 +29,7 @@ actor Main
     curl -v http://localhost:8080/api/42 -H "Authorization: Bearer secret"
     curl -v http://localhost:8080/nonexistent
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
 
@@ -36,65 +38,80 @@ actor Main
 
     match
       hobby.Application
-        .>add_response_interceptor(CorsResponseInterceptor("*"))
-        .>add_response_interceptor(SecurityHeadersInterceptor)
-        .>add_response_interceptor(LogResponseInterceptor(env.out))
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Hello from Hobby!")
-        } val)
-        .>get("/api/:id", {(ctx) =>
-          let handler = hobby.RequestHandler(consume ctx)
-          try
-            let id = handler.param("id")?
-            handler.respond(stallion.StatusOK, "Resource: " + id)
-          else
-            handler.respond(stallion.StatusBadRequest, "Bad Request")
-          end
-        } val where interceptors = auth_interceptor)
+        .> add_response_interceptor(CorsResponseInterceptor("*"))
+        .> add_response_interceptor(SecurityHeadersInterceptor)
+        .> add_response_interceptor(LogResponseInterceptor(env.out))
+        .> get(
+          "/",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Hello from Hobby!")
+          } val)
+        .> get(
+          "/api/:id",
+          {(ctx) =>
+            let handler = hobby.RequestHandler(consume ctx)
+            try
+              let id = handler.param("id")?
+              handler.respond(
+                stallion.StatusOK, "Resource: " + id)
+            else
+              handler.respond(
+                stallion.StatusBadRequest, "Bad Request")
+            end
+          } val
+          where interceptors = auth_interceptor)
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
     end
 
 // --- Response interceptors ---
-
 class val CorsResponseInterceptor is hobby.ResponseInterceptor
   """
+
   Adds CORS headers to every response.
 
   Captures the allowed origin at construction time. The interceptor is `val`
   and shareable across connections.
   """
+
   let _origin: String
 
   new val create(origin: String) => _origin = origin
 
   fun apply(ctx: hobby.ResponseContext ref) =>
     ctx.set_header("access-control-allow-origin", _origin)
-    ctx.set_header("access-control-allow-methods",
+    ctx.set_header(
+      "access-control-allow-methods",
       "GET, POST, PUT, DELETE, OPTIONS")
-    ctx.set_header("access-control-allow-headers",
+    ctx.set_header(
+      "access-control-allow-headers",
       "Content-Type, Authorization")
 
 primitive SecurityHeadersInterceptor is hobby.ResponseInterceptor
   """
+
   Adds common security headers to every response.
   """
+
   fun apply(ctx: hobby.ResponseContext ref) =>
     ctx.set_header("x-content-type-options", "nosniff")
     ctx.set_header("x-frame-options", "DENY")
-    ctx.set_header("strict-transport-security",
+    ctx.set_header(
+      "strict-transport-security",
       "max-age=31536000; includeSubDomains")
 
 class val LogResponseInterceptor is hobby.ResponseInterceptor
   """
+
   Logs the request method, path, and response status after handling.
 
   A read-only interceptor — it doesn't modify the response. For streaming
   responses, the status is still available for logging even though header
   modifications would be no-ops.
   """
+
   let _out: OutStream
 
   new val create(out: OutStream) => _out = out
@@ -105,9 +122,10 @@ class val LogResponseInterceptor is hobby.ResponseInterceptor
         + " -> " + ctx.status().string())
 
 // --- Request interceptor ---
-
 class val AuthInterceptor is hobby.RequestInterceptor
-  """Rejects requests that lack an Authorization header."""
+  """
+  Rejects requests that lack an Authorization header.
+  """
   fun apply(request: stallion.Request box): hobby.InterceptResult =>
     match request.headers.get("authorization")
     | let _: String => hobby.InterceptPass

--- a/examples/response-interceptors/response_interceptors.pony
+++ b/examples/response-interceptors/response_interceptors.pony
@@ -1,0 +1,5 @@
+"""
+
+Response interceptors example.
+"""
+

--- a/examples/route-groups/main.pony
+++ b/examples/route-groups/main.pony
@@ -6,6 +6,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Route groups example.
 
   Demonstrates route grouping with shared prefixes and interceptors:
@@ -26,8 +27,10 @@ actor Main
     curl http://localhost:8080/api/users                         # 401
     curl -H "Authorization: Bearer secret" http://localhost:8080/api/users
     curl -H "Authorization: Bearer secret" http://localhost:8080/api/users/42
-    curl -H "Authorization: Bearer secret" http://localhost:8080/api/admin/dashboard
+    curl -H "Authorization: Bearer secret" \
+      http://localhost:8080/api/admin/dashboard
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
 
@@ -36,44 +39,63 @@ actor Main
 
     match
       hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "Hello from Hobby!")
-        } val)
-        .>get("/health", {(ctx) =>
-          hobby.RequestHandler(consume ctx)
-            .respond(stallion.StatusOK, "OK")
-        } val)
-        .>group(
-          hobby.RouteGroup("/api" where interceptors = auth_interceptor)
-            .>get("/users", {(ctx) =>
-              hobby.RequestHandler(consume ctx)
-                .respond(stallion.StatusOK, "User list")
-            } val)
-            .>get("/users/:id", {(ctx) =>
-              let handler = hobby.RequestHandler(consume ctx)
-              try
-                let id = handler.param("id")?
-                handler.respond(stallion.StatusOK, "User " + id)
-              else
-                handler.respond(stallion.StatusBadRequest, "Bad Request")
-              end
-            } val)
-            .>group(
-              hobby.RouteGroup("/admin")
-                .>get("/dashboard", {(ctx) =>
+        .> get(
+          "/",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "Hello from Hobby!")
+          } val)
+        .> get(
+          "/health",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(stallion.StatusOK, "OK")
+          } val)
+        .> group(
+          hobby.RouteGroup(
+            "/api"
+            where interceptors = auth_interceptor)
+            .> get(
+              "/users",
+              {(ctx) =>
+                hobby.RequestHandler(consume ctx)
+                  .respond(stallion.StatusOK, "User list")
+              } val)
+            .> get(
+              "/users/:id",
+              {(ctx) =>
+                let handler =
                   hobby.RequestHandler(consume ctx)
-                    .respond(stallion.StatusOK, "Admin dashboard")
-                } val)))
+                try
+                  let id = handler.param("id")?
+                  handler.respond(
+                    stallion.StatusOK, "User " + id)
+                else
+                  handler.respond(
+                    stallion.StatusBadRequest,
+                    "Bad Request")
+                end
+              } val)
+            .> group(
+              hobby.RouteGroup("/admin")
+                .> get(
+                  "/dashboard",
+                  {(ctx) =>
+                    hobby.RequestHandler(consume ctx)
+                      .respond(
+                        stallion.StatusOK,
+                        "Admin dashboard")
+                  } val)))
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
     end
 
 // --- Request interceptor ---
-
 class val AuthInterceptor is hobby.RequestInterceptor
-  """Rejects requests without an Authorization header."""
+  """
+  Rejects requests without an Authorization header.
+  """
   fun apply(request: stallion.Request box): hobby.InterceptResult =>
     match request.headers.get("authorization")
     | let _: String => hobby.InterceptPass

--- a/examples/route-groups/route_groups.pony
+++ b/examples/route-groups/route_groups.pony
@@ -1,0 +1,5 @@
+"""
+
+Route groups example.
+"""
+

--- a/examples/serve-files/main.pony
+++ b/examples/serve-files/main.pony
@@ -7,6 +7,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Static file serving example.
 
   Starts an HTTP server on 0.0.0.0:8080 that serves files from a directory
@@ -24,6 +25,7 @@ actor Main
     curl http://localhost:8080/static/style.css
     curl http://localhost:8080/static/docs/
   """
+
   new create(env: Env) =>
     try
       let dir = env.args(1)?
@@ -32,11 +34,16 @@ actor Main
 
       match
         hobby.Application
-          .>get("/", {(ctx) =>
-            hobby.RequestHandler(consume ctx).respond(stallion.StatusOK,
-              "Visit /static/index.html to see a served file.")
-          } val)
-          .>get("/static/*filepath", hobby.ServeFiles(root))
+          .> get(
+            "/",
+            {(ctx) =>
+              hobby.RequestHandler(consume ctx)
+                .respond(
+                  stallion.StatusOK,
+                  "Visit /static/index.html"
+                    + " to see a served file.")
+            } val)
+          .> get("/static/*filepath", hobby.ServeFiles(root))
           .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
       | let err: hobby.ConfigError =>
         env.err.print(err.message)

--- a/examples/serve-files/serve_files.pony
+++ b/examples/serve-files/serve_files.pony
@@ -1,0 +1,5 @@
+"""
+
+Static file serving example.
+"""
+

--- a/examples/signed-cookie/main.pony
+++ b/examples/signed-cookie/main.pony
@@ -6,6 +6,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Signed cookie example.
 
   Demonstrates signing and verifying cookie values using HMAC-SHA256 to
@@ -23,6 +24,7 @@ actor Main
     curl -c cookies.txt -b cookies.txt http://localhost:8080/clear
     curl -c cookies.txt -b cookies.txt http://localhost:8080/
   """
+
   new create(env: Env) =>
     let key =
       try hobby.CookieSigningKey.generate()?
@@ -31,59 +33,79 @@ actor Main
     let auth = lori.TCPListenAuth(env.root)
     match
       hobby.Application
-        .>get("/", {(ctx)(key) =>
-          let handler = hobby.RequestHandler(consume ctx)
-          // Read and verify the signed visit count from the cookie
-          let count: U64 =
-            match handler.request().cookies.get("visits")
-            | let raw: String =>
-              match \exhaustive\ hobby.SignedCookie.verify(key, raw)
-              | let value: String =>
-                try value.u64()? else 0 end
-              | let _: hobby.SignedCookieError => 0
+        .> get(
+          "/",
+          {(ctx)(key) =>
+            let handler =
+              hobby.RequestHandler(consume ctx)
+            // Read and verify the signed visit count
+            let count: U64 =
+              match handler.request().cookies.get("visits")
+              | let raw: String =>
+                match \exhaustive\
+                  hobby.SignedCookie.verify(key, raw)
+                | let value: String =>
+                  try value.u64()? else 0 end
+                | let _: hobby.SignedCookieError => 0
+                end
+              else
+                0
               end
-            else
-              0
-            end
-          let new_count: String val = (count + 1).string()
-          let signed = hobby.SignedCookie.sign(key, new_count)
-          // Build response headers with the signed cookie.
-          // Secure=false for localhost testing; use the default (true) in
-          // production.
-          let headers: stallion.Headers val =
-            recover val
-              let h = stallion.Headers
-              match stallion.SetCookieBuilder("visits", signed)
-                .with_path("/")
-                .with_secure(false)
-                .build()
-              | let sc: stallion.SetCookie val =>
-                h.add("Set-Cookie", sc.header_value())
+            let new_count: String val =
+              (count + 1).string()
+            let signed =
+              hobby.SignedCookie.sign(key, new_count)
+            // Build response headers with signed cookie.
+            // Secure=false for localhost testing; use the
+            // default (true) in production.
+            let headers: stallion.Headers val =
+              recover val
+                let h = stallion.Headers
+                match
+                  stallion.SetCookieBuilder(
+                    "visits", signed)
+                    .with_path("/")
+                    .with_secure(false)
+                    .build()
+                | let sc: stallion.SetCookie val =>
+                  h.add(
+                    "Set-Cookie",
+                    sc.header_value())
+                end
+                h
               end
-              h
-            end
-          handler.respond_with_headers(stallion.StatusOK, headers,
-            "Visit #" + new_count)
-        } val)
-        .>get("/clear", {(ctx) =>
-          let handler = hobby.RequestHandler(consume ctx)
-          // Clear the cookie by setting Max-Age=0
-          let headers: stallion.Headers val =
-            recover val
-              let h = stallion.Headers
-              match stallion.SetCookieBuilder("visits", "")
-                .with_path("/")
-                .with_max_age(0)
-                .with_secure(false)
-                .build()
-              | let sc: stallion.SetCookie val =>
-                h.add("Set-Cookie", sc.header_value())
+            handler.respond_with_headers(
+              stallion.StatusOK,
+              headers,
+              "Visit #" + new_count)
+          } val)
+        .> get(
+          "/clear",
+          {(ctx) =>
+            let handler =
+              hobby.RequestHandler(consume ctx)
+            // Clear the cookie by setting Max-Age=0
+            let headers: stallion.Headers val =
+              recover val
+                let h = stallion.Headers
+                match
+                  stallion.SetCookieBuilder("visits", "")
+                    .with_path("/")
+                    .with_max_age(0)
+                    .with_secure(false)
+                    .build()
+                | let sc: stallion.SetCookie val =>
+                  h.add(
+                    "Set-Cookie",
+                    sc.header_value())
+                end
+                h
               end
-              h
-            end
-          handler.respond_with_headers(stallion.StatusOK, headers,
-            "Visit counter cleared.")
-        } val)
+            handler.respond_with_headers(
+              stallion.StatusOK,
+              headers,
+              "Visit counter cleared.")
+          } val)
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)

--- a/examples/signed-cookie/signed_cookie.pony
+++ b/examples/signed-cookie/signed_cookie.pony
@@ -1,0 +1,5 @@
+"""
+
+Signed cookie example.
+"""
+

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -6,6 +6,7 @@ use lori = "lori"
 
 actor Main
   """
+
   Streaming response example.
 
   Starts an HTTP server on 0.0.0.0:8080 with two routes:
@@ -20,33 +21,46 @@ actor Main
     curl http://localhost:8080/stream
     curl --head http://localhost:8080/stream
   """
+
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
     match
       hobby.Application
-        .>get("/", {(ctx) =>
-          hobby.RequestHandler(consume ctx).respond(stallion.StatusOK,
-            "Visit /stream to see a chunked streaming response.")
-        } val)
-        .>get("/stream", {(ctx) =>
-          StreamHandler(consume ctx)
-        } val)
+        .> get(
+          "/",
+          {(ctx) =>
+            hobby.RequestHandler(consume ctx)
+              .respond(
+                stallion.StatusOK,
+                "Visit /stream to see a chunked"
+                  + " streaming response.")
+          } val)
+        .> get(
+          "/stream",
+          {(ctx) =>
+            StreamHandler(consume ctx)
+          } val)
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
     end
 
 actor StreamHandler is hobby.HandlerReceiver
-  """Starts streaming and sends 5 numbered chunks."""
+  """
+  Starts streaming and sends 5 numbered chunks.
+  """
   embed _handler: hobby.RequestHandler
 
   new create(ctx: hobby.HandlerContext iso) =>
     _handler = hobby.RequestHandler(consume ctx)
-    match _handler.start_streaming(stallion.StatusOK)
+    match \exhaustive\
+      _handler.start_streaming(stallion.StatusOK)
     | hobby.StreamingStarted => _send()
     | stallion.ChunkedNotSupported =>
-      _handler.respond(stallion.StatusOK,
-        "Chunked encoding not supported — upgrade to HTTP/1.1.")
+      _handler.respond(
+        stallion.StatusOK,
+        "Chunked encoding not supported"
+          + " — upgrade to HTTP/1.1.")
     | hobby.BodyNotNeeded => None
     end
 

--- a/examples/streaming/streaming.pony
+++ b/examples/streaming/streaming.pony
@@ -1,0 +1,5 @@
+"""
+
+Streaming response example.
+"""
+

--- a/hobby/_buffered_response.pony
+++ b/hobby/_buffered_response.pony
@@ -2,6 +2,7 @@ use stallion = "stallion"
 
 class ref _BufferedResponse
   """
+
   Mutable response buffer for response interceptor modification.
 
   Created by `_Connection` when a response is produced (from handler, request
@@ -14,26 +15,36 @@ class ref _BufferedResponse
   Content-Length header is already present (from explicit user headers or an
   interceptor), `_build()` does not override it.
   """
+
   var status: stallion.Status
   embed headers: Array[(String, String)]
   var body: (ByteSeq | None)
   let is_streaming: Bool
   let is_head: Bool
 
-  new ref _standard(status': stallion.Status, body': ByteSeq,
+  new ref _standard(
+    status': stallion.Status,
+    body': ByteSeq,
     is_head': Bool)
   =>
-    """Create a buffered response for a simple respond() call."""
+    """
+    Create a buffered response for a simple respond() call.
+    """
     status = status'
     headers = Array[(String, String)]
     body = body'
     is_streaming = false
     is_head = is_head'
 
-  new ref _with_headers(status': stallion.Status,
-    hdrs: stallion.Headers val, body': ByteSeq, is_head': Bool)
+  new ref _with_headers(
+    status': stallion.Status,
+    hdrs: stallion.Headers val,
+    body': ByteSeq,
+    is_head': Bool)
   =>
-    """Create a buffered response with explicit headers."""
+    """
+    Create a buffered response with explicit headers.
+    """
     status = status'
     headers = Array[(String, String)]
     for hdr in hdrs.values() do
@@ -46,7 +57,9 @@ class ref _BufferedResponse
   new ref _from_intercept_respond(respond: InterceptRespond ref,
     is_head': Bool)
   =>
-    """Create a buffered response from an interceptor short-circuit."""
+    """
+    Create a buffered response from an interceptor short-circuit.
+    """
     status = respond._response_status()
     headers = Array[(String, String)]
     var i: USize = 0
@@ -63,7 +76,9 @@ class ref _BufferedResponse
     is_head = is_head'
 
   new ref _streaming_complete(status': stallion.Status, is_head': Bool) =>
-    """Create a buffered response for response interceptors on stream finish."""
+    """
+    Create a buffered response for response interceptors on stream finish.
+    """
     status = status'
     headers = Array[(String, String)]
     body = None
@@ -72,6 +87,7 @@ class ref _BufferedResponse
 
   fun box _build(): Array[U8] val =>
     """
+
     Serialize this buffered response into HTTP bytes for the wire.
 
     For non-streaming responses, auto-adds Content-Length from the final body
@@ -79,6 +95,7 @@ class ref _BufferedResponse
     response interceptors, so interceptors that call `set_body()` get correct
     Content-Length automatically.
     """
+
     let builder = stallion.ResponseBuilder(status)
     for (name, value) in headers.values() do
       builder.add_header(name, value)
@@ -94,12 +111,13 @@ class ref _BufferedResponse
         end
       end
       if not has_content_length then
-        let body_size: USize = match body
-        | let s: String val => s.size()
-        | let a: Array[U8] val => a.size()
-        else
-          0
-        end
+        let body_size: USize =
+          match body
+          | let s: String val => s.size()
+          | let a: Array[U8] val => a.size()
+          else
+            0
+          end
         builder.add_header("content-length", body_size.string())
       end
     end

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -14,6 +14,7 @@ type _PendingRequest is
 
 actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   """
+
   Internal connection actor that handles a single HTTP connection.
 
   Implements Stallion's `HTTPServerActor` to receive HTTP events and
@@ -21,14 +22,13 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   runs through: request interceptors (synchronous) → handler factory →
   handler actor (async) → response interceptors (synchronous) → wire.
   """
+
   var _http: stallion.HTTPServer = stallion.HTTPServer.none()
   let _router: _Router val
   let _timers: Timers tag
   let _timeout_ns: U64
   var _body: Array[U8] iso = recover iso Array[U8] end
   var _has_body: Bool = false
-
-  // Per-request state
   var _current_token: U64 = 0
   var _handler: (HandlerReceiver tag | None) = None
   var _handler_timer: (Timer tag | None) = None
@@ -42,9 +42,13 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   var _is_head: Bool = false
   embed _pending_requests: Array[_PendingRequest]
 
-  new create(auth: lori.TCPServerAuth, fd: U32,
-    config: stallion.ServerConfig, router: _Router val,
-    timers: Timers tag, timeout_ns: U64)
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: stallion.ServerConfig,
+    router: _Router val,
+    timers: Timers tag,
+    timeout_ns: U64)
   =>
     _router = router
     _timers = timers
@@ -55,12 +59,12 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   fun ref _http_connection(): stallion.HTTPServer => _http
 
   // --- HTTP lifecycle callbacks ---
-
   fun ref on_body_chunk(data: Array[U8] val) =>
     _has_body = true
     _body.append(data)
 
-  fun ref on_request_complete(request': stallion.Request val,
+  fun ref on_request_complete(
+    request': stallion.Request val,
     responder: stallion.Responder)
   =>
     let body: Array[U8] val =
@@ -110,31 +114,37 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
     end
 
   // --- Request processing ---
-
-  fun ref _process_request(request': stallion.Request val,
-    responder: stallion.Responder, body: Array[U8] val)
+  fun ref _process_request(
+    request': stallion.Request val,
+    responder: stallion.Responder,
+    body: Array[U8] val)
   =>
     let path = request'.uri.path
     let is_head = request'.method is stallion.HEAD
 
     // Single lookup — HEAD→GET fallback is handled inside the router
-    match _router.lookup(request'.method, path)
+    match \exhaustive\ _router.lookup(request'.method, path)
     | let m: _RouteMatch =>
       _dispatch(request', responder, body, m, is_head)
     | let na: _MethodNotAllowed =>
       // Path exists but method not allowed — run interceptors then send 405
       match _RunRequestInterceptors(request', na.interceptors)
       | let respond: InterceptRespond =>
-        let buf = _BufferedResponse._from_intercept_respond(respond, is_head)
+        let buf =
+          _BufferedResponse._from_intercept_respond(
+            respond, is_head)
         let ctx = ResponseContext._create(buf, request')
         _RunResponseInterceptors(ctx, na.response_interceptors)
         responder.respond(buf._build())
         return
       end
-      let allow_value: String val = ", ".join(
-        na.allowed_methods.values())
-      let buf = _BufferedResponse._standard(
-        stallion.StatusMethodNotAllowed, "Method Not Allowed", is_head)
+      let allow_value: String val =
+        ", ".join(na.allowed_methods.values())
+      let buf =
+        _BufferedResponse._standard(
+          stallion.StatusMethodNotAllowed,
+          "Method Not Allowed",
+          is_head)
       buf.headers.push(("allow", allow_value))
       let ctx = ResponseContext._create(buf, request')
       _RunResponseInterceptors(ctx, na.response_interceptors)
@@ -143,7 +153,9 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
       // Run request interceptors from the traversal — may short-circuit
       match _RunRequestInterceptors(request', miss.interceptors)
       | let respond: InterceptRespond =>
-        let buf = _BufferedResponse._from_intercept_respond(respond, is_head)
+        let buf =
+          _BufferedResponse._from_intercept_respond(
+            respond, is_head)
         let ctx = ResponseContext._create(buf, request')
         _RunResponseInterceptors(ctx, miss.response_interceptors)
         responder.respond(buf._build())
@@ -151,21 +163,27 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
       end
       // No interceptor short-circuit — send 404 with accumulated response
       // interceptors
-      let buf = _BufferedResponse._standard(
-        stallion.StatusNotFound, "Not Found", is_head)
+      let buf =
+        _BufferedResponse._standard(
+          stallion.StatusNotFound, "Not Found", is_head)
       let ctx = ResponseContext._create(buf, request')
       _RunResponseInterceptors(ctx, miss.response_interceptors)
       responder.respond(buf._build())
     end
 
-  fun ref _dispatch(request': stallion.Request val,
-    responder: stallion.Responder, body: Array[U8] val,
-    m: _RouteMatch, is_head: Bool)
+  fun ref _dispatch(
+    request': stallion.Request val,
+    responder: stallion.Responder,
+    body: Array[U8] val,
+    m: _RouteMatch,
+    is_head: Bool)
   =>
     // Run request interceptors — short-circuit before creating handler state
     match _RunRequestInterceptors(request', m.interceptors)
     | let respond: InterceptRespond =>
-      let buf = _BufferedResponse._from_intercept_respond(respond, is_head)
+      let buf =
+        _BufferedResponse._from_intercept_respond(
+          respond, is_head)
       let ctx = ResponseContext._create(buf, request')
       _RunResponseInterceptors(ctx, m.response_interceptors)
       responder.respond(buf._build())
@@ -182,10 +200,16 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
 
     let conn_tag: _ConnectionProtocol tag = this
 
-    let handler_ctx: HandlerContext iso = recover iso
-      HandlerContext._create(request', m.params, body,
-        conn_tag, token, is_head)
-    end
+    let handler_ctx: HandlerContext iso =
+      recover iso
+        HandlerContext._create(
+          request',
+          m.params,
+          body,
+          conn_tag,
+          token,
+          is_head)
+      end
 
     let handler_receiver = m.factory(consume handler_ctx)
     _handler = handler_receiver
@@ -194,32 +218,41 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
 
     // Start timeout timer (if timeouts enabled)
     if _timeout_ns > 0 then
-      let timer = Timer(
-        _HandlerTimeoutNotify(this, token), _timeout_ns, _timeout_ns)
+      let timer =
+        Timer(
+          _HandlerTimeoutNotify(this, token),
+          _timeout_ns,
+          _timeout_ns)
       let timer_tag: Timer tag = timer
       _handler_timer = timer_tag
       _timers(consume timer)
     end
 
   // --- Handler protocol behaviors ---
-
-  be _handler_respond(token: U64, status: stallion.Status,
-    headers: (stallion.Headers val | None), body': ByteSeq)
+  be _handler_respond(
+    token: U64,
+    status: stallion.Status,
+    headers: (stallion.Headers val | None),
+    body': ByteSeq)
   =>
     if (_state isnt _HandlerInProgress) or (token != _current_token) then
       return
     end
 
-    let buf = match headers
-    | let h: stallion.Headers val =>
-      _BufferedResponse._with_headers(status, h, body', _is_head)
-    else
-      _BufferedResponse._standard(status, body', _is_head)
-    end
+    let buf =
+      match headers
+      | let h: stallion.Headers val =>
+        _BufferedResponse._with_headers(
+          status, h, body', _is_head)
+      else
+        _BufferedResponse._standard(status, body', _is_head)
+      end
 
     _run_after_and_send(buf)
 
-  be _handler_start_streaming(token: U64, status: stallion.Status,
+  be _handler_start_streaming(
+    token: U64,
+    status: stallion.Status,
     headers: (stallion.Headers val | None))
   =>
     if (_state isnt _HandlerInProgress) or (token != _current_token) then
@@ -235,9 +268,11 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
         _last_handler_activity = Time.nanos()
       | stallion.ChunkedNotSupported =>
         // Shouldn't happen — RequestHandler checked HTTP version
-        let buf = _BufferedResponse._standard(
-          stallion.StatusInternalServerError, "Internal Server Error",
-          _is_head)
+        let buf =
+          _BufferedResponse._standard(
+            stallion.StatusInternalServerError,
+            "Internal Server Error",
+            _is_head)
         _run_after_and_send(buf)
       | stallion.AlreadyResponded =>
         // Shouldn't happen — token validated
@@ -246,7 +281,9 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
     end
 
   be _handler_send_chunk(token: U64, data: ByteSeq) =>
-    if (_state isnt _Streaming) or (token != _current_token) then return end
+    if (_state isnt _Streaming) or (token != _current_token) then
+      return
+    end
     match _current_responder
     | let responder: stallion.Responder =>
       responder.send_chunk(data)
@@ -254,35 +291,46 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
     end
 
   be _handler_finish(token: U64) =>
-    if (_state isnt _Streaming) or (token != _current_token) then return end
+    if (_state isnt _Streaming) or (token != _current_token) then
+      return
+    end
     match _current_responder
     | let responder: stallion.Responder =>
       responder.finish_response()
     end
 
-    let status = match _streaming_status
-    | let s: stallion.Status => s
-    else
-      stallion.StatusOK
-    end
-    let buf = _BufferedResponse._streaming_complete(status, _is_head)
+    let status =
+      match _streaming_status
+      | let s: stallion.Status => s
+      else
+        stallion.StatusOK
+      end
+    let buf =
+      _BufferedResponse._streaming_complete(status, _is_head)
     _run_after_and_send(buf)
 
   be _handler_timeout(token: U64) =>
     if token != _current_token then return end
-    if (_state isnt _HandlerInProgress) and (_state isnt _Streaming) then
+    if (_state isnt _HandlerInProgress)
+      and (_state isnt _Streaming)
+    then
       return
     end
 
     // Check if handler was actually idle long enough
     let now = Time.nanos()
-    if (now - _last_handler_activity) < _timeout_ns then return end
+    if (now - _last_handler_activity) < _timeout_ns then
+      return
+    end
 
     match _state
     | _HandlerInProgress =>
       // Send 504 Gateway Timeout
-      let buf = _BufferedResponse._standard(
-        stallion.StatusGatewayTimeout, "Gateway Timeout", _is_head)
+      let buf =
+        _BufferedResponse._standard(
+          stallion.StatusGatewayTimeout,
+          "Gateway Timeout",
+          _is_head)
       // Dispose handler before cleanup
       match _handler
       | let h: HandlerReceiver tag => h.dispose()
@@ -307,12 +355,13 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
     end
 
   // --- Helpers ---
-
   fun ref _run_after_and_send(buf: _BufferedResponse ref) =>
     """
+
     Run response interceptors on the buffered response, send to wire,
     clean up.
     """
+
     match _current_request
     | let req: stallion.Request val =>
       let ctx = ResponseContext._create(buf, req)
@@ -344,7 +393,8 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   fun ref _drain_pending() =>
     while (_state is _Idle) and (_pending_requests.size() > 0) do
       try
-        (let req, let resp, let body) = _pending_requests.shift()?
+        (let req, let resp, let body) =
+          _pending_requests.shift()?
         _process_request(req, resp, body)
       else
         _Unreachable()

--- a/hobby/_connection_protocol.pony
+++ b/hobby/_connection_protocol.pony
@@ -2,13 +2,23 @@ use stallion = "stallion"
 
 trait tag _ConnectionProtocol
   """
+
   Protocol behaviors that `RequestHandler` sends to `_Connection`.
 
   Package-private — users interact with `RequestHandler`, not this interface.
   """
-  be _handler_respond(token: U64, status: stallion.Status,
-    headers: (stallion.Headers val | None), body: ByteSeq)
-  be _handler_start_streaming(token: U64, status: stallion.Status,
+
+  be _handler_respond(
+    token: U64,
+    status: stallion.Status,
+    headers: (stallion.Headers val | None),
+    body: ByteSeq)
+
+  be _handler_start_streaming(
+    token: U64,
+    status: stallion.Status,
     headers: (stallion.Headers val | None))
+
   be _handler_send_chunk(token: U64, data: ByteSeq)
+
   be _handler_finish(token: U64)

--- a/hobby/_e_tag.pony
+++ b/hobby/_e_tag.pony
@@ -1,5 +1,6 @@
 primitive _ETag
   """
+
   Compute and match weak ETags from file metadata.
 
   ETags use the weak format `W/"<inode>-<size>-<mtime_secs>"`, matching the
@@ -9,8 +10,13 @@ primitive _ETag
   On Windows, `FileInfo.inode` is always 0, reducing collision resistance to
   size+mtime only. This is a known limitation.
   """
+
   fun apply(inode: U64, size: USize, mtime: I64): String =>
-    """Compute a weak ETag from file metadata."""
+    """
+
+    Compute a weak ETag from file metadata.
+    """
+
     let inode_str: String val = inode.string()
     let size_str: String val = size.string()
     let mtime_str: String val = mtime.string()
@@ -18,30 +24,32 @@ primitive _ETag
     let len = 4 + inode_str.size() + size_str.size() + mtime_str.size()
     recover val
       String(len)
-        .>append("W/\"")
-        .>append(inode_str)
-        .>push('-')
-        .>append(size_str)
-        .>push('-')
-        .>append(mtime_str)
-        .>push('"')
+        .> append("W/\"")
+        .> append(inode_str)
+        .> push('-')
+        .> append(size_str)
+        .> push('-')
+        .> append(mtime_str)
+        .> push('"')
     end
 
   fun matches(if_none_match: String, server_etag: String): Bool =>
     """
+
     Check if an `If-None-Match` header value matches the server's ETag.
 
     Uses weak comparison per RFC 7232 section 2.3.2: strip the `W/` prefix and
     compare opaque-tags. Handles the `*` wildcard and comma-separated lists.
     """
-    let trimmed = if_none_match.clone().>strip()
+
+    let trimmed = if_none_match.clone() .> strip()
     if trimmed == "*" then return true end
 
     let server_opaque = _opaque_tag(server_etag)
 
     // Split by comma and check each entry
     for entry in trimmed.split(",").values() do
-      let candidate: String val = entry.clone().>strip()
+      let candidate: String val = entry.clone() .> strip()
       if candidate.size() > 0 then
         if _opaque_tag(candidate) == server_opaque then
           return true
@@ -52,12 +60,14 @@ primitive _ETag
 
   fun _opaque_tag(etag: String): String =>
     """
+
     Extract the opaque-tag from an ETag value.
 
     Strips the optional `W/` weak indicator prefix (case-insensitive), then
     strips surrounding double quotes.
     """
-    var s = etag.clone().>strip()
+
+    var s = etag.clone() .> strip()
     // Strip W/ prefix (case-insensitive)
     if (s.size() >= 2) and
       (s.compare_sub("W/", 2, 0, 0, true) is Equal)

--- a/hobby/_file_streamer.pony
+++ b/hobby/_file_streamer.pony
@@ -2,6 +2,7 @@ use "files"
 
 actor _FileStreamer
   """
+
   Read a file in chunks and send them to a `_FileTarget`.
 
   Reads 64 KB chunks using self-directed `_read_next()` messages so the Pony
@@ -15,6 +16,7 @@ actor _FileStreamer
   off. The connection's `throttled()`/`unthrottled()` signals drive this —
   see `_ServeFilesHandler` for the wiring.
   """
+
   let _file: File
   let _target: _FileTarget tag
   var _disposed: Bool = false
@@ -39,11 +41,15 @@ actor _FileStreamer
     end
 
   be pause() =>
-    """Pause the read loop. No further chunks are sent until `resume()`."""
+    """
+    Pause the read loop. No further chunks are sent until `resume()`.
+    """
     _paused = true
 
   be resume() =>
-    """Resume the read loop after a `pause()`. No-op if not paused."""
+    """
+    Resume the read loop after a `pause()`. No-op if not paused.
+    """
     if _paused then
       _paused = false
       if not _disposed then

--- a/hobby/_file_target.pony
+++ b/hobby/_file_target.pony
@@ -1,10 +1,12 @@
 trait tag _FileTarget
   """
+
   Internal interface for `_FileStreamer` to send file chunks to.
 
   Replaces the public `StreamSender` interface for file streaming. The handler
   actor (`_ServeFilesHandler`) implements this and forwards chunks through
   `RequestHandler`.
   """
+
   be _file_chunk(data: Array[U8] val)
   be _file_done()

--- a/hobby/_flatten.pony
+++ b/hobby/_flatten.pony
@@ -1,11 +1,13 @@
 primitive _SplitSegments
   """
+
   Split a normalized path into an array of path segments.
 
   Strips the leading slash and splits on `/`, skipping empty segments
   (which normalizes double slashes). `/api/users/:id` → `["api", "users",
   ":id"]`. `/` → `[]`. `/api//users` → `["api", "users"]`.
   """
+
   fun apply(path: String): Array[String] val =>
     if path.size() <= 1 then
       return recover val Array[String] end
@@ -33,12 +35,17 @@ primitive _SplitSegments
 
 primitive _JoinRemainingSegments
   """
+
   Join segments from a start index onward with `/` separators.
 
   Used to reconstruct the captured value for wildcard parameters.
   """
-  fun apply(segments: Array[String] val, from: USize,
-    size_hint: USize = 0): String
+
+  fun apply(
+    segments: Array[String] val,
+    from: USize,
+    size_hint: USize = 0)
+    : String
   =>
     if from >= segments.size() then
       return ""
@@ -67,6 +74,7 @@ primitive _JoinRemainingSegments
 
 primitive _JoinPath
   """
+
   Join a group prefix with a route path.
 
   Strips any trailing slash from the prefix, then concatenates with the route
@@ -76,6 +84,7 @@ primitive _JoinPath
   Examples: `("/api/", "/users")` -> `"/api/users"`,
   `("/", "/health")` -> `"/health"`, `("", "/health")` -> `"/health"`.
   """
+
   fun apply(prefix: String, path: String): String =>
     if prefix.size() == 0 then
       return path
@@ -89,7 +98,9 @@ primitive _JoinPath
     end
 
 primitive _TrimTrailingSlash
-  """Strip trailing slash from a string (unconditionally)."""
+  """
+  Strip trailing slash from a string (unconditionally).
+  """
   fun apply(s: String): String =>
     try
       if (s.size() > 0) and (s(s.size() - 1)? == '/') then
@@ -102,6 +113,7 @@ primitive _TrimTrailingSlash
 
 primitive _ValidateGroups
   """
+
   Validate group configuration before tree insertion.
 
   Called in `Application.serve()` where the original full prefix strings
@@ -111,6 +123,7 @@ primitive _ValidateGroups
   - Special characters in prefix (`:` or `*`)
   - Overlapping prefixes (two groups with the same prefix)
   """
+
   fun apply(infos: Array[_GroupInfo] box): (ConfigError | None) =>
     for gi in infos.values() do
       if (gi.prefix.size() == 0) or (gi.prefix == "/") then
@@ -149,7 +162,9 @@ primitive _ValidateGroups
     None
 
 primitive _HasSpecialChars
-  """Check if a string contains `:` or `*` (param/wildcard markers)."""
+  """
+  Check if a string contains `:` or `*` (param/wildcard markers).
+  """
   fun apply(s: String box): Bool =>
     var i: USize = 0
     try
@@ -165,20 +180,23 @@ primitive _HasSpecialChars
 
 primitive _ConcatResponseInterceptors
   """
+
   Concatenate two optional response interceptor arrays.
 
   Returns a combined array with outer interceptors first, then inner.
   When one side is `None`, returns the other directly (no allocation).
   When both are `None`, returns `None`.
   """
+
   fun apply(
     outer: (Array[ResponseInterceptor val] val | None),
     inner: (Array[ResponseInterceptor val] val | None))
     : (Array[ResponseInterceptor val] val | None)
   =>
     match (outer, inner)
-    | (let o: Array[ResponseInterceptor val] val,
-       let i: Array[ResponseInterceptor val] val) =>
+    | ( let o: Array[ResponseInterceptor val] val,
+        let i: Array[ResponseInterceptor val] val
+      ) =>
       recover val
         let combined =
           Array[ResponseInterceptor val](o.size() + i.size())
@@ -198,20 +216,23 @@ primitive _ConcatResponseInterceptors
 
 primitive _ConcatInterceptors
   """
+
   Concatenate two optional interceptor arrays.
 
   Returns a combined array with outer interceptors first, then inner.
   When one side is `None`, returns the other directly (no allocation).
   When both are `None`, returns `None`.
   """
+
   fun apply(
     outer: (Array[RequestInterceptor val] val | None),
     inner: (Array[RequestInterceptor val] val | None))
     : (Array[RequestInterceptor val] val | None)
   =>
     match (outer, inner)
-    | (let o: Array[RequestInterceptor val] val,
-       let i: Array[RequestInterceptor val] val) =>
+    | ( let o: Array[RequestInterceptor val] val,
+        let i: Array[RequestInterceptor val] val
+      ) =>
       recover val
         let combined =
           Array[RequestInterceptor val](o.size() + i.size())

--- a/hobby/_group_info.pony
+++ b/hobby/_group_info.pony
@@ -1,5 +1,6 @@
 class val _GroupInfo
   """
+
   Group metadata preserved for tree building.
 
   Carries the fully-joined prefix and interceptors for a route group. Created
@@ -7,6 +8,7 @@ class val _GroupInfo
   `Application.serve()` to tag intermediate tree nodes with group-level
   interceptors via `_RouterBuilder.add_interceptors()`.
   """
+
   let prefix: String
   let interceptors: (Array[RequestInterceptor val] val | None)
   let response_interceptors: (Array[ResponseInterceptor val] val | None)

--- a/hobby/_handler_timeout_notify.pony
+++ b/hobby/_handler_timeout_notify.pony
@@ -2,6 +2,7 @@ use "time"
 
 class iso _HandlerTimeoutNotify is TimerNotify
   """
+
   Timer notify that sends `_handler_timeout(token)` to the connection on
   each interval fire.
 
@@ -9,6 +10,7 @@ class iso _HandlerTimeoutNotify is TimerNotify
   constitute a timeout. The interval-based approach avoids per-chunk timer
   allocation overhead during high-throughput streaming.
   """
+
   let _conn: _Connection tag
   let _token: U64
 

--- a/hobby/_http_date.pony
+++ b/hobby/_http_date.pony
@@ -1,7 +1,8 @@
 use "time"
 
-primitive _HttpDate
+primitive _HTTPDate
   """
+
   Format epoch seconds as an RFC 7231 IMF-fixdate HTTP-date.
 
   The output is always 29 characters in the form:
@@ -12,30 +13,33 @@ primitive _HttpDate
   `ponyc/src/libponyrt/lang/time.c`), so `day_of_week` is 0=Sunday,
   1=Monday, ..., 6=Saturday.
   """
+
   fun apply(seconds: I64): String =>
     let date = PosixDate(seconds)
 
     // tm_wday: 0=Sunday, 1=Monday, ..., 6=Saturday
     let days = ["Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat"]
     // PosixDate.month is 1-indexed
-    let months = [
-      "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun"
-      "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec"
-    ]
+    let months =
+      [ "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun"
+        "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec"
+      ]
 
-    let day_name = try
-      days(date.day_of_week.usize())?
-    else
-      _Unreachable()
-      ""
-    end
+    let day_name =
+      try
+        days(date.day_of_week.usize())?
+      else
+        _Unreachable()
+        ""
+      end
 
-    let month_name = try
-      months((date.month - 1).usize())?
-    else
-      _Unreachable()
-      ""
-    end
+    let month_name =
+      try
+        months((date.month - 1).usize())?
+      else
+        _Unreachable()
+        ""
+      end
 
     let day_str = _pad(date.day_of_month)
     let hour_str = _pad(date.hour)
@@ -44,20 +48,20 @@ primitive _HttpDate
 
     recover val
       String(29)
-        .>append(day_name)
-        .>append(", ")
-        .>append(day_str)
-        .>push(' ')
-        .>append(month_name)
-        .>push(' ')
-        .>append(date.year.string())
-        .>push(' ')
-        .>append(hour_str)
-        .>push(':')
-        .>append(min_str)
-        .>push(':')
-        .>append(sec_str)
-        .>append(" GMT")
+        .> append(day_name)
+        .> append(", ")
+        .> append(day_str)
+        .> push(' ')
+        .> append(month_name)
+        .> push(' ')
+        .> append(date.year.string())
+        .> push(' ')
+        .> append(hour_str)
+        .> push(':')
+        .> append(min_str)
+        .> push(':')
+        .> append(sec_str)
+        .> append(" GMT")
     end
 
   fun _pad(value: I32): String =>

--- a/hobby/_listener.pony
+++ b/hobby/_listener.pony
@@ -4,6 +4,7 @@ use stallion = "stallion"
 
 actor _Listener is lori.TCPListenerActor
   """
+
   Internal TCP listener that accepts connections and spawns connection actors.
 
   Created by `Application.serve()` with a frozen `_Router val`. Each accepted
@@ -13,6 +14,7 @@ actor _Listener is lori.TCPListenerActor
   Interceptors are carried by the router's path tree — the listener no longer
   needs to pass them through separately.
   """
+
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: stallion.ServerConfig
@@ -21,8 +23,12 @@ actor _Listener is lori.TCPListenerActor
   let _timers: Timers tag
   let _timeout_ns: U64
 
-  new create(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
-    router: _Router val, out: OutStream, timeout_ns: U64)
+  new create(
+    auth: lori.TCPListenAuth,
+    config: stallion.ServerConfig,
+    router: _Router val,
+    out: OutStream,
+    timeout_ns: U64)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = config

--- a/hobby/_method_entry.pony
+++ b/hobby/_method_entry.pony
@@ -1,5 +1,6 @@
 class val _MethodEntry
   """
+
   A handler and its per-route interceptors for a specific HTTP method at a
   path node.
 
@@ -7,6 +8,7 @@ class val _MethodEntry
   final pre-computed arrays: accumulated path interceptors concatenated with
   per-route interceptors, computed at freeze time.
   """
+
   let factory: HandlerFactory
   let interceptors: (Array[RequestInterceptor val] val | None)
   let response_interceptors: (Array[ResponseInterceptor val] val | None)

--- a/hobby/_route_definition.pony
+++ b/hobby/_route_definition.pony
@@ -2,6 +2,7 @@ use stallion = "stallion"
 
 class val _RouteDefinition
   """
+
   A route registration captured during route setup.
 
   Stores the HTTP method, path pattern, handler factory, and optional
@@ -11,13 +12,16 @@ class val _RouteDefinition
   interceptors are registered separately on tree nodes — the interceptors
   here are per-route only.
   """
+
   let method: stallion.Method
   let path: String
   let factory: HandlerFactory
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)
 
-  new val create(method': stallion.Method, path': String,
+  new val create(
+    method': stallion.Method,
+    path': String,
     factory': HandlerFactory,
     response_interceptors': (Array[ResponseInterceptor val] val | None),
     interceptors': (Array[RequestInterceptor val] val | None) = None)

--- a/hobby/_route_match.pony
+++ b/hobby/_route_match.pony
@@ -2,12 +2,14 @@ use "collections"
 
 class val _RouteMatch
   """
+
   Result of a successful route lookup.
 
   Contains the handler factory, optional response interceptor and request
   interceptor chains, and extracted route parameters. Produced by
   `_Router.lookup()` when a request path matches a registered route.
   """
+
   let factory: HandlerFactory
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)
@@ -25,6 +27,7 @@ class val _RouteMatch
 
 class val _RouteMiss
   """
+
   Result of a failed route lookup.
 
   Carries accumulated request and response interceptors from the deepest
@@ -32,6 +35,7 @@ class val _RouteMiss
   group prefixes to run on 404 responses — e.g., an auth interceptor on
   `/api` can reject unauthenticated requests to `/api/nonexistent`.
   """
+
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)
 
@@ -43,21 +47,26 @@ class val _RouteMiss
     interceptors = interceptors'
 
   fun _interceptor_count(): USize =>
-    """Total interceptor count — used to compare miss depth."""
-    let req_count = match interceptors
-    | let a: Array[RequestInterceptor val] val => a.size()
-    else
-      0
-    end
-    let resp_count = match response_interceptors
-    | let a: Array[ResponseInterceptor val] val => a.size()
-    else
-      0
-    end
+    """
+    Total interceptor count — used to compare miss depth.
+    """
+    let req_count =
+      match interceptors
+      | let a: Array[RequestInterceptor val] val => a.size()
+      else
+        0
+      end
+    let resp_count =
+      match response_interceptors
+      | let a: Array[ResponseInterceptor val] val => a.size()
+      else
+        0
+      end
     req_count + resp_count
 
 class val _MethodNotAllowed
   """
+
   Result of a lookup where the path exists but no handler matches the
   requested method.
 
@@ -66,6 +75,7 @@ class val _MethodNotAllowed
   still run on 405 responses — an auth interceptor should reject before
   revealing which methods are allowed.
   """
+
   let allowed_methods: Array[String] val
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)

--- a/hobby/_router.pony
+++ b/hobby/_router.pony
@@ -3,6 +3,7 @@ use stallion = "stallion"
 
 class ref _RouterBuilder
   """
+
   Mutable builder for constructing a `_Router`.
 
   Accumulates route definitions and group interceptors into a single shared
@@ -10,6 +11,7 @@ class ref _RouterBuilder
   Configuration errors (e.g., conflicting param names) are accumulated in
   `_errors` and available via `first_error()`.
   """
+
   var _root: _BuildNode ref
   embed _errors: Array[String]
 
@@ -17,28 +19,41 @@ class ref _RouterBuilder
     _root = _BuildNode
     _errors = Array[String]
 
-  fun ref add(method: stallion.Method, path: String,
+  fun ref add(
+    method: stallion.Method,
+    path: String,
     factory: HandlerFactory,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None,
-    interceptors: (Array[RequestInterceptor val] val | None) = None)
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None)
   =>
     """
+
     Register a route handler for a specific method and path.
 
     Per-route interceptors are stored in the method entry at the leaf node.
     Path-level interceptors are registered separately via `add_interceptors()`.
     """
+
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
     let segments = _SplitSegments(normalized)
-    _root._insert_segments(segments, 0, method_key, factory,
-      response_interceptors, interceptors, _errors)
+    _root._insert_segments(
+      segments,
+      0,
+      method_key,
+      factory,
+      response_interceptors,
+      interceptors,
+      _errors)
 
   fun ref add_interceptors(path: String,
     interceptors: (Array[RequestInterceptor val] val | None),
     response_interceptors: (Array[ResponseInterceptor val] val | None))
   =>
     """
+
     Register path-level interceptors on a tree node.
 
     Used for app-level interceptors (on the root node, path `""`) and
@@ -46,6 +61,7 @@ class ref _RouterBuilder
     happens earlier in `Application.serve()` via `_ValidateGroups`.
     `_set_interceptors` concatenates as defense-in-depth.
     """
+
     if (interceptors is None) and (response_interceptors is None) then
       return
     end
@@ -59,14 +75,18 @@ class ref _RouterBuilder
     _root._ensure_path(segments, 0, interceptors, response_interceptors)
 
   fun ref build(): _Router val =>
-    """Freeze the builder into an immutable router."""
+    """
+    Freeze the builder into an immutable router.
+    """
     _Router._create(_root.freeze(None, None))
 
   fun box first_error(): (ConfigError | None) =>
     """
+
     Return the first configuration error detected during route registration,
     or `None` if no errors were found.
     """
+
     if _errors.size() > 0 then
       try
         ConfigError(_errors(0)?)
@@ -80,12 +100,14 @@ class ref _RouterBuilder
 
 class val _Router
   """
+
   Immutable segment trie router with a single shared path tree.
 
   Handlers are keyed by HTTP method at leaf nodes. Interceptors live on
   shared path nodes and are method-independent. `lookup()` finds the matching
   handler, accumulated interceptors, and extracted parameters.
   """
+
   let _root: _TreeNode val
 
   new val _create(root: _TreeNode val) =>
@@ -95,6 +117,7 @@ class val _Router
     (_RouteMatch | _RouteMiss | _MethodNotAllowed)
   =>
     """
+
     Look up a route for the given method and path.
 
     Returns `_RouteMatch` on success, `_RouteMiss` when the path doesn't
@@ -102,6 +125,7 @@ class val _Router
     matches the method. For HEAD requests, automatically falls back to GET
     if no explicit HEAD handler exists.
     """
+
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
     let is_head = method is stallion.HEAD
@@ -109,7 +133,9 @@ class val _Router
     _root.lookup(segments, method_key, is_head, normalized.size())
 
 primitive _NormalizePath
-  """Strip trailing slash (except root `/`)."""
+  """
+  Strip trailing slash (except root `/`).
+  """
   fun apply(path: String): String =>
     try
       if (path.size() > 1) and (path(path.size() - 1)? == '/') then
@@ -121,9 +147,9 @@ primitive _NormalizePath
     path
 
 // --- Mutable build-time node ---
-
 class ref _BuildNode
   """
+
   Mutable segment trie node for route construction.
 
   Used by `_RouterBuilder` during route registration, then frozen into a
@@ -133,6 +159,7 @@ class ref _BuildNode
   - Method-keyed handler entries (from route registration)
   - Static children, param child, and wildcard entries for tree structure
   """
+
   var _interceptors: (Array[RequestInterceptor val] val | None) = None
   var _response_interceptors:
     (Array[ResponseInterceptor val] val | None) = None
@@ -148,9 +175,11 @@ class ref _BuildNode
 
   fun ref _set_interceptors(
     interceptors: (Array[RequestInterceptor val] val | None),
-    response_interceptors: (Array[ResponseInterceptor val] val | None))
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None))
   =>
     """
+
     Set path-level interceptors on this node.
 
     Overlap detection happens earlier in `Application.serve()` via
@@ -158,99 +187,146 @@ class ref _BuildNode
     available for a clear error message. As defense-in-depth,
     concatenates rather than overwrites if interceptors already exist.
     """
+
     _interceptors = _ConcatInterceptors(_interceptors, interceptors)
     _response_interceptors =
-      _ConcatResponseInterceptors(_response_interceptors,
+      _ConcatResponseInterceptors(
+        _response_interceptors,
         response_interceptors)
 
-  fun ref _insert_segments(segments: Array[String] val, idx: USize,
-    method: String, factory: HandlerFactory,
-    response_interceptors: (Array[ResponseInterceptor val] val | None),
-    interceptors: (Array[RequestInterceptor val] val | None),
+  fun ref _insert_segments(
+    segments: Array[String] val,
+    idx: USize,
+    method: String,
+    factory: HandlerFactory,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None),
+    interceptors:
+      (Array[RequestInterceptor val] val | None),
     errors: Array[String] ref)
   =>
-    """Insert a route by walking the segment array."""
+    """
+    Insert a route by walking the segment array.
+    """
     if idx >= segments.size() then
-      _method_entries(method) = _BuildMethodEntry(factory,
-        interceptors, response_interceptors)
+      _method_entries(method) =
+        _BuildMethodEntry(
+          factory, interceptors, response_interceptors)
       return
     end
 
-    let segment = try segments(idx)? else _Unreachable(); return end
-    let first = try segment(0)? else _Unreachable(); return end
+    let segment =
+      try segments(idx)? else _Unreachable(); return end
+    let first =
+      try segment(0)? else _Unreachable(); return end
 
     if first == ':' then
       let name = segment.trim(1)
-      let child = match _param_child
-      | let existing: _BuildNode ref => existing
-      else
-        let c: _BuildNode ref = _BuildNode
-        _param_child = c
-        c
-      end
-      if (child._param_name.size() > 0) and (child._param_name != name) then
+      let child =
+        match _param_child
+        | let existing: _BuildNode ref => existing
+        else
+          let c: _BuildNode ref = _BuildNode
+          _param_child = c
+          c
+        end
+      if (child._param_name.size() > 0)
+        and (child._param_name != name)
+      then
         errors.push(
-          "Conflicting param names at the same path position: ':" +
-          child._param_name + "' vs ':" + name +
-          "'. All methods at the same path must use the same " +
-          "param name.")
+          "Conflicting param names at the same path " +
+          "position: ':" + child._param_name +
+          "' vs ':" + name +
+          "'. All methods at the same path must use " +
+          "the same param name.")
       end
       child._param_name = name
-      child._insert_segments(segments, idx + 1, method, factory,
-        response_interceptors, interceptors, errors)
+      child._insert_segments(
+        segments,
+        idx + 1,
+        method,
+        factory,
+        response_interceptors,
+        interceptors,
+        errors)
     elseif first == '*' then
-      _wildcard_entries(method) = _BuildMethodEntry(factory,
-        interceptors, response_interceptors)
+      _wildcard_entries(method) =
+        _BuildMethodEntry(
+          factory,
+          interceptors,
+          response_interceptors)
       _wildcard_name = segment.trim(1)
     else
-      let child = try _children(segment)? else
-        let c: _BuildNode ref = _BuildNode
-        _children(segment) = c
-        c
-      end
-      child._insert_segments(segments, idx + 1, method, factory,
-        response_interceptors, interceptors, errors)
+      let child =
+        try _children(segment)? else
+          let c: _BuildNode ref = _BuildNode
+          _children(segment) = c
+          c
+        end
+      child._insert_segments(
+        segments,
+        idx + 1,
+        method,
+        factory,
+        response_interceptors,
+        interceptors,
+        errors)
     end
 
-  fun ref _ensure_path(segments: Array[String] val, idx: USize,
-    interceptors: (Array[RequestInterceptor val] val | None),
-    response_interceptors: (Array[ResponseInterceptor val] val | None))
+  fun ref _ensure_path(
+    segments: Array[String] val,
+    idx: USize,
+    interceptors:
+      (Array[RequestInterceptor val] val | None),
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None))
   =>
     """
+
     Traverse or create nodes to reach the given path and set interceptors.
     """
+
     if idx >= segments.size() then
       _set_interceptors(interceptors, response_interceptors)
       return
     end
 
-    let segment = try segments(idx)? else _Unreachable(); return end
-    let child = try _children(segment)? else
-      let c: _BuildNode ref = _BuildNode
-      _children(segment) = c
-      c
-    end
-    child._ensure_path(segments, idx + 1, interceptors,
+    let segment =
+      try segments(idx)? else _Unreachable(); return end
+    let child =
+      try _children(segment)? else
+        let c: _BuildNode ref = _BuildNode
+        _children(segment) = c
+        c
+      end
+    child._ensure_path(
+      segments,
+      idx + 1,
+      interceptors,
       response_interceptors)
 
   fun box freeze(
-    accumulated_interceptors: (Array[RequestInterceptor val] val | None),
+    accumulated_interceptors:
+      (Array[RequestInterceptor val] val | None),
     accumulated_response_interceptors:
       (Array[ResponseInterceptor val] val | None))
     : _TreeNode val
   =>
     """
+
     Create an immutable deep copy of this node tree.
 
     Pre-computes accumulated interceptor arrays from root to each node.
     Per-route interceptors in method entries are concatenated with the
     accumulated path interceptors at freeze time, so lookup is zero-allocation.
     """
+
     // Accumulate this node's interceptors with ancestors'
     let new_accumulated =
       _ConcatInterceptors(accumulated_interceptors, _interceptors)
     let new_accumulated_response =
-      _ConcatResponseInterceptors(accumulated_response_interceptors,
+      _ConcatResponseInterceptors(
+        accumulated_response_interceptors,
         _response_interceptors)
 
     // Freeze children — all children unconditionally receive this node's
@@ -263,12 +339,13 @@ class ref _BuildNode
     end
 
     // Param child gets full accumulated
-    let frozen_param: (_TreeNode val | None) = match _param_child
-    | let child: _BuildNode box =>
-      child.freeze(new_accumulated, new_accumulated_response)
-    else
-      None
-    end
+    let frozen_param: (_TreeNode val | None) =
+      match _param_child
+      | let child: _BuildNode box =>
+        child.freeze(new_accumulated, new_accumulated_response)
+      else
+        None
+      end
 
     // Freeze method entries — concatenate accumulated path interceptors
     // with per-route interceptors
@@ -278,10 +355,14 @@ class ref _BuildNode
       let final_interceptors =
         _ConcatInterceptors(new_accumulated, entry.interceptors)
       let final_response_interceptors =
-        _ConcatResponseInterceptors(new_accumulated_response,
+        _ConcatResponseInterceptors(
+          new_accumulated_response,
           entry.response_interceptors)
-      frozen_method_entries(method) = _MethodEntry(entry.factory,
-        final_interceptors, final_response_interceptors)
+      frozen_method_entries(method) =
+        _MethodEntry(
+          entry.factory,
+          final_interceptors,
+          final_response_interceptors)
     end
 
     let frozen_wildcard_entries: Map[String, _MethodEntry val] iso =
@@ -290,43 +371,56 @@ class ref _BuildNode
       let final_interceptors =
         _ConcatInterceptors(new_accumulated, entry.interceptors)
       let final_response_interceptors =
-        _ConcatResponseInterceptors(new_accumulated_response,
+        _ConcatResponseInterceptors(
+          new_accumulated_response,
           entry.response_interceptors)
-      frozen_wildcard_entries(method) = _MethodEntry(entry.factory,
-        final_interceptors, final_response_interceptors)
+      frozen_wildcard_entries(method) =
+        _MethodEntry(
+          entry.factory,
+          final_interceptors,
+          final_response_interceptors)
     end
 
     _TreeNode._create(
-      new_accumulated, new_accumulated_response,
-      _param_name, consume frozen_children, frozen_param,
-      consume frozen_method_entries, consume frozen_wildcard_entries,
+      new_accumulated,
+      new_accumulated_response,
+      _param_name,
+      consume frozen_children,
+      frozen_param,
+      consume frozen_method_entries,
+      consume frozen_wildcard_entries,
       _wildcard_name)
 
 // --- Build-time method entry (mutable) ---
-
 class ref _BuildMethodEntry
   """
+
   Mutable method entry during tree construction.
 
   Holds the handler factory and per-route interceptors before freeze-time
   concatenation with accumulated path interceptors.
   """
+
   let factory: HandlerFactory
   let interceptors: (Array[RequestInterceptor val] val | None)
-  let response_interceptors: (Array[ResponseInterceptor val] val | None)
+  let response_interceptors:
+    (Array[ResponseInterceptor val] val | None)
 
-  new ref create(factory': HandlerFactory,
-    interceptors': (Array[RequestInterceptor val] val | None),
-    response_interceptors': (Array[ResponseInterceptor val] val | None))
+  new ref create(
+    factory': HandlerFactory,
+    interceptors':
+      (Array[RequestInterceptor val] val | None),
+    response_interceptors':
+      (Array[ResponseInterceptor val] val | None))
   =>
     factory = factory'
     interceptors = interceptors'
     response_interceptors = response_interceptors'
 
 // --- Immutable lookup node ---
-
 class val _TreeNode
   """
+
   Immutable segment trie node for route lookup.
 
   Produced by freezing a `_BuildNode`. Each node stores pre-computed
@@ -338,6 +432,7 @@ class val _TreeNode
   concatenated at freeze time). Lookup is zero-allocation for both hits
   and misses.
   """
+
   let _accumulated_interceptors:
     (Array[RequestInterceptor val] val | None)
   let _accumulated_response_interceptors:
@@ -362,7 +457,8 @@ class val _TreeNode
     wildcard_name: String)
   =>
     _accumulated_interceptors = accumulated_interceptors'
-    _accumulated_response_interceptors = accumulated_response_interceptors'
+    _accumulated_response_interceptors =
+      accumulated_response_interceptors'
     _param_name = param_name
     _children = consume children
     _param_child = param_child
@@ -370,32 +466,48 @@ class val _TreeNode
     _wildcard_entries = consume wildcard_entries
     _wildcard_name = wildcard_name
 
-  fun lookup(segments: Array[String] val, method_key: String,
-    is_head: Bool, path_size: USize):
-    (_RouteMatch | _RouteMiss | _MethodNotAllowed)
+  fun lookup(
+    segments: Array[String] val,
+    method_key: String,
+    is_head: Bool,
+    path_size: USize)
+    : (_RouteMatch | _RouteMiss | _MethodNotAllowed)
   =>
-    """Find a matching route for the given path and method."""
-    match _lookup(segments, 0, method_key, is_head, path_size)
-    | (let entry: _MethodEntry val, let p: Array[(String, String)] val) =>
-      let frozen: Map[String, String] val = recover val
-        let m = Map[String, String]
-        for (k, v) in p.values() do
-          m(k) = v
+    """
+    Find a matching route for the given path and method.
+    """
+    match \exhaustive\ _lookup(
+      segments, 0, method_key, is_head, path_size)
+    | (let entry: _MethodEntry val,
+      let p: Array[(String, String)] val) =>
+      let frozen: Map[String, String] val =
+        recover val
+          let m = Map[String, String]
+          for (k, v) in p.values() do
+            m(k) = v
+          end
+          m
         end
-        m
-      end
-      _RouteMatch(entry.factory, entry.response_interceptors,
-        entry.interceptors, frozen)
+      _RouteMatch(
+        entry.factory,
+        entry.response_interceptors,
+        entry.interceptors,
+        frozen)
     | let miss: _RouteMiss => miss
     | let na: _MethodNotAllowed => na
     end
 
-  fun _lookup(segments: Array[String] val, idx: USize,
-    method_key: String, is_head: Bool, path_size: USize):
-    ((_MethodEntry val, Array[(String, String)] val) |
+  fun _lookup(
+    segments: Array[String] val,
+    idx: USize,
+    method_key: String,
+    is_head: Bool,
+    path_size: USize)
+    : ((_MethodEntry val, Array[(String, String)] val) |
       _RouteMiss | _MethodNotAllowed)
   =>
     """
+
     Recursive lookup returning method entry and accumulated params on hit,
     `_RouteMiss` when the path doesn't exist, or `_MethodNotAllowed` when
     the path exists but no handler matches the requested method.
@@ -403,14 +515,17 @@ class val _TreeNode
     Params are built bottom-up: the leaf returns an empty val array, and each
     param level prepends its parameter to the child's val result.
     """
+
     if idx >= segments.size() then
-      match _resolve_or_405(method_key, is_head, _method_entries)
+      match _resolve_or_405(
+        method_key, is_head, _method_entries)
       | let entry: _MethodEntry val =>
         return (entry, _EmptyParams())
       | let na: _MethodNotAllowed =>
         return na
       end
-      return _RouteMiss(_accumulated_response_interceptors,
+      return _RouteMiss(
+        _accumulated_response_interceptors,
         _accumulated_interceptors)
     end
 
@@ -426,10 +541,14 @@ class val _TreeNode
       let segment = segments(idx)?
       try
         let child = _children(segment)?
-        match child._lookup(segments, idx + 1, method_key, is_head,
+        match \exhaustive\ child._lookup(
+          segments,
+          idx + 1,
+          method_key,
+          is_head,
           path_size)
         | (let entry: _MethodEntry val,
-           let p: Array[(String, String)] val) =>
+          let p: Array[(String, String)] val) =>
           return (entry, p)
         | let na: _MethodNotAllowed =>
           if method_not_allowed is None then
@@ -448,30 +567,42 @@ class val _TreeNode
     | let child: _TreeNode val =>
       try
         let segment = segments(idx)?
-        // _SplitSegments never produces empty segments, but guard defensively
+        // _SplitSegments never produces empty segments,
+        // but guard defensively
         if segment.size() > 0 then
-          match child._lookup(segments, idx + 1, method_key, is_head,
+          match \exhaustive\ child._lookup(
+            segments,
+            idx + 1,
+            method_key,
+            is_head,
             path_size)
           | (let entry: _MethodEntry val,
-             let child_params: Array[(String, String)] val) =>
-            let with_param: Array[(String, String)] val = recover val
-              let a = Array[(String, String)]
-              a.push((child._param_name, segment))
-              for (k, v) in child_params.values() do
-                a.push((k, v))
+            let child_params:
+              Array[(String, String)] val) =>
+            let with_param:
+              Array[(String, String)] val
+            =
+              recover val
+                let a = Array[(String, String)]
+                a.push((child._param_name, segment))
+                for (k, v) in child_params.values() do
+                  a.push((k, v))
+                end
+                a
               end
-              a
-            end
             return (entry, with_param)
           | let na: _MethodNotAllowed =>
             if method_not_allowed is None then
               method_not_allowed = na
             end
           | let miss: _RouteMiss =>
-            // Keep whichever miss traversed deeper (has richer interceptors).
+            // Keep whichever miss traversed deeper
+            // (has richer interceptors).
             match deepest_miss
             | let prev: _RouteMiss =>
-              if miss._interceptor_count() > prev._interceptor_count() then
+              if miss._interceptor_count()
+                > prev._interceptor_count()
+              then
                 deepest_miss = miss
               end
             else
@@ -485,14 +616,18 @@ class val _TreeNode
     end
 
     // Try wildcard (lowest priority)
-    match _resolve_or_405(method_key, is_head, _wildcard_entries)
+    match _resolve_or_405(
+      method_key, is_head, _wildcard_entries)
     | let entry: _MethodEntry val =>
-      let remainder = _JoinRemainingSegments(segments, idx, path_size)
-      let wildcard_params: Array[(String, String)] val = recover val
-        let a = Array[(String, String)]
-        a.push((_wildcard_name, remainder))
-        a
-      end
+      let remainder =
+        _JoinRemainingSegments(segments, idx, path_size)
+      let wildcard_params:
+        Array[(String, String)] val
+      =
+        recover val
+          Array[(String, String)]
+            .> push((_wildcard_name, remainder))
+        end
       return (entry, wildcard_params)
     | let na: _MethodNotAllowed =>
       if method_not_allowed is None then
@@ -510,15 +645,19 @@ class val _TreeNode
     match deepest_miss
     | let miss: _RouteMiss => miss
     else
-      _RouteMiss(_accumulated_response_interceptors,
+      _RouteMiss(
+        _accumulated_response_interceptors,
         _accumulated_interceptors)
     end
 
-  fun _resolve_or_405(method_key: String, is_head: Bool,
+  fun _resolve_or_405(
+    method_key: String,
+    is_head: Bool,
     entries: Map[String, _MethodEntry val] val)
     : (_MethodEntry val | _MethodNotAllowed | None)
   =>
     """
+
     Try to resolve a method entry from the given entries map.
 
     Returns the entry on match, `_MethodNotAllowed` if the map has entries
@@ -527,6 +666,7 @@ class val _TreeNode
     the methods from this specific map — exact-path and wildcard entries
     are never mixed.
     """
+
     try
       return entries(method_key)?
     end
@@ -536,31 +676,39 @@ class val _TreeNode
       end
     end
     if entries.size() > 0 then
-      let allowed: Array[String] val = recover val
-        let methods = Array[String]
-        var has_get = false
-        for k in entries.keys() do
-          methods.push(k)
-          if k == "GET" then has_get = true end
-        end
-        if has_get then
-          var has_head = false
-          for m in methods.values() do
-            if m == "HEAD" then has_head = true; break end
+      let allowed: Array[String] val =
+        recover val
+          let methods = Array[String]
+          var has_get = false
+          for k in entries.keys() do
+            methods.push(k)
+            if k == "GET" then has_get = true end
           end
-          if not has_head then methods.push("HEAD") end
+          if has_get then
+            var has_head = false
+            for m in methods.values() do
+              if m == "HEAD" then
+                has_head = true; break
+              end
+            end
+            if not has_head then
+              methods.push("HEAD")
+            end
+          end
+          methods
         end
-        methods
-      end
-      _MethodNotAllowed(allowed,
-        _accumulated_response_interceptors, _accumulated_interceptors)
+      _MethodNotAllowed(
+        allowed,
+        _accumulated_response_interceptors,
+        _accumulated_interceptors)
     else
       None
     end
 
 // --- Shared constants ---
-
 primitive _EmptyParams
-  """Empty params array returned at leaf nodes. Intermediate recursion levels don't allocate params — only the leaf does."""
+  """
+  Empty params array returned at leaf nodes.
+  """
   fun apply(): Array[(String, String)] val =>
     recover val Array[(String, String)] end

--- a/hobby/_run_request_interceptors.pony
+++ b/hobby/_run_request_interceptors.pony
@@ -2,12 +2,14 @@ use stallion = "stallion"
 
 primitive _RunRequestInterceptors
   """
+
   Run request interceptors in order on a request.
 
   Calls each interceptor and inspects the result. Stops on the first
   `InterceptRespond`. Returns the response if any interceptor short-circuited,
   or `None` if all passed.
   """
+
   fun apply(request: stallion.Request val,
     interceptors: (Array[RequestInterceptor val] val | None))
     : (InterceptRespond | None)

--- a/hobby/_run_response_interceptors.pony
+++ b/hobby/_run_response_interceptors.pony
@@ -1,10 +1,12 @@
 primitive _RunResponseInterceptors
   """
+
   Run response interceptors in order on a ResponseContext.
 
   All interceptors run — there is no short-circuiting. Each interceptor
   sees the response as modified by previous interceptors.
   """
+
   fun apply(ctx: ResponseContext ref,
     interceptors: (Array[ResponseInterceptor val] val | None))
   =>

--- a/hobby/_serve_files_handler.pony
+++ b/hobby/_serve_files_handler.pony
@@ -9,21 +9,25 @@ actor _ServeFilesHandler is (HandlerReceiver & _FileTarget)
   Implements `HandlerReceiver` for lifecycle notifications and `_FileTarget`
   for receiving file data from the streamer.
   """
+
   embed _handler: RequestHandler
   var _streamer: (_FileStreamer | None) = None
 
-  new create(ctx: HandlerContext iso, file: File iso,
+  new create(
+    ctx: HandlerContext iso,
+    file: File iso,
     status: stallion.Status,
     headers: (stallion.Headers val | None))
   =>
     _handler = RequestHandler(consume ctx)
-    match _handler.start_streaming(status, headers)
+    match \exhaustive\ _handler.start_streaming(status, headers)
     | StreamingStarted =>
       _streamer = _FileStreamer(consume file, this)
     | stallion.ChunkedNotSupported =>
       // Shouldn't happen — ServeFiles checked inline. Clean up.
       file.dispose()
-      _handler.respond(stallion.StatusHTTPVersionNotSupported,
+      _handler.respond(
+        stallion.StatusHTTPVersionNotSupported,
         "HTTP Version Not Supported")
     | BodyNotNeeded =>
       // HEAD — already responded, just clean up file

--- a/hobby/_test.pony
+++ b/hobby/_test.pony
@@ -8,7 +8,7 @@ actor \nodoc\ Main is TestList
     _TestRouterList.tests(test)
     _TestRouteGroupList.tests(test)
     _TestContentTypeList.tests(test)
-    _TestHttpDateList.tests(test)
+    _TestHTTPDateList.tests(test)
     _TestETagList.tests(test)
     _TestRequestHandlerList.tests(test)
     _TestRequestInterceptorList.tests(test)

--- a/hobby/_test_content_type.pony
+++ b/hobby/_test_content_type.pony
@@ -3,7 +3,7 @@ use "pony_check"
 
 primitive \nodoc\ _TestContentTypeList
   fun tests(test: PonyTest) =>
-    test(Property1UnitTest[String](_PropertyKnownExtensionMapsToMime))
+    test(Property1UnitTest[String](_PropertyKnownExtensionMapsToMIME))
     test(Property1UnitTest[String](_PropertyUnknownExtensionMapsToOctetStream))
     test(_TestContentTypeCaseInsensitive)
     test(Property1UnitTest[(String, String)](_PropertyOverrideReplacesDefault))
@@ -12,33 +12,39 @@ primitive \nodoc\ _TestContentTypeList
     test(_TestOverrideCaseInsensitive)
 
 // --- Generators ---
-
 primitive \nodoc\ _GenKnownExtension
-  """Generate a known file extension."""
+  """
+  Generate a known file extension.
+  """
   fun apply(): Generator[String] =>
-    Generators.one_of[String]([
-      "html"; "htm"; "css"; "js"; "json"; "xml"; "txt"
-      "png"; "jpg"; "jpeg"; "gif"; "svg"; "ico"
-      "woff"; "woff2"; "pdf"; "wasm"
-    ])
+    Generators.one_of[String](
+      [ "html"; "htm"; "css"; "js"; "json"; "xml"; "txt"
+        "png"; "jpg"; "jpeg"; "gif"; "svg"; "ico"
+        "woff"; "woff2"; "pdf"; "wasm"
+      ])
 
 primitive \nodoc\ _GenUnknownExtension
-  """Generate an extension guaranteed not to be in the known set."""
+  """
+  Generate an extension guaranteed not to be in the known set.
+  """
   fun apply(): Generator[String] =>
     // Use a prefix that can't collide with any known extension
     Generators.ascii(1, 5 where range = ASCIILetters)
-      .map[String]({(s: String): String => "zz" + s})
+      .map[String]({(s: String): String => "zz" + s })
 
-primitive \nodoc\ _GenMimeType
-  """Generate a random MIME-like string."""
+primitive \nodoc\ _GenMIMEType
+  """
+  Generate a random MIME-like string.
+  """
   fun apply(): Generator[String] =>
     Generators.ascii(3, 20 where range = ASCIILetters)
-      .map[String]({(s: String): String => "test/" + s})
+      .map[String]({(s: String): String => "test/" + s })
 
 // --- Property tests ---
-
-class \nodoc\ iso _PropertyKnownExtensionMapsToMime is Property1[String]
-  """Every known extension maps to a non-empty, non-default MIME type."""
+class \nodoc\ iso _PropertyKnownExtensionMapsToMIME is Property1[String]
+  """
+  Every known extension maps to a non-empty, non-default MIME type.
+  """
   fun name(): String => "content-type/property/known extension maps to MIME"
 
   fun gen(): Generator[String] => _GenKnownExtension()
@@ -51,7 +57,9 @@ class \nodoc\ iso _PropertyKnownExtensionMapsToMime is Property1[String]
 
 class \nodoc\ iso _PropertyUnknownExtensionMapsToOctetStream is
   Property1[String]
-  """Unknown extensions map to application/octet-stream."""
+  """
+  Unknown extensions map to application/octet-stream.
+  """
   fun name(): String =>
     "content-type/property/unknown extension maps to octet-stream"
 
@@ -63,12 +71,14 @@ class \nodoc\ iso _PropertyUnknownExtensionMapsToOctetStream is
 
 class \nodoc\ iso _PropertyOverrideReplacesDefault is
   Property1[(String, String)]
-  """Overriding a known extension replaces the default MIME type."""
+  """
+  Overriding a known extension replaces the default MIME type.
+  """
   fun name(): String =>
     "content-type/property/override replaces default"
 
   fun gen(): Generator[(String, String)] =>
-    Generators.zip2[String, String](_GenKnownExtension(), _GenMimeType())
+    Generators.zip2[String, String](_GenKnownExtension(), _GenMIMEType())
 
   fun property(sample: (String, String), h: PropertyHelper) =>
     (let ext, let mime) = sample
@@ -77,12 +87,14 @@ class \nodoc\ iso _PropertyOverrideReplacesDefault is
 
 class \nodoc\ iso _PropertyOverrideAddsNew is
   Property1[(String, String)]
-  """Adding an unknown extension via add makes it resolvable."""
+  """
+  Adding an unknown extension via add makes it resolvable.
+  """
   fun name(): String =>
     "content-type/property/override adds new"
 
   fun gen(): Generator[(String, String)] =>
-    Generators.zip2[String, String](_GenUnknownExtension(), _GenMimeType())
+    Generators.zip2[String, String](_GenUnknownExtension(), _GenMIMEType())
 
   fun property(sample: (String, String), h: PropertyHelper) =>
     (let ext, let mime) = sample
@@ -90,9 +102,10 @@ class \nodoc\ iso _PropertyOverrideAddsNew is
     h.assert_eq[String](mime, ct(ext))
 
 // --- Example-based tests ---
-
 class \nodoc\ iso _TestContentTypeCaseInsensitive is UnitTest
-  """Content-type lookup is case-insensitive."""
+  """
+  Content-type lookup is case-insensitive.
+  """
   fun name(): String => "content-type/case insensitive"
 
   fun apply(h: TestHelper) =>
@@ -103,7 +116,9 @@ class \nodoc\ iso _TestContentTypeCaseInsensitive is UnitTest
     h.assert_eq[String]("text/javascript", ct("Js"))
 
 class \nodoc\ iso _TestOverridePreservesDefaults is UnitTest
-  """Overriding one extension doesn't affect other defaults."""
+  """
+  Overriding one extension doesn't affect other defaults.
+  """
   fun name(): String => "content-type/override preserves defaults"
 
   fun apply(h: TestHelper) =>
@@ -114,7 +129,9 @@ class \nodoc\ iso _TestOverridePreservesDefaults is UnitTest
     h.assert_eq[String]("application/json", ct("json"))
 
 class \nodoc\ iso _TestOverrideCaseInsensitive is UnitTest
-  """Override keys are case-insensitive."""
+  """
+  Override keys are case-insensitive.
+  """
   fun name(): String => "content-type/override case insensitive"
 
   fun apply(h: TestHelper) =>

--- a/hobby/_test_etag.pony
+++ b/hobby/_test_etag.pony
@@ -16,23 +16,28 @@ primitive \nodoc\ _TestETagList
     test(Property1UnitTest[(U64, USize, I64)](_PropertyETagWildcardMatch))
 
 // --- Example-based tests ---
-
 class \nodoc\ iso _TestETagFormat is UnitTest
-  """ETag has expected W/"inode-size-mtime" format."""
+  """
+  ETag has expected W/"inode-size-mtime" format.
+  """
   fun name(): String => "etag/format"
 
   fun apply(h: TestHelper) =>
     h.assert_eq[String]("W/\"1-2048-12345\"", _ETag(1, 2048, 12345))
 
 class \nodoc\ iso _TestETagDeterministic is UnitTest
-  """Same inputs produce the same ETag."""
+  """
+  Same inputs produce the same ETag.
+  """
   fun name(): String => "etag/deterministic"
 
   fun apply(h: TestHelper) =>
     h.assert_eq[String](_ETag(42, 1024, 99999), _ETag(42, 1024, 99999))
 
 class \nodoc\ iso _TestETagExactMatch is UnitTest
-  """Exact weak ETag match."""
+  """
+  Exact weak ETag match.
+  """
   fun name(): String => "etag/matches/exact"
 
   fun apply(h: TestHelper) =>
@@ -40,21 +45,27 @@ class \nodoc\ iso _TestETagExactMatch is UnitTest
     h.assert_true(_ETag.matches(etag, etag))
 
 class \nodoc\ iso _TestETagWildcard is UnitTest
-  """`*` matches any ETag."""
+  """
+  `*` matches any ETag.
+  """
   fun name(): String => "etag/matches/wildcard"
 
   fun apply(h: TestHelper) =>
     h.assert_true(_ETag.matches("*", _ETag(1, 20, 12345)))
 
 class \nodoc\ iso _TestETagNoMatch is UnitTest
-  """Non-matching ETag."""
+  """
+  Non-matching ETag.
+  """
   fun name(): String => "etag/matches/no match"
 
   fun apply(h: TestHelper) =>
     h.assert_false(_ETag.matches("W/\"9-9-9\"", _ETag(1, 20, 12345)))
 
 class \nodoc\ iso _TestETagCommaSeparatedMatch is UnitTest
-  """Comma-separated list with a match."""
+  """
+  Comma-separated list with a match.
+  """
   fun name(): String => "etag/matches/comma separated match"
 
   fun apply(h: TestHelper) =>
@@ -62,7 +73,9 @@ class \nodoc\ iso _TestETagCommaSeparatedMatch is UnitTest
     h.assert_true(_ETag.matches("W/\"a-b-c\", " + etag, etag))
 
 class \nodoc\ iso _TestETagCommaSeparatedNoMatch is UnitTest
-  """Comma-separated list with no match."""
+  """
+  Comma-separated list with no match.
+  """
   fun name(): String => "etag/matches/comma separated no match"
 
   fun apply(h: TestHelper) =>
@@ -70,7 +83,9 @@ class \nodoc\ iso _TestETagCommaSeparatedNoMatch is UnitTest
       _ETag.matches("W/\"a-b-c\", W/\"x-y-z\"", _ETag(1, 20, 12345)))
 
 class \nodoc\ iso _TestETagStrongMatchesWeak is UnitTest
-  """Strong ETag (no W/ prefix) matches weak via weak comparison."""
+  """
+  Strong ETag (no W/ prefix) matches weak via weak comparison.
+  """
   fun name(): String => "etag/matches/strong matches weak"
 
   fun apply(h: TestHelper) =>
@@ -80,7 +95,9 @@ class \nodoc\ iso _TestETagStrongMatchesWeak is UnitTest
     h.assert_true(_ETag.matches("\"1-20-12345\"", etag))
 
 class \nodoc\ iso _TestETagCaseInsensitivePrefix is UnitTest
-  """Lowercase `w/` prefix is treated the same as `W/`."""
+  """
+  Lowercase `w/` prefix is treated the same as `W/`.
+  """
   fun name(): String => "etag/matches/case insensitive prefix"
 
   fun apply(h: TestHelper) =>
@@ -88,9 +105,10 @@ class \nodoc\ iso _TestETagCaseInsensitivePrefix is UnitTest
     h.assert_true(_ETag.matches("w/\"1-20-12345\"", etag))
 
 // --- Property tests ---
-
 class \nodoc\ iso _PropertyETagSelfMatch is Property1[(U64, USize, I64)]
-  """An ETag always matches itself (all three components varied)."""
+  """
+  An ETag always matches itself (all three components varied).
+  """
   fun name(): String => "etag/property/self match"
 
   fun gen(): Generator[(U64, USize, I64)] =>
@@ -103,7 +121,9 @@ class \nodoc\ iso _PropertyETagSelfMatch is Property1[(U64, USize, I64)]
     h.assert_true(_ETag.matches(etag, etag))
 
 class \nodoc\ iso _PropertyETagWildcardMatch is Property1[(U64, USize, I64)]
-  """`*` matches any generated ETag (all three components varied)."""
+  """
+  `*` matches any generated ETag (all three components varied).
+  """
   fun name(): String => "etag/property/wildcard match"
 
   fun gen(): Generator[(U64, USize, I64)] =>

--- a/hobby/_test_http_date.pony
+++ b/hobby/_test_http_date.pony
@@ -1,86 +1,99 @@
 use "pony_test"
 use "pony_check"
 
-primitive \nodoc\ _TestHttpDateList
+primitive \nodoc\ _TestHTTPDateList
   fun tests(test: PonyTest) =>
-    test(_TestHttpDateEpochZero)
-    test(_TestHttpDateSunday)
-    test(_TestHttpDateKnownDate)
-    test(Property1UnitTest[I64](_PropertyHttpDateLength))
-    test(Property1UnitTest[I64](_PropertyHttpDateEndsWithGMT))
-    test(Property1UnitTest[I64](_PropertyHttpDateStartsWithDayName))
-    test(Property1UnitTest[I64](_PropertyHttpDateDayPadded))
+    test(_TestHTTPDateEpochZero)
+    test(_TestHTTPDateSunday)
+    test(_TestHTTPDateKnownDate)
+    test(Property1UnitTest[I64](_PropertyHTTPDateLength))
+    test(Property1UnitTest[I64](_PropertyHTTPDateEndsWithGMT))
+    test(Property1UnitTest[I64](_PropertyHTTPDateStartsWithDayName))
+    test(Property1UnitTest[I64](_PropertyHTTPDateDayPadded))
 
 // --- Generators ---
-
 primitive \nodoc\ _GenEpochSeconds
-  """Generate non-negative epoch seconds for HTTP date testing."""
+  """
+  Generate non-negative epoch seconds for HTTP date testing.
+  """
   fun apply(): Generator[I64] =>
     // Range from 0 to ~year 2100 (4102444800)
     Generators.i64(0, 4_102_444_800)
 
 // --- Example-based tests ---
-
-class \nodoc\ iso _TestHttpDateEpochZero is UnitTest
-  """Epoch 0 formats as Thu, 01 Jan 1970 00:00:00 GMT."""
+class \nodoc\ iso _TestHTTPDateEpochZero is UnitTest
+  """
+  Epoch 0 formats as Thu, 01 Jan 1970 00:00:00 GMT.
+  """
   fun name(): String => "http-date/epoch zero"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String]("Thu, 01 Jan 1970 00:00:00 GMT", _HttpDate(0))
+    h.assert_eq[String]("Thu, 01 Jan 1970 00:00:00 GMT", _HTTPDate(0))
 
-class \nodoc\ iso _TestHttpDateSunday is UnitTest
+class \nodoc\ iso _TestHTTPDateSunday is UnitTest
   """
+
   Known Sunday date guards against day_of_week indexing bugs.
   Jan 4, 1970 (epoch 259200) is a Sunday.
   """
+
   fun name(): String => "http-date/sunday"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String]("Sun, 04 Jan 1970 00:00:00 GMT", _HttpDate(259200))
+    h.assert_eq[String]("Sun, 04 Jan 1970 00:00:00 GMT", _HTTPDate(259200))
 
-class \nodoc\ iso _TestHttpDateKnownDate is UnitTest
-  """Known date in a different month and year for coverage."""
+class \nodoc\ iso _TestHTTPDateKnownDate is UnitTest
+  """
+  Known date in a different month and year for coverage.
+  """
   fun name(): String => "http-date/known date"
 
   fun apply(h: TestHelper) =>
     // 2024-07-15 14:30:00 UTC = 1721053800
     // July 15, 2024 is a Monday
     h.assert_eq[String](
-      "Mon, 15 Jul 2024 14:30:00 GMT", _HttpDate(1_721_053_800))
+      "Mon, 15 Jul 2024 14:30:00 GMT", _HTTPDate(1_721_053_800))
 
 // --- Property tests ---
-
-class \nodoc\ iso _PropertyHttpDateLength is Property1[I64]
-  """IMF-fixdate is always 29 characters."""
+class \nodoc\ iso _PropertyHTTPDateLength is Property1[I64]
+  """
+  IMF-fixdate is always 29 characters.
+  """
   fun name(): String => "http-date/property/length is 29"
 
   fun gen(): Generator[I64] => _GenEpochSeconds()
 
   fun property(seconds: I64, h: PropertyHelper) =>
-    h.assert_eq[USize](29, _HttpDate(seconds).size())
+    h.assert_eq[USize](29, _HTTPDate(seconds).size())
 
-class \nodoc\ iso _PropertyHttpDateEndsWithGMT is Property1[I64]
-  """Output always ends with ' GMT'."""
+class \nodoc\ iso _PropertyHTTPDateEndsWithGMT is Property1[I64]
+  """
+  Output always ends with ' GMT'.
+  """
   fun name(): String => "http-date/property/ends with GMT"
 
   fun gen(): Generator[I64] => _GenEpochSeconds()
 
   fun property(seconds: I64, h: PropertyHelper) =>
-    let result = _HttpDate(seconds)
-    h.assert_true(result.contains(" GMT"),
+    let result = _HTTPDate(seconds)
+    h.assert_true(
+      result.contains(" GMT"),
       "Expected ' GMT' suffix in: " + result)
 
-class \nodoc\ iso _PropertyHttpDateStartsWithDayName is Property1[I64]
-  """Output always starts with a valid 3-letter day name followed by ', '."""
+class \nodoc\ iso _PropertyHTTPDateStartsWithDayName is Property1[I64]
+  """
+  Output always starts with a valid 3-letter day name followed by ', '.
+  """
   fun name(): String => "http-date/property/starts with day name"
 
   fun gen(): Generator[I64] => _GenEpochSeconds()
 
   fun property(seconds: I64, h: PropertyHelper) =>
-    let result = _HttpDate(seconds)
-    let valid_prefixes = [
-      "Sun, "; "Mon, "; "Tue, "; "Wed, "; "Thu, "; "Fri, "; "Sat, "
-    ]
+    let result = _HTTPDate(seconds)
+    let valid_prefixes =
+      [ "Sun, "; "Mon, "; "Tue, "; "Wed, "
+        "Thu, "; "Fri, "; "Sat, "
+      ]
     var found = false
     for prefix in valid_prefixes.values() do
       if result.substring(0, 5) == prefix then
@@ -88,24 +101,29 @@ class \nodoc\ iso _PropertyHttpDateStartsWithDayName is Property1[I64]
         break
       end
     end
-    h.assert_true(found,
+    h.assert_true(
+      found,
       "Expected valid day prefix in: " + result)
 
-class \nodoc\ iso _PropertyHttpDateDayPadded is Property1[I64]
-  """Day-of-month is always 2 digits (zero-padded)."""
+class \nodoc\ iso _PropertyHTTPDateDayPadded is Property1[I64]
+  """
+  Day-of-month is always 2 digits (zero-padded).
+  """
   fun name(): String => "http-date/property/day is 2 digits"
 
   fun gen(): Generator[I64] => _GenEpochSeconds()
 
   fun property(seconds: I64, h: PropertyHelper) =>
-    let result = _HttpDate(seconds)
+    let result = _HTTPDate(seconds)
     // Day-of-month occupies positions 5-6 in "Thu, 01 Jan 1970..."
     try
       let d1 = result(5)?
       let d2 = result(6)?
-      h.assert_true((d1 >= '0') and (d1 <= '9'),
+      h.assert_true(
+        (d1 >= '0') and (d1 <= '9'),
         "Day digit 1 not numeric in: " + result)
-      h.assert_true((d2 >= '0') and (d2 <= '9'),
+      h.assert_true(
+        (d2 >= '0') and (d2 <= '9'),
         "Day digit 2 not numeric in: " + result)
     else
       h.fail("Could not access day digits in: " + result)

--- a/hobby/_test_integration.pony
+++ b/hobby/_test_integration.pony
@@ -35,13 +35,16 @@ primitive \nodoc\ _TestIntegrationList
     test(_TestMethodNotAllowed405)
 
 // --- Test helpers ---
-
 primitive \nodoc\ _TestHost
   fun apply(): String =>
     ifdef linux then "127.0.0.2" else "localhost" end
 
-actor \nodoc\ _TestClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
-  """Simple TCP client that sends raw HTTP and collects the response."""
+actor \nodoc\ _TestClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
+  """
+  Simple TCP client that sends raw HTTP and collects the response.
+  """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
@@ -49,15 +52,22 @@ actor \nodoc\ _TestClient is (lori.TCPConnectionActor & lori.ClientLifecycleEven
   let _listener: _TestIntegrationListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, expected: String,
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    expected: String,
     listener: _TestIntegrationListener)
   =>
     _h = h
     _request = request
     _expected = expected
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -90,10 +100,14 @@ actor \nodoc\ _TestIntegrationListener is lori.TCPListenerActor
   let _run_client:
     {(TestHelper, String, _TestIntegrationListener)} val
 
-  new create(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
-    router: _Router val, h: TestHelper,
+  new create(
+    auth: lori.TCPListenAuth,
+    config: stallion.ServerConfig,
+    router: _Router val,
+    h: TestHelper,
     run_client:
-      {(TestHelper, String, _TestIntegrationListener)} val)
+      {(TestHelper, String,
+        _TestIntegrationListener)} val)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = config
@@ -101,7 +115,9 @@ actor \nodoc\ _TestIntegrationListener is lori.TCPListenerActor
     _timers = Timers
     _h = h
     _run_client = run_client
-    _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
+    _tcp_listener =
+      lori.TCPListener(
+        auth, config.host, config.port, this)
 
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
@@ -126,7 +142,6 @@ actor \nodoc\ _TestIntegrationListener is lori.TCPListenerActor
     _timers.dispose()
 
 // --- Test factories ---
-
 primitive \nodoc\ _HelloFactory
   fun apply(ctx: HandlerContext iso): (HandlerReceiver tag | None) =>
     RequestHandler(consume ctx)
@@ -148,7 +163,6 @@ primitive \nodoc\ _EchoBodyFactory
     handler.respond(stallion.StatusOK, handler.body())
 
 // --- Helpers ---
-
 primitive \nodoc\ _IntegrationHelpers
   fun build_router(
     routes: Array[(stallion.Method, String, HandlerFactory)] val,
@@ -162,112 +176,163 @@ primitive \nodoc\ _IntegrationHelpers
     end
     builder.build()
 
-  fun run_test(h: TestHelper, router: _Router val,
-    request: String, expected: String)
+  fun run_test(
+    h: TestHelper,
+    router: _Router val,
+    request: String,
+    expected: String)
   =>
     h.long_test(5_000_000_000)
     let host = _TestHost()
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    _TestIntegrationListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    _TestIntegrationListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestIntegrationListener) =>
-        _TestClient(connect_auth, host, port, h', request, expected,
+        _TestClient(
+          connect_auth,
+          host,
+          port,
+          h',
+          request,
+          expected,
           listener)
       })
 
 // --- Integration tests ---
-
 class \nodoc\ iso _TestBasicGet is UnitTest
-  """Basic GET returns 200 + body."""
+  """
+  Basic GET returns 200 + body.
+  """
   fun name(): String => "integration/basic GET"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello from Hobby!")
 
 class \nodoc\ iso _TestUnknownPath404 is UnitTest
-  """Unknown path returns 404."""
+  """
+  Unknown path returns 404.
+  """
   fun name(): String => "integration/unknown path 404"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Not Found")
 
 class \nodoc\ iso _TestNamedParams is UnitTest
-  """Named params delivered to handler."""
+  """
+  Named params delivered to handler.
+  """
   fun name(): String => "integration/named params"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/greet/:name", _GreetFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/greet/:name", _GreetFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /greet/World HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello, World!")
 
 class \nodoc\ iso _TestPostWithBody is UnitTest
-  """POST with body: handler receives body bytes."""
+  """
+  POST with body: handler receives body bytes.
+  """
   fun name(): String => "integration/POST with body"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.POST, "/echo", _EchoBodyFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.POST, "/echo", _EchoBodyFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "POST /echo HTTP/1.1\r\nHost: localhost\r\n" +
         "Content-Length: 11\r\n\r\nHello Body!",
       "Hello Body!")
 
 class \nodoc\ iso _TestMultipleRoutes is UnitTest
-  """Multiple routes dispatch correctly."""
+  """
+  Multiple routes dispatch correctly.
+  """
   fun name(): String => "integration/multiple routes"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [ (stallion.GET, "/", _HelloFactory)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [ (stallion.GET, "/", _HelloFactory)
         (stallion.GET, "/greet/:name", _GreetFactory) ]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /greet/Pony HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello, Pony!")
 
 class \nodoc\ iso _TestGroupedRoute is UnitTest
-  """Route at a group-prefixed path resolves correctly."""
+  """
+  Route at a group-prefixed path resolves correctly.
+  """
   fun name(): String => "integration/grouped route"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let joined = _JoinPath("/api", "/users")
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, joined, _HelloFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, joined, _HelloFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /api/users HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello from Hobby!")
 
 class \nodoc\ iso _TestNestedGroupIntegration is UnitTest
-  """Nested group path resolves correctly through the HTTP stack."""
+  """
+  Nested group path resolves correctly through the HTTP stack.
+  """
   fun name(): String => "integration/nested group"
 
   fun label(): String => "integration"
@@ -275,22 +340,29 @@ class \nodoc\ iso _TestNestedGroupIntegration is UnitTest
   fun apply(h: TestHelper) =>
     let inner_path = _JoinPath("/admin", "/dashboard")
     let outer_path = _JoinPath("/api", inner_path)
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, outer_path, _HelloFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, outer_path, _HelloFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /api/admin/dashboard HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello from Hobby!")
 
 // --- Async handler test ---
-
 actor \nodoc\ _AsyncTestService
-  """Simulates an async service via self-directed message."""
+  """
+  Simulates an async service via self-directed message.
+  """
   be query(requester: _AsyncTestHandler tag) =>
     requester._result("async-response-data")
 
 actor \nodoc\ _AsyncTestHandler is HandlerReceiver
-  """Handler that responds after an async callback."""
+  """
+  Handler that responds after an async callback.
+  """
   embed _handler: RequestHandler
 
   new create(ctx: HandlerContext iso, service: _AsyncTestService tag) =>
@@ -305,32 +377,40 @@ actor \nodoc\ _AsyncTestHandler is HandlerReceiver
   be unthrottled() => None
 
 class \nodoc\ iso _TestAsyncHandler is UnitTest
-  """Async handler responds after receiving a callback from a service."""
+  """
+  Async handler responds after receiving a callback from a service.
+  """
   fun name(): String => "integration/async handler"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let service = _AsyncTestService
-    let factory: HandlerFactory = {(ctx)(service) =>
+    let factory: HandlerFactory =
+      {(ctx)(service) =>
       _AsyncTestHandler(consume ctx, service)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", factory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", factory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "async-response-data")
 
 // --- Streaming chunked not supported test ---
-
 actor \nodoc\ _StreamingFallbackHandler is HandlerReceiver
-  """Starts streaming with fallback for ChunkedNotSupported."""
+  """
+  Starts streaming with fallback for ChunkedNotSupported.
+  """
   embed _handler: RequestHandler
 
   new create(ctx: HandlerContext iso) =>
     _handler = RequestHandler(consume ctx)
-    match _handler.start_streaming(stallion.StatusOK)
+    match \exhaustive\ _handler.start_streaming(stallion.StatusOK)
     | StreamingStarted => _send()
     | stallion.ChunkedNotSupported =>
       _handler.respond(stallion.StatusOK, "chunked-fallback")
@@ -346,26 +426,34 @@ actor \nodoc\ _StreamingFallbackHandler is HandlerReceiver
   be unthrottled() => None
 
 class \nodoc\ iso _TestStreamingChunkedNotSupported is UnitTest
-  """HTTP/1.0 request to streaming handler triggers ChunkedNotSupported fallback."""
+  """
+  HTTP/1.0 request to streaming handler triggers ChunkedNotSupported fallback.
+  """
   fun name(): String => "integration/streaming chunked not supported"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let factory: HandlerFactory = {(ctx) =>
+    let factory: HandlerFactory =
+      {(ctx) =>
       _StreamingFallbackHandler(consume ctx)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", factory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", factory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n",
       "chunked-fallback")
 
 // --- Streaming test handler actor ---
-
 actor \nodoc\ _StreamingTestHandler is HandlerReceiver
-  """Starts streaming and sends numbered chunks."""
+  """
+  Starts streaming and sends numbered chunks.
+  """
   embed _handler: RequestHandler
 
   new create(ctx: HandlerContext iso) =>
@@ -389,9 +477,10 @@ primitive \nodoc\ _StreamingFactory
     _StreamingTestHandler(consume ctx)
 
 // --- Pipelined streaming test handler actor ---
-
 actor \nodoc\ _PipelinedStreamTestHandler is HandlerReceiver
-  """Sends a single marker chunk and finishes."""
+  """
+  Sends a single marker chunk and finishes.
+  """
   embed _handler: RequestHandler
 
   new create(ctx: HandlerContext iso) =>
@@ -413,47 +502,61 @@ primitive \nodoc\ _PipelinedStreamFactory
     _PipelinedStreamTestHandler(consume ctx)
 
 // --- Streaming integration tests ---
-
 class \nodoc\ iso _TestStreamingResponse is UnitTest
-  """Streaming handler delivers chunks to the client."""
+  """
+  Streaming handler delivers chunks to the client.
+  """
   fun name(): String => "integration/streaming response"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _StreamingFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _StreamingFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "chunk-1;")
 
 class \nodoc\ iso _TestPipelinedStreaming is UnitTest
   """
+
   Pipelined streaming request is buffered and processed after first stream
   finishes.
   """
+
   fun name(): String => "integration/pipelined streaming"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [ (stallion.GET, "/stream1", _StreamingFactory)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [ (stallion.GET, "/stream1", _StreamingFactory)
         (stallion.GET, "/stream2", _PipelinedStreamFactory) ]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /stream1 HTTP/1.1\r\nHost: localhost\r\n\r\n" +
         "GET /stream2 HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "pipelined-ok")
 
 // --- HEAD test helpers ---
-
-actor \nodoc\ _TestHeadClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+actor \nodoc\ _TestHeadClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
   """
+
   TCP client for HEAD tests: checks that an expected header is present AND
   a forbidden body string is absent.
   """
+
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
@@ -462,16 +565,24 @@ actor \nodoc\ _TestHeadClient is (lori.TCPConnectionActor & lori.ClientLifecycle
   let _listener: _TestIntegrationListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, expect_header: String,
-    forbid_body: String, listener: _TestIntegrationListener)
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    expect_header: String,
+    forbid_body: String,
+    listener: _TestIntegrationListener)
   =>
     _h = h
     _request = request
     _expect_header = expect_header
     _forbid_body = forbid_body
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -482,8 +593,10 @@ actor \nodoc\ _TestHeadClient is (lori.TCPConnectionActor & lori.ClientLifecycle
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expect_header) then
-      _h.assert_false(response_str.contains(_forbid_body),
-        "HEAD response must not contain body: " + _forbid_body)
+      _h.assert_false(
+        response_str.contains(_forbid_body),
+        "HEAD response must not contain body: "
+          + _forbid_body)
       _tcp_connection.close()
       _listener.dispose()
       _h.complete(true)
@@ -497,127 +610,182 @@ actor \nodoc\ _TestHeadClient is (lori.TCPConnectionActor & lori.ClientLifecycle
     _h.complete(false)
 
 // --- HEAD test factory ---
-
 primitive \nodoc\ _HeadOnlyFactory
   fun apply(ctx: HandlerContext iso): (HandlerReceiver tag | None) =>
     RequestHandler(consume ctx)
       .respond(stallion.StatusOK, "HEAD only response")
 
 // --- HEAD helpers ---
-
 primitive \nodoc\ _HeadIntegrationHelpers
-  fun run_head_test(h: TestHelper, router: _Router val,
-    request: String, expect_header: String, forbid_body: String)
+  fun run_head_test(
+    h: TestHelper,
+    router: _Router val,
+    request: String,
+    expect_header: String,
+    forbid_body: String)
   =>
     h.long_test(5_000_000_000)
     let host = _TestHost()
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    _TestIntegrationListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    _TestIntegrationListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestIntegrationListener) =>
-        _TestHeadClient(connect_auth, host, port, h', request,
-          expect_header, forbid_body, listener)
+        _TestHeadClient(
+          connect_auth,
+          host,
+          port,
+          h',
+          request,
+          expect_header,
+          forbid_body,
+          listener)
       })
 
 // --- HEAD integration tests ---
-
 class \nodoc\ iso _TestHeadFallbackToGet is UnitTest
-  """HEAD with no explicit HEAD route falls back to GET handler."""
+  """
+  HEAD with no explicit HEAD route falls back to GET handler.
+  """
   fun name(): String => "integration/HEAD fallback to GET"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end)
-    _HeadIntegrationHelpers.run_head_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end)
+    _HeadIntegrationHelpers.run_head_test(
+      h,
+      router,
       "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n",
-      "content-length: 17", "Hello from Hobby!")
+      "content-length: 17",
+      "Hello from Hobby!")
 
 class \nodoc\ iso _TestHeadExplicitRoute is UnitTest
-  """Explicit HEAD route takes precedence over GET fallback."""
+  """
+  Explicit HEAD route takes precedence over GET fallback.
+  """
   fun name(): String => "integration/HEAD explicit route"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [ (stallion.HEAD, "/", _HeadOnlyFactory)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [ (stallion.HEAD, "/", _HeadOnlyFactory)
         (stallion.GET, "/", _HelloFactory) ]
-    end)
-    _HeadIntegrationHelpers.run_head_test(h, router,
+        end)
+    _HeadIntegrationHelpers.run_head_test(
+      h,
+      router,
       "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n",
-      "content-length: 18", "HEAD only response")
+      "content-length: 18",
+      "HEAD only response")
 
 class \nodoc\ iso _TestHead404 is UnitTest
-  """HEAD to nonexistent path returns 404 headers without body."""
+  """
+  HEAD to nonexistent path returns 404 headers without body.
+  """
   fun name(): String => "integration/HEAD 404"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end)
     // Forbid "\r\n\r\nNot Found" (body after headers), not just "Not Found"
     // which also appears in the status line "404 Not Found".
-    _HeadIntegrationHelpers.run_head_test(h, router,
+    _HeadIntegrationHelpers.run_head_test(
+      h,
+      router,
       "HEAD /nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
-      "content-length: 9", "\r\n\r\nNot Found")
+      "content-length: 9",
+      "\r\n\r\nNot Found")
 
 class \nodoc\ iso _TestHeadStreamingHandler is UnitTest
-  """HEAD to streaming handler: returns 200 OK without chunks."""
+  """
+  HEAD to streaming handler: returns 200 OK without chunks.
+  """
   fun name(): String => "integration/HEAD streaming handler"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _StreamingFactory)]
-    end)
-    _HeadIntegrationHelpers.run_head_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _StreamingFactory)]
+        end)
+    _HeadIntegrationHelpers.run_head_test(
+      h,
+      router,
       "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n",
-      "200 OK", "chunk-1;")
+      "200 OK",
+      "chunk-1;")
 
 class \nodoc\ iso _TestHeadPostOnlyRoute is UnitTest
-  """HEAD to POST-only route returns 405 with Allow header."""
+  """
+  HEAD to POST-only route returns 405 with Allow header.
+  """
   fun name(): String => "integration/HEAD on POST-only route"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.POST, "/echo", _EchoBodyFactory)]
-    end)
-    _HeadIntegrationHelpers.run_head_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.POST, "/echo", _EchoBodyFactory)]
+        end)
+    _HeadIntegrationHelpers.run_head_test(
+      h,
+      router,
       "HEAD /echo HTTP/1.1\r\nHost: localhost\r\n\r\n",
-      "405 Method Not Allowed", "\r\n\r\nMethod Not Allowed")
+      "405 Method Not Allowed",
+      "\r\n\r\nMethod Not Allowed")
 
 class \nodoc\ iso _TestHeadStreamingPipelinedGet is UnitTest
   """
+
   HEAD to streaming handler followed by pipelined GET: HEAD completes without
   setting streaming mode, so the GET is NOT buffered and processes immediately.
   """
+
   fun name(): String => "integration/HEAD streaming + pipelined GET"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _StreamingFactory)]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _StreamingFactory)]
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n" +
         "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "chunk-1;")
 
 // --- Handler timeout test ---
-
 primitive \nodoc\ _NeverRespondFactory
-  """Factory that creates a handler actor that never responds."""
+  """
+  Factory that creates a handler actor that never responds.
+  """
   fun apply(ctx: HandlerContext iso): (HandlerReceiver tag | None) =>
     _NeverRespondHandler(consume ctx)
 
@@ -633,7 +801,9 @@ actor \nodoc\ _NeverRespondHandler is HandlerReceiver
   be unthrottled() => None
 
 actor \nodoc\ _TestTimeoutListener is lori.TCPListenerActor
-  """Listener that creates connections with a short handler timeout."""
+  """
+  Listener that creates connections with a short handler timeout.
+  """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: stallion.ServerConfig
@@ -643,10 +813,14 @@ actor \nodoc\ _TestTimeoutListener is lori.TCPListenerActor
   let _run_client:
     {(TestHelper, String, _TestTimeoutListener)} val
 
-  new create(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
-    router: _Router val, h: TestHelper,
+  new create(
+    auth: lori.TCPListenAuth,
+    config: stallion.ServerConfig,
+    router: _Router val,
+    h: TestHelper,
     run_client:
-      {(TestHelper, String, _TestTimeoutListener)} val)
+      {(TestHelper, String,
+        _TestTimeoutListener)} val)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = config
@@ -654,7 +828,9 @@ actor \nodoc\ _TestTimeoutListener is lori.TCPListenerActor
     _timers = Timers
     _h = h
     _run_client = run_client
-    _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
+    _tcp_listener =
+      lori.TCPListener(
+        auth, config.host, config.port, this)
 
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
@@ -679,21 +855,32 @@ actor \nodoc\ _TestTimeoutListener is lori.TCPListenerActor
     _tcp_listener.close()
     _timers.dispose()
 
-actor \nodoc\ _TestTimeoutClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
-  """TCP client for timeout tests that expects 504."""
+actor \nodoc\ _TestTimeoutClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
+  """
+  TCP client for timeout tests that expects 504.
+  """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
   let _listener: _TestTimeoutListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, listener: _TestTimeoutListener)
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    listener: _TestTimeoutListener)
   =>
     _h = h
     _request = request
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -719,7 +906,9 @@ actor \nodoc\ _TestTimeoutClient is (lori.TCPConnectionActor & lori.ClientLifecy
     _h.complete(false)
 
 class \nodoc\ iso _TestHandlerTimeout504 is UnitTest
-  """Handler that never responds gets 504 after timeout."""
+  """
+  Handler that never responds gets 504 after timeout.
+  """
   fun name(): String => "integration/handler timeout 504"
 
   fun label(): String => "integration"
@@ -730,21 +919,33 @@ class \nodoc\ iso _TestHandlerTimeout504 is UnitTest
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _NeverRespondFactory)]
-    end)
-    _TestTimeoutListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _NeverRespondFactory)]
+        end)
+    _TestTimeoutListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestTimeoutListener) =>
-        _TestTimeoutClient(connect_auth, host, port, h',
+        _TestTimeoutClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
           listener)
       })
 
 // --- Streaming timeout test ---
-
 actor \nodoc\ _StreamTimeoutHandler is HandlerReceiver
-  """Starts streaming, sends one chunk, never finishes."""
+  """
+  Starts streaming, sends one chunk, never finishes.
+  """
   embed _handler: RequestHandler
 
   new create(ctx: HandlerContext iso) =>
@@ -759,8 +960,12 @@ actor \nodoc\ _StreamTimeoutHandler is HandlerReceiver
   be throttled() => None
   be unthrottled() => None
 
-actor \nodoc\ _TestStreamTimeoutClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
-  """Accumulates response; expects chunk received then connection closed."""
+actor \nodoc\ _TestStreamTimeoutClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
+  """
+  Accumulates response; expects chunk received then connection closed.
+  """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
@@ -768,13 +973,20 @@ actor \nodoc\ _TestStreamTimeoutClient is (lori.TCPConnectionActor & lori.Client
   var _response: String iso = recover iso String end
   var _got_chunk: Bool = false
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, listener: _TestTimeoutListener)
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    listener: _TestTimeoutListener)
   =>
     _h = h
     _request = request
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -804,7 +1016,9 @@ actor \nodoc\ _TestStreamTimeoutClient is (lori.TCPConnectionActor & lori.Client
     _h.complete(false)
 
 class \nodoc\ iso _TestStreamingTimeout is UnitTest
-  """Streaming handler that never finishes gets connection closed after timeout."""
+  """
+  Streaming handler that never finishes gets connection closed after timeout.
+  """
   fun name(): String => "integration/streaming timeout"
 
   fun label(): String => "integration"
@@ -815,24 +1029,37 @@ class \nodoc\ iso _TestStreamingTimeout is UnitTest
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    let factory: HandlerFactory = {(ctx) =>
+    let factory: HandlerFactory =
+      {(ctx) =>
       _StreamTimeoutHandler(consume ctx)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", factory)]
-    end)
-    _TestTimeoutListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", factory)]
+        end)
+    _TestTimeoutListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestTimeoutListener) =>
-        _TestStreamTimeoutClient(connect_auth, host, port, h',
+        _TestStreamTimeoutClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
           listener)
       })
 
 // --- on_closed dispose test ---
-
 actor \nodoc\ _DisposeCoordinator
-  """Receives handler disposal notification and completes the test."""
+  """
+  Receives handler disposal notification and completes the test.
+  """
   var _h: (TestHelper | None) = None
   var _listener: (_TestIntegrationListener | None) = None
 
@@ -848,11 +1075,14 @@ actor \nodoc\ _DisposeCoordinator
     end
 
 actor \nodoc\ _WaitForDisposeHandler is HandlerReceiver
-  """Handler that never responds. Reports disposal to coordinator."""
+  """
+  Handler that never responds. Reports disposal to coordinator.
+  """
   embed _handler: RequestHandler
   let _coordinator: _DisposeCoordinator tag
 
-  new create(ctx: HandlerContext iso,
+  new create(
+    ctx: HandlerContext iso,
     coordinator: _DisposeCoordinator tag)
   =>
     _handler = RequestHandler(consume ctx)
@@ -865,18 +1095,28 @@ actor \nodoc\ _WaitForDisposeHandler is HandlerReceiver
   be throttled() => None
   be unthrottled() => None
 
-actor \nodoc\ _DisconnectAfterSendClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
-  """Sends a request then closes the connection after a short delay."""
+actor \nodoc\ _DisconnectAfterSendClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
+  """
+  Sends a request then closes the connection after a short delay.
+  """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String)
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String)
   =>
     _h = h
     _request = request
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -899,7 +1139,9 @@ actor \nodoc\ _DisconnectAfterSendClient is (lori.TCPConnectionActor & lori.Clie
     _h.complete(false)
 
 class \nodoc\ iso _TestOnClosedDispose is UnitTest
-  """Client disconnect during active handler fires dispose()."""
+  """
+  Client disconnect during active handler fires dispose().
+  """
   fun name(): String => "integration/on_closed dispose"
 
   fun label(): String => "integration"
@@ -911,24 +1153,38 @@ class \nodoc\ iso _TestOnClosedDispose is UnitTest
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
     let coordinator = _DisposeCoordinator
-    let factory: HandlerFactory = {(ctx)(coordinator) =>
+    let factory: HandlerFactory =
+      {(ctx)(coordinator) =>
       _WaitForDisposeHandler(consume ctx, coordinator)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", factory)]
-    end)
-    _TestIntegrationListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
-        listener: _TestIntegrationListener)(coordinator) =>
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", factory)]
+        end)
+    _TestIntegrationListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
+        listener:
+          _TestIntegrationListener)(coordinator) =>
         coordinator.setup(h', listener)
-        _DisconnectAfterSendClient(connect_auth, host, port, h',
+        _DisconnectAfterSendClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
       })
 
 // --- Pipelined handler-in-progress test ---
-
 actor \nodoc\ _DelayedResponseHandler is HandlerReceiver
-  """Handler that responds via a self-directed behavior hop."""
+  """
+  Handler that responds via a self-directed behavior hop.
+  """
   embed _handler: RequestHandler
 
   new create(ctx: HandlerContext iso) =>
@@ -943,48 +1199,63 @@ actor \nodoc\ _DelayedResponseHandler is HandlerReceiver
   be unthrottled() => None
 
 class \nodoc\ iso _TestPipelinedHandlerInProgress is UnitTest
-  """Pipelined request during _HandlerInProgress is buffered and drained."""
+  """
+  Pipelined request during _HandlerInProgress is buffered and drained.
+  """
   fun name(): String => "integration/pipelined handler in progress"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let factory: HandlerFactory = {(ctx) =>
+    let factory: HandlerFactory =
+      {(ctx) =>
       _DelayedResponseHandler(consume ctx)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [ (stallion.GET, "/slow", factory)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [ (stallion.GET, "/slow", factory)
         (stallion.GET, "/fast", _HelloFactory) ]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /slow HTTP/1.1\r\nHost: localhost\r\n\r\n" +
         "GET /fast HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello from Hobby!")
 
 class \nodoc\ iso _TestPipelinedMultipleRequests is UnitTest
-  """Three pipelined requests where the first two are async: all three drain."""
+  """
+  Three pipelined requests where the first two are async: all three drain.
+  """
   fun name(): String => "integration/pipelined multiple requests"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let factory: HandlerFactory = {(ctx) =>
+    let factory: HandlerFactory =
+      {(ctx) =>
       _DelayedResponseHandler(consume ctx)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [ (stallion.GET, "/slow", factory)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [ (stallion.GET, "/slow", factory)
         (stallion.GET, "/fast", _HelloFactory) ]
-    end)
-    _IntegrationHelpers.run_test(h, router,
+        end)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /slow HTTP/1.1\r\nHost: localhost\r\n\r\n" +
         "GET /slow HTTP/1.1\r\nHost: localhost\r\n\r\n" +
         "GET /fast HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello from Hobby!")
 
 // --- Respond after dispose (late response) test ---
-
 actor \nodoc\ _LateRespondHandler is HandlerReceiver
-  """Handler that responds after its timeout has expired."""
+  """
+  Handler that responds after its timeout has expired.
+  """
   embed _handler: RequestHandler
   let _timers: Timers
 
@@ -992,8 +1263,11 @@ actor \nodoc\ _LateRespondHandler is HandlerReceiver
     _handler = RequestHandler(consume ctx)
     _timers = Timers
     // Fire after 1 second — timeout is 500ms, so this fires after disposal
-    let timer = Timer(
-      _LateRespondNotify(this), 1_000_000_000, 0)
+    let timer =
+      Timer(
+        _LateRespondNotify(this),
+        1_000_000_000,
+        0)
     _timers(consume timer)
 
   be _respond_now() =>
@@ -1009,7 +1283,9 @@ actor \nodoc\ _LateRespondHandler is HandlerReceiver
   be unthrottled() => None
 
 class \nodoc\ iso _LateRespondNotify is TimerNotify
-  """Fires _respond_now on the handler after delay."""
+  """
+  Fires _respond_now on the handler after delay.
+  """
   let _handler: _LateRespondHandler tag
 
   new iso create(handler: _LateRespondHandler tag) =>
@@ -1020,7 +1296,9 @@ class \nodoc\ iso _LateRespondNotify is TimerNotify
     false
 
 class \nodoc\ iso _TestRespondAfterDispose is UnitTest
-  """Late response after timeout is dropped; client sees 504."""
+  """
+  Late response after timeout is dropped; client sees 504.
+  """
   fun name(): String => "integration/respond after dispose"
 
   fun label(): String => "integration"
@@ -1031,37 +1309,59 @@ class \nodoc\ iso _TestRespondAfterDispose is UnitTest
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    let factory: HandlerFactory = {(ctx) =>
+    let factory: HandlerFactory =
+      {(ctx) =>
       _LateRespondHandler(consume ctx)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", factory)]
-    end)
-    _TestTimeoutListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", factory)]
+        end)
+    _TestTimeoutListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestTimeoutListener) =>
-        _TestTimeoutClient(connect_auth, host, port, h',
+        _TestTimeoutClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
           listener)
       })
 
 // --- Normal completion with timeout test ---
-
-actor \nodoc\ _TestTimeoutNormalClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
-  """TCP client that expects a normal response, fails on 504."""
+actor \nodoc\ _TestTimeoutNormalClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
+  """
+  TCP client that expects a normal response, fails on 504.
+  """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
   let _listener: _TestTimeoutListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, listener: _TestTimeoutListener)
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    listener: _TestTimeoutListener)
   =>
     _h = h
     _request = request
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -1090,7 +1390,9 @@ actor \nodoc\ _TestTimeoutNormalClient is (lori.TCPConnectionActor & lori.Client
     _h.complete(false)
 
 class \nodoc\ iso _TestNormalCompletionWithTimeout is UnitTest
-  """Handler completes before timeout — no 504."""
+  """
+  Handler completes before timeout — no 504.
+  """
   fun name(): String => "integration/normal completion with timeout"
 
   fun label(): String => "integration"
@@ -1101,25 +1403,38 @@ class \nodoc\ iso _TestNormalCompletionWithTimeout is UnitTest
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end)
-    _TestTimeoutListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end)
+    _TestTimeoutListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestTimeoutListener) =>
-        _TestTimeoutNormalClient(connect_auth, host, port, h',
+        _TestTimeoutNormalClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
           listener)
       })
 
 // --- Streaming dispose test ---
-
 actor \nodoc\ _StreamingDisposeHandler is HandlerReceiver
-  """Starts streaming, sends a chunk, waits. Reports disposal."""
+  """
+  Starts streaming, sends a chunk, waits. Reports disposal.
+  """
   embed _handler: RequestHandler
   let _coordinator: _DisposeCoordinator tag
 
-  new create(ctx: HandlerContext iso,
+  new create(
+    ctx: HandlerContext iso,
     coordinator: _DisposeCoordinator tag)
   =>
     _handler = RequestHandler(consume ctx)
@@ -1137,7 +1452,9 @@ actor \nodoc\ _StreamingDisposeHandler is HandlerReceiver
   be unthrottled() => None
 
 class \nodoc\ iso _TestOnClosedStreamingDispose is UnitTest
-  """Client disconnect during streaming fires dispose()."""
+  """
+  Client disconnect during streaming fires dispose().
+  """
   fun name(): String => "integration/on_closed streaming dispose"
 
   fun label(): String => "integration"
@@ -1149,33 +1466,52 @@ class \nodoc\ iso _TestOnClosedStreamingDispose is UnitTest
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
     let coordinator = _DisposeCoordinator
-    let factory: HandlerFactory = {(ctx)(coordinator) =>
+    let factory: HandlerFactory =
+      {(ctx)(coordinator) =>
       _StreamingDisposeHandler(consume ctx, coordinator)
     } val
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", factory)]
-    end)
-    _TestIntegrationListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
-        listener: _TestIntegrationListener)(coordinator) =>
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", factory)]
+        end)
+    _TestIntegrationListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
+        listener:
+          _TestIntegrationListener)(coordinator) =>
         coordinator.setup(h', listener)
-        _DisconnectAfterSendClient(connect_auth, host, port, h',
+        _DisconnectAfterSendClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
       })
 
 class \nodoc\ iso _TestMethodNotAllowed405 is UnitTest
-  """GET to a POST-only route returns 405 with Allow header."""
+  """
+  GET to a POST-only route returns 405 with Allow header.
+  """
   fun name(): String => "integration/method not allowed 405"
 
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.POST, "/echo", _EchoBodyFactory)]
-    end)
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.POST, "/echo", _EchoBodyFactory)]
+        end)
     // Check for Allow header — implies 405 status and verifies the header
     // appears on the wire
-    _IntegrationHelpers.run_test(h, router,
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /echo HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "allow: POST")
 

--- a/hobby/_test_request_handler.pony
+++ b/hobby/_test_request_handler.pony
@@ -11,19 +11,25 @@ primitive \nodoc\ _TestRequestHandlerList
     test(_TestSendChunkNotStreaming)
     test(_TestRespondWithHeaders)
     test(_TestStartStreamingHead)
-    test(_TestStartStreamingHttp10)
+    test(_TestStartStreamingHTTP10)
 
 // --- Mock connection ---
-
 actor \nodoc\ _MockConnection is _ConnectionProtocol
-  """Mock connection that accepts all protocol messages as no-ops."""
+  """
+  Mock connection that accepts all protocol messages as no-ops.
+  """
 
-  be _handler_respond(token: U64, status: stallion.Status,
-    headers: (stallion.Headers val | None), body: ByteSeq)
+  be _handler_respond(
+    token: U64,
+    status: stallion.Status,
+    headers: (stallion.Headers val | None),
+    body: ByteSeq)
   =>
     None
 
-  be _handler_start_streaming(token: U64, status: stallion.Status,
+  be _handler_start_streaming(
+    token: U64,
+    status: stallion.Status,
     headers: (stallion.Headers val | None))
   =>
     None
@@ -32,17 +38,24 @@ actor \nodoc\ _MockConnection is _ConnectionProtocol
   be _handler_finish(token: U64) => None
 
 actor \nodoc\ _CountingMockConnection is _ConnectionProtocol
-  """Mock connection that counts protocol calls."""
+  """
+  Mock connection that counts protocol calls.
+  """
   var _respond_count: USize = 0
   var _chunk_count: USize = 0
   var _finish_count: USize = 0
 
-  be _handler_respond(token: U64, status: stallion.Status,
-    headers: (stallion.Headers val | None), body: ByteSeq)
+  be _handler_respond(
+    token: U64,
+    status: stallion.Status,
+    headers: (stallion.Headers val | None),
+    body: ByteSeq)
   =>
     _respond_count = _respond_count + 1
 
-  be _handler_start_streaming(token: U64, status: stallion.Status,
+  be _handler_start_streaming(
+    token: U64,
+    status: stallion.Status,
     headers: (stallion.Headers val | None))
   =>
     None
@@ -53,138 +66,213 @@ actor \nodoc\ _CountingMockConnection is _ConnectionProtocol
   be _handler_finish(token: U64) =>
     _finish_count = _finish_count + 1
 
-  be check_respond_count(h: TestHelper, expected: USize) =>
+  be check_respond_count(
+    h: TestHelper,
+    expected: USize)
+  =>
     h.assert_eq[USize](expected, _respond_count)
     h.complete(true)
 
-  be check_no_streaming(h: TestHelper, expected_respond: USize) =>
-    h.assert_eq[USize](expected_respond, _respond_count,
+  be check_no_streaming(
+    h: TestHelper,
+    expected_respond: USize)
+  =>
+    h.assert_eq[USize](
+      expected_respond,
+      _respond_count,
       "respond count")
-    h.assert_eq[USize](0, _chunk_count, "chunk count")
-    h.assert_eq[USize](0, _finish_count, "finish count")
+    h.assert_eq[USize](
+      0,
+      _chunk_count,
+      "chunk count")
+    h.assert_eq[USize](
+      0,
+      _finish_count,
+      "finish count")
     h.complete(true)
 
 // --- Helper ---
-
 primitive \nodoc\ _MockRequest
   fun apply(): stallion.Request val =>
     let mock_uri = URI(None, None, "/", None, None)
     let mock_headers: stallion.Headers val =
       recover val stallion.Headers end
     let mock_cookies = stallion.ParseCookies("")
-    stallion.Request(stallion.GET, mock_uri, stallion.HTTP11,
-      mock_headers, mock_cookies)
+    stallion.Request(
+      stallion.GET,
+      mock_uri,
+      stallion.HTTP11,
+      mock_headers,
+      mock_cookies)
 
 primitive \nodoc\ _MockHandlerContext
-  fun apply(conn: _ConnectionProtocol tag): HandlerContext iso^ =>
+  fun apply(
+    conn: _ConnectionProtocol tag)
+    : HandlerContext iso^
+  =>
     let params: Map[String, String] val =
       recover val Map[String, String] end
     let body: Array[U8] val = recover val Array[U8] end
     recover iso
-      HandlerContext._create(_MockRequest(), params, body,
-        conn, 1, false)
+      HandlerContext._create(
+        _MockRequest(),
+        params,
+        body,
+        conn,
+        1,
+        false)
     end
 
-primitive \nodoc\ _MockHttp10Request
+primitive \nodoc\ _MockHTTP10Request
   fun apply(): stallion.Request val =>
     let mock_uri = URI(None, None, "/", None, None)
     let mock_headers: stallion.Headers val =
       recover val stallion.Headers end
     let mock_cookies = stallion.ParseCookies("")
-    stallion.Request(stallion.GET, mock_uri, stallion.HTTP10,
-      mock_headers, mock_cookies)
+    stallion.Request(
+      stallion.GET,
+      mock_uri,
+      stallion.HTTP10,
+      mock_headers,
+      mock_cookies)
 
 primitive \nodoc\ _MockHeadHandlerContext
-  fun apply(conn: _ConnectionProtocol tag): HandlerContext iso^ =>
+  fun apply(
+    conn: _ConnectionProtocol tag)
+    : HandlerContext iso^
+  =>
     let params: Map[String, String] val =
       recover val Map[String, String] end
     let body: Array[U8] val = recover val Array[U8] end
     recover iso
-      HandlerContext._create(_MockRequest(), params, body,
-        conn, 1, true)
+      HandlerContext._create(
+        _MockRequest(),
+        params,
+        body,
+        conn,
+        1,
+        true)
     end
 
-primitive \nodoc\ _MockHttp10HandlerContext
-  fun apply(conn: _ConnectionProtocol tag): HandlerContext iso^ =>
+primitive \nodoc\ _MockHTTP10HandlerContext
+  fun apply(
+    conn: _ConnectionProtocol tag)
+    : HandlerContext iso^
+  =>
     let params: Map[String, String] val =
       recover val Map[String, String] end
     let body: Array[U8] val = recover val Array[U8] end
     recover iso
-      HandlerContext._create(_MockHttp10Request(), params, body,
-        conn, 1, false)
+      HandlerContext._create(
+        _MockHTTP10Request(),
+        params,
+        body,
+        conn,
+        1,
+        false)
     end
 
 // --- Tests ---
-
 class \nodoc\ iso _TestStartStreamingAfterRespond is UnitTest
-  """start_streaming() returns BodyNotNeeded after respond() was called."""
-  fun name(): String => "request handler/start_streaming after respond"
+  """
+  start_streaming() returns BodyNotNeeded after respond() was called.
+  """
+  fun name(): String =>
+    "request handler/start_streaming after respond"
 
   fun apply(h: TestHelper) =>
     let mock = _MockConnection
-    let handler = RequestHandler(_MockHandlerContext(mock))
+    let handler =
+      RequestHandler(_MockHandlerContext(mock))
     handler.respond(stallion.StatusOK, "done")
-    let result = handler.start_streaming(stallion.StatusOK)
+    let result =
+      handler.start_streaming(stallion.StatusOK)
     h.assert_true(result is BodyNotNeeded)
 
 class \nodoc\ iso _TestDoubleRespond is UnitTest
-  """Second respond() call is silently ignored."""
+  """
+  Second respond() call is silently ignored.
+  """
   fun name(): String => "request handler/double respond"
 
   fun apply(h: TestHelper) =>
     h.long_test(10_000_000_000)
     let mock = _CountingMockConnection
-    let handler = RequestHandler(_MockHandlerContext(mock))
+    let handler =
+      RequestHandler(_MockHandlerContext(mock))
     handler.respond(stallion.StatusOK, "first")
     handler.respond(stallion.StatusOK, "second")
     mock.check_respond_count(h, 1)
 
 class \nodoc\ iso _TestSendChunkNotStreaming is UnitTest
-  """send_chunk() and finish() are no-ops when not streaming."""
-  fun name(): String => "request handler/send_chunk not streaming"
+  """
+  send_chunk() and finish() are no-ops when not streaming.
+  """
+  fun name(): String =>
+    "request handler/send_chunk not streaming"
 
   fun apply(h: TestHelper) =>
     h.long_test(10_000_000_000)
     let mock = _CountingMockConnection
-    let handler = RequestHandler(_MockHandlerContext(mock))
+    let handler =
+      RequestHandler(_MockHandlerContext(mock))
     handler.respond(stallion.StatusOK, "done")
     handler.send_chunk("ignored")
     handler.finish()
     mock.check_no_streaming(h, 1)
 
 class \nodoc\ iso _TestRespondWithHeaders is UnitTest
-  """respond_with_headers() sends once, second call is ignored."""
-  fun name(): String => "request handler/respond with headers"
+  """
+  respond_with_headers() sends once, second call is ignored.
+  """
+  fun name(): String =>
+    "request handler/respond with headers"
 
   fun apply(h: TestHelper) =>
     h.long_test(10_000_000_000)
     let mock = _CountingMockConnection
-    let handler = RequestHandler(_MockHandlerContext(mock))
+    let handler =
+      RequestHandler(_MockHandlerContext(mock))
     let headers: stallion.Headers val =
-      recover val stallion.Headers .> set("X-Test", "value") end
-    handler.respond_with_headers(stallion.StatusOK, headers, "body")
-    handler.respond_with_headers(stallion.StatusOK, headers, "body2")
+      recover val
+        stallion.Headers .> set("X-Test", "value")
+      end
+    handler.respond_with_headers(
+      stallion.StatusOK, headers, "body")
+    handler.respond_with_headers(
+      stallion.StatusOK, headers, "body2")
     mock.check_respond_count(h, 1)
 
 class \nodoc\ iso _TestStartStreamingHead is UnitTest
-  """start_streaming() returns BodyNotNeeded for HEAD requests."""
-  fun name(): String => "request handler/start_streaming HEAD"
+  """
+  start_streaming() returns BodyNotNeeded for HEAD requests.
+  """
+  fun name(): String =>
+    "request handler/start_streaming HEAD"
 
   fun apply(h: TestHelper) =>
     h.long_test(10_000_000_000)
     let mock = _CountingMockConnection
-    let handler = RequestHandler(_MockHeadHandlerContext(mock))
-    let result = handler.start_streaming(stallion.StatusOK)
+    let handler =
+      RequestHandler(_MockHeadHandlerContext(mock))
+    let result =
+      handler.start_streaming(stallion.StatusOK)
     h.assert_true(result is BodyNotNeeded)
     // HEAD path sends a headers-only respond
     mock.check_respond_count(h, 1)
 
-class \nodoc\ iso _TestStartStreamingHttp10 is UnitTest
-  """start_streaming() returns ChunkedNotSupported for HTTP/1.0."""
-  fun name(): String => "request handler/start_streaming HTTP/1.0"
+class \nodoc\ iso _TestStartStreamingHTTP10 is UnitTest
+  """
+  start_streaming() returns ChunkedNotSupported for HTTP/1.0.
+  """
+  fun name(): String =>
+    "request handler/start_streaming HTTP/1.0"
 
   fun apply(h: TestHelper) =>
     let mock = _MockConnection
-    let handler = RequestHandler(_MockHttp10HandlerContext(mock))
-    let result = handler.start_streaming(stallion.StatusOK)
-    h.assert_true(result is stallion.ChunkedNotSupported)
+    let handler =
+      RequestHandler(_MockHTTP10HandlerContext(mock))
+    let result =
+      handler.start_streaming(stallion.StatusOK)
+    h.assert_true(
+      result is stallion.ChunkedNotSupported)

--- a/hobby/_test_request_interceptor.pony
+++ b/hobby/_test_request_interceptor.pony
@@ -27,7 +27,6 @@ primitive \nodoc\ _TestRequestInterceptorList
     test(_TestInterceptGroup405Integration)
 
 // --- Test interceptors ---
-
 class \nodoc\ val _RejectInterceptor is RequestInterceptor
   fun apply(request: stallion.Request box): InterceptResult =>
     InterceptRespond(stallion.StatusForbidden, "Forbidden by interceptor")
@@ -35,7 +34,7 @@ class \nodoc\ val _RejectInterceptor is RequestInterceptor
 class \nodoc\ val _RejectWithHeaderInterceptor is RequestInterceptor
   fun apply(request: stallion.Request box): InterceptResult =>
     InterceptRespond(stallion.StatusForbidden, "Forbidden")
-      .>set_header("x-interceptor", "rejected")
+      .> set_header("x-interceptor", "rejected")
 
 class \nodoc\ val _PassInterceptor is RequestInterceptor
   fun apply(request: stallion.Request box): InterceptResult =>
@@ -50,7 +49,6 @@ class \nodoc\ val _AuthHeaderInterceptor is RequestInterceptor
     end
 
 // --- InterceptRespond unit tests ---
-
 class \nodoc\ iso _TestInterceptRespondSetHeader is UnitTest
   fun name(): String => "interceptor/reject set_header"
 
@@ -121,7 +119,6 @@ class \nodoc\ iso _TestInterceptRespondAddHeaderMultiple is UnitTest
     h.assert_eq[USize](2, r._headers_size())
 
 // --- _RunRequestInterceptors unit tests ---
-
 class \nodoc\ iso _TestRunInterceptorsNone is UnitTest
   fun name(): String => "interceptor/run interceptors none"
 
@@ -159,7 +156,10 @@ class \nodoc\ iso _TestRunInterceptorsFirstRejectWins is UnitTest
     let request = _InterceptorTestRequest()
     let interceptors: Array[RequestInterceptor val] val =
       recover val
-        [as RequestInterceptor val: _PassInterceptor; _RejectInterceptor; _PassInterceptor]
+        [ as RequestInterceptor val:
+          _PassInterceptor
+          _RejectInterceptor
+          _PassInterceptor]
       end
     match _RunRequestInterceptors(request, interceptors)
     | let r: InterceptRespond =>
@@ -169,7 +169,6 @@ class \nodoc\ iso _TestRunInterceptorsFirstRejectWins is UnitTest
     end
 
 // --- _ConcatInterceptors unit tests ---
-
 class \nodoc\ iso _TestConcatInterceptorsNone is UnitTest
   fun name(): String => "interceptor/concat interceptors none"
 
@@ -218,7 +217,6 @@ class \nodoc\ iso _TestConcatInterceptorsInnerOnly is UnitTest
     end
 
 // --- Integration tests ---
-
 class \nodoc\ iso _TestInterceptRespondIntegration is UnitTest
   fun name(): String => "integration/interceptor reject"
   fun label(): String => "integration"
@@ -227,10 +225,15 @@ class \nodoc\ iso _TestInterceptRespondIntegration is UnitTest
     h.long_test(10_000_000_000)
     let interceptors: Array[RequestInterceptor val] val =
       recover val [as RequestInterceptor val: _RejectInterceptor] end
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end where interceptors' = interceptors)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end
+        where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Forbidden by interceptor")
 
@@ -242,15 +245,22 @@ class \nodoc\ iso _TestInterceptPassIntegration is UnitTest
     h.long_test(10_000_000_000)
     let interceptors: Array[RequestInterceptor val] val =
       recover val [as RequestInterceptor val: _PassInterceptor] end
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end where interceptors' = interceptors)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end
+        where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Hello from Hobby!")
 
 class \nodoc\ iso _TestInterceptGroupIntegration is UnitTest
-  """Interceptors on a route group reject before the handler runs."""
+  """
+  Interceptors on a route group reject before the handler runs.
+  """
   fun name(): String => "integration/interceptor route group"
   fun label(): String => "integration"
 
@@ -261,7 +271,9 @@ class \nodoc\ iso _TestInterceptGroupIntegration is UnitTest
     let builder = _RouterBuilder
     builder.add(stallion.GET, "/api/users", _HelloFactory, None, interceptors)
     let router = builder.build()
-    _IntegrationHelpers.run_test(h, router,
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /api/users HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Forbidden by interceptor")
 
@@ -273,15 +285,22 @@ class \nodoc\ iso _TestAppInterceptIntegration is UnitTest
     h.long_test(10_000_000_000)
     let interceptors: Array[RequestInterceptor val] val =
       recover val [as RequestInterceptor val: _RejectInterceptor] end
-    let router = _IntegrationHelpers.build_router(recover val
-      [(stallion.GET, "/", _HelloFactory)]
-    end where interceptors' = interceptors)
-    _IntegrationHelpers.run_test(h, router,
+    let router =
+      _IntegrationHelpers.build_router(
+        recover val
+          [(stallion.GET, "/", _HelloFactory)]
+        end
+        where interceptors' = interceptors)
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Forbidden by interceptor")
 
 class \nodoc\ iso _TestInterceptGroup404Integration is UnitTest
-  """Group request interceptor fires on 404 under the group's prefix."""
+  """
+  Group request interceptor fires on 404 under the group's prefix.
+  """
   fun name(): String => "integration/interceptor group 404"
   fun label(): String => "integration"
 
@@ -295,12 +314,16 @@ class \nodoc\ iso _TestInterceptGroup404Integration is UnitTest
     let router = builder.build()
     // Request to /api/nonexistent should hit the /api group's interceptor
     // and get rejected with 403 instead of 404
-    _IntegrationHelpers.run_test(h, router,
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /api/nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Forbidden by interceptor")
 
 class \nodoc\ iso _TestInterceptGroup405Integration is UnitTest
-  """Group request interceptor fires on 405 under the group's prefix."""
+  """
+  Group request interceptor fires on 405 under the group's prefix.
+  """
   fun name(): String => "integration/interceptor group 405"
   fun label(): String => "integration"
 
@@ -314,17 +337,22 @@ class \nodoc\ iso _TestInterceptGroup405Integration is UnitTest
     let router = builder.build()
     // GET to POST-only /api/users should hit the /api group's interceptor
     // and get rejected with 403 instead of 405
-    _IntegrationHelpers.run_test(h, router,
+    _IntegrationHelpers.run_test(
+      h,
+      router,
       "GET /api/users HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "Forbidden by interceptor")
 
 // --- Helpers ---
-
 primitive \nodoc\ _InterceptorTestRequest
   fun apply(): stallion.Request val =>
     let mock_uri = URI(None, None, "/", None, None)
     let mock_headers: stallion.Headers val =
       recover val stallion.Headers end
     let mock_cookies = stallion.ParseCookies("")
-    stallion.Request(stallion.GET, mock_uri, stallion.HTTP11,
-      mock_headers, mock_cookies)
+    stallion.Request(
+      stallion.GET,
+      mock_uri,
+      stallion.HTTP11,
+      mock_headers,
+      mock_cookies)

--- a/hobby/_test_response_interceptor.pony
+++ b/hobby/_test_response_interceptor.pony
@@ -31,25 +31,30 @@ primitive \nodoc\ _TestResponseInterceptorList
     test(_TestResponseInterceptorGroupOn404)
 
 // --- Test interceptors ---
-
 class \nodoc\ val _AddHeaderResponseInterceptor is ResponseInterceptor
   let _name: String
   let _value: String
+
   new val create(name': String, value': String) =>
     _name = name'
     _value = value'
+
   fun apply(ctx: ResponseContext ref) =>
     ctx.set_header(_name, _value)
 
 class \nodoc\ val _SetBodyResponseInterceptor is ResponseInterceptor
   let _body: String
+
   new val create(body': String) => _body = body'
+
   fun apply(ctx: ResponseContext ref) =>
     ctx.set_body(_body)
 
 class \nodoc\ val _SetStatusResponseInterceptor is ResponseInterceptor
   let _status: stallion.Status
+
   new val create(status': stallion.Status) => _status = status'
+
   fun apply(ctx: ResponseContext ref) =>
     ctx.set_status(_status)
 
@@ -57,41 +62,54 @@ class \nodoc\ val _NoOpResponseInterceptor is ResponseInterceptor
   fun apply(ctx: ResponseContext ref) => None
 
 // --- Helper ---
-
 primitive \nodoc\ _ResponseInterceptorTestRequest
   fun apply(): stallion.Request val =>
     let mock_uri = URI(None, None, "/", None, None)
     let mock_headers: stallion.Headers val =
       recover val stallion.Headers end
     let mock_cookies = stallion.ParseCookies("")
-    stallion.Request(stallion.GET, mock_uri, stallion.HTTP11,
-      mock_headers, mock_cookies)
+    stallion.Request(
+      stallion.GET,
+      mock_uri,
+      stallion.HTTP11,
+      mock_headers,
+      mock_cookies)
 
 // --- ResponseContext unit tests ---
-
 class \nodoc\ iso _TestResponseContextSetHeader is UnitTest
   fun name(): String => "response interceptor/set_header case insensitive"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "body", false)
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "body", false)
     buf.headers.push(("X-Custom", "old-value"))
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     ctx.set_header("x-custom", "new-value")
     var found_old = false
     var found_new = false
     for (n, v) in buf.headers.values() do
       if n == "X-Custom" then found_old = true end
-      if (n == "x-custom") and (v == "new-value") then found_new = true end
+      if (n == "x-custom") and (v == "new-value") then
+        found_new = true
+      end
     end
     h.assert_false(found_old, "old header should be removed")
     h.assert_true(found_new, "new header should be present")
 
 class \nodoc\ iso _TestResponseContextAddHeader is UnitTest
-  fun name(): String => "response interceptor/add_header multiple"
+  fun name(): String =>
+    "response interceptor/add_header multiple"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "body", false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "body", false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     ctx.add_header("Set-Cookie", "a=1")
     ctx.add_header("Set-Cookie", "b=2")
     var count: USize = 0
@@ -104,92 +122,134 @@ class \nodoc\ iso _TestResponseContextSetStatus is UnitTest
   fun name(): String => "response interceptor/set_status"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "body", false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "body", false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     h.assert_true(ctx.status() is stallion.StatusOK)
     ctx.set_status(stallion.StatusNotFound)
-    h.assert_true(ctx.status() is stallion.StatusNotFound)
+    h.assert_true(
+      ctx.status() is stallion.StatusNotFound)
 
 class \nodoc\ iso _TestResponseContextSetBody is UnitTest
   fun name(): String => "response interceptor/set_body"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "original", false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "original", false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     match ctx.body()
-    | let s: String val => h.assert_eq[String]("original", s)
+    | let s: String val =>
+      h.assert_eq[String]("original", s)
     else
       h.fail("expected string body")
     end
     ctx.set_body("replaced")
     match ctx.body()
-    | let s: String val => h.assert_eq[String]("replaced", s)
+    | let s: String val =>
+      h.assert_eq[String]("replaced", s)
     else
       h.fail("expected string body after set_body")
     end
 
 class \nodoc\ iso _TestResponseContextStreamingNoOps is UnitTest
-  fun name(): String => "response interceptor/streaming no-ops"
+  fun name(): String =>
+    "response interceptor/streaming no-ops"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._streaming_complete(stallion.StatusOK, false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._streaming_complete(
+        stallion.StatusOK, false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     h.assert_true(ctx.is_streaming())
     // All writes should be no-ops
     ctx.set_status(stallion.StatusNotFound)
-    h.assert_true(ctx.status() is stallion.StatusOK,
+    h.assert_true(
+      ctx.status() is stallion.StatusOK,
       "set_status should be no-op for streaming")
     ctx.set_header("x-test", "value")
-    h.assert_eq[USize](0, buf.headers.size(),
+    h.assert_eq[USize](
+      0,
+      buf.headers.size(),
       "set_header should be no-op for streaming")
     ctx.add_header("x-test", "value")
-    h.assert_eq[USize](0, buf.headers.size(),
+    h.assert_eq[USize](
+      0,
+      buf.headers.size(),
       "add_header should be no-op for streaming")
     ctx.set_body("new body")
-    h.assert_true(ctx.body() is None,
+    h.assert_true(
+      ctx.body() is None,
       "set_body should be no-op for streaming")
 
 // --- _RunResponseInterceptors unit tests ---
-
 class \nodoc\ iso _TestRunResponseInterceptorsNone is UnitTest
-  fun name(): String => "response interceptor/run interceptors none"
+  fun name(): String =>
+    "response interceptor/run interceptors none"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "body", false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "body", false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     _RunResponseInterceptors(ctx, None)
     // No error, headers unchanged
     h.assert_eq[USize](0, buf.headers.size())
 
 class \nodoc\ iso _TestRunResponseInterceptorsSingle is UnitTest
-  fun name(): String => "response interceptor/run interceptors single"
+  fun name(): String =>
+    "response interceptor/run interceptors single"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "body", false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "body", false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-custom", "test-value")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-custom", "test-value")]
       end
     _RunResponseInterceptors(ctx, interceptors)
     var found = false
     for (n, v) in buf.headers.values() do
-      if (n == "x-custom") and (v == "test-value") then found = true end
+      if (n == "x-custom") and (v == "test-value") then
+        found = true
+      end
     end
-    h.assert_true(found, "interceptor should have added header")
+    h.assert_true(
+      found, "interceptor should have added header")
 
 class \nodoc\ iso _TestRunResponseInterceptorsMultiple is UnitTest
-  fun name(): String => "response interceptor/run interceptors multiple in order"
+  fun name(): String =>
+    "response interceptor/run interceptors multiple in order"
 
   fun apply(h: TestHelper) =>
-    let buf = _BufferedResponse._standard(stallion.StatusOK, "body", false)
-    let ctx = ResponseContext._create(buf, _ResponseInterceptorTestRequest())
+    let buf =
+      _BufferedResponse._standard(
+        stallion.StatusOK, "body", false)
+    let ctx =
+      ResponseContext._create(
+        buf, _ResponseInterceptorTestRequest())
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-custom", "first")
-          _AddHeaderResponseInterceptor("x-custom", "second")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-custom", "first")
+          _AddHeaderResponseInterceptor(
+            "x-custom", "second")]
       end
     _RunResponseInterceptors(ctx, interceptors)
     // Last set_header wins (replaces)
@@ -201,25 +261,33 @@ class \nodoc\ iso _TestRunResponseInterceptorsMultiple is UnitTest
         last_value = v
       end
     end
-    h.assert_eq[USize](1, count, "set_header should replace")
-    h.assert_eq[String]("second", last_value, "last interceptor wins")
+    h.assert_eq[USize](
+      1, count, "set_header should replace")
+    h.assert_eq[String](
+      "second", last_value, "last interceptor wins")
 
 // --- _ConcatResponseInterceptors unit tests ---
-
 class \nodoc\ iso _TestConcatResponseInterceptorsNone is UnitTest
   fun name(): String => "response interceptor/concat none"
 
   fun apply(h: TestHelper) =>
-    h.assert_true(_ConcatResponseInterceptors(None, None) is None)
+    h.assert_true(
+      _ConcatResponseInterceptors(None, None) is None)
 
 class \nodoc\ iso _TestConcatResponseInterceptorsBoth is UnitTest
   fun name(): String => "response interceptor/concat both"
 
   fun apply(h: TestHelper) =>
     let outer: Array[ResponseInterceptor val] val =
-      recover val [as ResponseInterceptor val: _NoOpResponseInterceptor] end
+      recover val
+        [ as ResponseInterceptor val:
+          _NoOpResponseInterceptor]
+      end
     let inner: Array[ResponseInterceptor val] val =
-      recover val [as ResponseInterceptor val: _NoOpResponseInterceptor] end
+      recover val
+        [ as ResponseInterceptor val:
+          _NoOpResponseInterceptor]
+      end
     match _ConcatResponseInterceptors(outer, inner)
     | let combined: Array[ResponseInterceptor val] val =>
       h.assert_eq[USize](2, combined.size())
@@ -228,11 +296,15 @@ class \nodoc\ iso _TestConcatResponseInterceptorsBoth is UnitTest
     end
 
 class \nodoc\ iso _TestConcatResponseInterceptorsOuterOnly is UnitTest
-  fun name(): String => "response interceptor/concat outer only"
+  fun name(): String =>
+    "response interceptor/concat outer only"
 
   fun apply(h: TestHelper) =>
     let outer: Array[ResponseInterceptor val] val =
-      recover val [as ResponseInterceptor val: _NoOpResponseInterceptor] end
+      recover val
+        [ as ResponseInterceptor val:
+          _NoOpResponseInterceptor]
+      end
     match _ConcatResponseInterceptors(outer, None)
     | let result: Array[ResponseInterceptor val] val =>
       h.assert_eq[USize](1, result.size())
@@ -241,11 +313,15 @@ class \nodoc\ iso _TestConcatResponseInterceptorsOuterOnly is UnitTest
     end
 
 class \nodoc\ iso _TestConcatResponseInterceptorsInnerOnly is UnitTest
-  fun name(): String => "response interceptor/concat inner only"
+  fun name(): String =>
+    "response interceptor/concat inner only"
 
   fun apply(h: TestHelper) =>
     let inner: Array[ResponseInterceptor val] val =
-      recover val [as ResponseInterceptor val: _NoOpResponseInterceptor] end
+      recover val
+        [ as ResponseInterceptor val:
+          _NoOpResponseInterceptor]
+      end
     match _ConcatResponseInterceptors(None, inner)
     | let result: Array[ResponseInterceptor val] val =>
       h.assert_eq[USize](1, result.size())
@@ -254,22 +330,29 @@ class \nodoc\ iso _TestConcatResponseInterceptorsInnerOnly is UnitTest
     end
 
 // --- Integration test infrastructure ---
-
 actor \nodoc\ _TestResponseInterceptorListener is lori.TCPListenerActor
-  """Listener for response interceptor integration tests."""
-  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  """
+  Listener for response interceptor integration tests.
+  """
+  var _tcp_listener: lori.TCPListener =
+    lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _config: stallion.ServerConfig
   let _router: _Router val
   let _timers: Timers tag
   let _h: TestHelper
   let _run_client:
-    {(TestHelper, String, _TestResponseInterceptorListener)} val
+    {(TestHelper, String,
+      _TestResponseInterceptorListener)} val
 
-  new create(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
-    router: _Router val, h: TestHelper,
+  new create(
+    auth: lori.TCPListenAuth,
+    config: stallion.ServerConfig,
+    router: _Router val,
+    h: TestHelper,
     run_client:
-      {(TestHelper, String, _TestResponseInterceptorListener)} val)
+      {(TestHelper, String,
+        _TestResponseInterceptorListener)} val)
   =>
     _server_auth = lori.TCPServerAuth(auth)
     _config = config
@@ -277,16 +360,21 @@ actor \nodoc\ _TestResponseInterceptorListener is lori.TCPListenerActor
     _timers = Timers
     _h = h
     _run_client = run_client
-    _tcp_listener = lori.TCPListener(auth, config.host, config.port, this)
+    _tcp_listener =
+      lori.TCPListener(
+        auth, config.host, config.port, this)
 
-  fun ref _listener(): lori.TCPListener => _tcp_listener
+  fun ref _listener(): lori.TCPListener =>
+    _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    _Connection(_server_auth, fd, _config, _router, _timers, 0)
+    _Connection(
+      _server_auth, fd, _config, _router, _timers, 0)
 
   fun ref _on_listening() =>
     try
-      (_, let port) = _tcp_listener.local_address().name()?
+      (_, let port) =
+        _tcp_listener.local_address().name()?
       _run_client(_h, port, this)
     else
       _h.fail("could not get listener port")
@@ -301,26 +389,40 @@ actor \nodoc\ _TestResponseInterceptorListener is lori.TCPListenerActor
     _tcp_listener.close()
     _timers.dispose()
 
-actor \nodoc\ _TestResponseInterceptorClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
-  """TCP client that checks for an expected string in the response."""
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+actor \nodoc\ _TestResponseInterceptorClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
+  """
+  TCP client that checks for an expected string in
+  the response.
+  """
+  var _tcp_connection: lori.TCPConnection =
+    lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
   let _expected: String
   let _listener: _TestResponseInterceptorListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, expected: String,
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    expected: String,
     listener: _TestResponseInterceptorListener)
   =>
     _h = h
     _request = request
     _expected = expected
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
-  fun ref _connection(): lori.TCPConnection => _tcp_connection
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
 
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
@@ -336,158 +438,254 @@ actor \nodoc\ _TestResponseInterceptorClient is (lori.TCPConnectionActor & lori.
 
   fun ref _on_closed() => None
 
-  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+  fun ref _on_connection_failure(
+    reason: lori.ConnectionFailureReason)
+  =>
     _h.fail("connection failed")
     _listener.dispose()
     _h.complete(false)
 
 primitive \nodoc\ _ResponseInterceptorIntegrationHelpers
-  fun run_test(h: TestHelper, router: _Router val,
-    request: String, expected: String)
+  fun run_test(
+    h: TestHelper,
+    router: _Router val,
+    request: String,
+    expected: String)
   =>
     h.long_test(5_000_000_000)
     let host = _TestHost()
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    _TestResponseInterceptorListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
-        listener: _TestResponseInterceptorListener) =>
-        _TestResponseInterceptorClient(connect_auth, host, port, h',
-          request, expected, listener)
+    _TestResponseInterceptorListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
+        listener:
+          _TestResponseInterceptorListener) =>
+        _TestResponseInterceptorClient(
+          connect_auth,
+          host,
+          port,
+          h',
+          request,
+          expected,
+          listener)
       })
 
 // --- Integration tests ---
-
 class \nodoc\ iso _TestResponseInterceptorSetHeaderIntegration is UnitTest
-  """Response interceptor adds a header on a normal response."""
-  fun name(): String => "integration/response interceptor set header"
+  """
+  Response interceptor adds a header on a normal response.
+  """
+  fun name(): String =>
+    "integration/response interceptor set header"
+
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-custom", "test-value")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-custom", "test-value")]
       end
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/", _HelloFactory, interceptors)
+    builder.add(
+      stallion.GET, "/", _HelloFactory, interceptors)
     let router = builder.build()
-    _ResponseInterceptorIntegrationHelpers.run_test(h, router,
+    _ResponseInterceptorIntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-custom: test-value")
 
 class \nodoc\ iso _TestResponseInterceptorOn404 is UnitTest
-  """App-level response interceptor adds a header on a 404 response."""
-  fun name(): String => "integration/response interceptor on 404"
+  """
+  App-level response interceptor adds a header on a 404
+  response.
+  """
+  fun name(): String =>
+    "integration/response interceptor on 404"
+
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-custom", "on-404")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-custom", "on-404")]
       end
     let builder = _RouterBuilder
     // Register app-level interceptors on root node
     builder.add_interceptors("", None, interceptors)
     builder.add(stallion.GET, "/exists", _HelloFactory)
     let router = builder.build()
-    _ResponseInterceptorIntegrationHelpers.run_test(h, router,
+    _ResponseInterceptorIntegrationHelpers.run_test(
+      h,
+      router,
       "GET /nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-custom: on-404")
 
 class \nodoc\ iso _TestResponseInterceptorOnRejectIntercept is UnitTest
-  """Response interceptor adds a header on a request interceptor short-circuit."""
-  fun name(): String => "integration/response interceptor on reject"
+  """
+  Response interceptor adds a header on a request
+  interceptor short-circuit.
+  """
+  fun name(): String =>
+    "integration/response interceptor on reject"
+
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
-    let response_interceptors: Array[ResponseInterceptor val] val =
+    let response_interceptors:
+      Array[ResponseInterceptor val] val
+    =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-custom", "on-reject")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-custom", "on-reject")]
       end
-    let request_interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let request_interceptors:
+      Array[RequestInterceptor val] val
+    =
+      recover val
+        [ as RequestInterceptor val:
+          _RejectInterceptor]
+      end
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/", _HelloFactory, response_interceptors,
+    builder.add(
+      stallion.GET,
+      "/",
+      _HelloFactory,
+      response_interceptors,
       request_interceptors)
     let router = builder.build()
-    _ResponseInterceptorIntegrationHelpers.run_test(h, router,
+    _ResponseInterceptorIntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-custom: on-reject")
 
 class \nodoc\ iso _TestResponseInterceptorSetBodyIntegration is UnitTest
-  """Response interceptor replaces body, Content-Length auto-updated."""
-  fun name(): String => "integration/response interceptor set body"
+  """
+  Response interceptor replaces body, Content-Length
+  auto-updated.
+  """
+  fun name(): String =>
+    "integration/response interceptor set body"
+
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
+        [ as ResponseInterceptor val:
           _SetBodyResponseInterceptor("replaced-body")]
       end
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/", _HelloFactory, interceptors)
+    builder.add(
+      stallion.GET, "/", _HelloFactory, interceptors)
     let router = builder.build()
-    _ResponseInterceptorIntegrationHelpers.run_test(h, router,
+    _ResponseInterceptorIntegrationHelpers.run_test(
+      h,
+      router,
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "replaced-body")
 
 class \nodoc\ iso _TestResponseInterceptorStreamingIntegration is UnitTest
-  """Response interceptor header write is no-op for streaming responses."""
-  fun name(): String => "integration/response interceptor streaming no-op"
+  """
+  Response interceptor header write is no-op for streaming
+  responses.
+  """
+  fun name(): String =>
+    "integration/response interceptor streaming no-op"
+
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-after-stream", "should-not-appear")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-after-stream", "should-not-appear")]
       end
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/", _StreamingFactory, interceptors)
+    builder.add(
+      stallion.GET,
+      "/",
+      _StreamingFactory,
+      interceptors)
     let router = builder.build()
     h.long_test(5_000_000_000)
     let host = _TestHost()
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
-    let connect_auth = lori.TCPConnectAuth(h.env.root)
-    _TestResponseInterceptorListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
-        listener: _TestResponseInterceptorListener) =>
-        _TestStreamingNoOpClient(connect_auth, host, port, h',
+    let connect_auth =
+      lori.TCPConnectAuth(h.env.root)
+    _TestResponseInterceptorListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
+        listener:
+          _TestResponseInterceptorListener) =>
+        _TestStreamingNoOpClient(
+          connect_auth,
+          host,
+          port,
+          h',
           "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
-          "chunk-1;", "x-after-stream", listener)
+          "chunk-1;",
+          "x-after-stream",
+          listener)
       })
 
 class \nodoc\ iso _TestResponseInterceptorGroupOn404 is UnitTest
-  """Group response interceptor runs on 404 under the group's prefix."""
-  fun name(): String => "integration/response interceptor group on 404"
+  """
+  Group response interceptor runs on 404 under the group's
+  prefix.
+  """
+  fun name(): String =>
+    "integration/response interceptor group on 404"
+
   fun label(): String => "integration"
 
   fun apply(h: TestHelper) =>
     let interceptors: Array[ResponseInterceptor val] val =
       recover val
-        [as ResponseInterceptor val:
-          _AddHeaderResponseInterceptor("x-group", "api-404")]
+        [ as ResponseInterceptor val:
+          _AddHeaderResponseInterceptor(
+            "x-group", "api-404")]
       end
     let builder = _RouterBuilder
-    builder.add_interceptors("/api", None, interceptors)
+    builder.add_interceptors(
+      "/api", None, interceptors)
     builder.add(stallion.GET, "/api/users", _HelloFactory)
     let router = builder.build()
-    _ResponseInterceptorIntegrationHelpers.run_test(h, router,
+    _ResponseInterceptorIntegrationHelpers.run_test(
+      h,
+      router,
       "GET /api/nonexistent HTTP/1.1\r\nHost: localhost\r\n\r\n",
       "x-group: api-404")
 
-actor \nodoc\ _TestStreamingNoOpClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+actor \nodoc\ _TestStreamingNoOpClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
   """
-  TCP client for streaming no-op test: expects chunk data present AND
-  a forbidden header absent.
+
+  TCP client for streaming no-op test: expects chunk data
+  present AND a forbidden header absent.
   """
-  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+
+  var _tcp_connection: lori.TCPConnection =
+    lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
   let _expect: String
@@ -495,18 +693,27 @@ actor \nodoc\ _TestStreamingNoOpClient is (lori.TCPConnectionActor & lori.Client
   let _listener: _TestResponseInterceptorListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, expect: String,
-    forbid: String, listener: _TestResponseInterceptorListener)
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    expect: String,
+    forbid: String,
+    listener: _TestResponseInterceptorListener)
   =>
     _h = h
     _request = request
     _expect = expect
     _forbid = forbid
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
-  fun ref _connection(): lori.TCPConnection => _tcp_connection
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
 
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
@@ -515,8 +722,10 @@ actor \nodoc\ _TestStreamingNoOpClient is (lori.TCPConnectionActor & lori.Client
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expect) then
-      _h.assert_false(response_str.contains(_forbid),
-        "streaming response must not contain header: " + _forbid)
+      _h.assert_false(
+        response_str.contains(_forbid),
+        "streaming response must not contain header: "
+          + _forbid)
       _tcp_connection.close()
       _listener.dispose()
       _h.complete(true)
@@ -524,7 +733,9 @@ actor \nodoc\ _TestStreamingNoOpClient is (lori.TCPConnectionActor & lori.Client
 
   fun ref _on_closed() => None
 
-  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+  fun ref _on_connection_failure(
+    reason: lori.ConnectionFailureReason)
+  =>
     _h.fail("connection failed")
     _listener.dispose()
     _h.complete(false)

--- a/hobby/_test_route_group.pony
+++ b/hobby/_test_route_group.pony
@@ -9,9 +9,11 @@ primitive \nodoc\ _TestRouteGroupList
     test(Property1UnitTest[
       (String, String)](_PropertyGroupPrefixMatches))
     test(Property1UnitTest[
-      (String, String, String)](_PropertyNestedGroupPrefixOrder))
+      (String, String, String)](
+      _PropertyNestedGroupPrefixOrder))
     test(Property1UnitTest[
-      (String, String)](_PropertyGroupFlattenEquivalence))
+      (String, String)](
+      _PropertyGroupFlattenEquivalence))
     // Example tests
     test(_TestJoinPath)
     test(_TestEmptyGroup)
@@ -21,21 +23,24 @@ primitive \nodoc\ _TestRouteGroupList
     test(_TestTripleLevelGroupInfoCollection)
 
 // --- Generators ---
-
 primitive \nodoc\ _GenSegment
-  """Generate a single path segment: lowercase letters, length 1-10."""
+  """
+  Generate a single path segment: lowercase letters, length 1-10.
+  """
   fun apply(): Generator[String] =>
     Generators.ascii(1, 10 where range = ASCIILetters)
 
 // --- Property tests ---
-
 class \nodoc\ iso _PropertyGroupPrefixMatches is
   Property1[(String, String)]
-  """A route registered via a group matches at the joined path."""
+  """
+  A route registered via a group matches at the joined path.
+  """
   fun name(): String => "route-group/property/prefix matches"
 
   fun gen(): Generator[(String, String)] =>
-    Generators.zip2[String, String](_GenSegment(), _GenSegment())
+    Generators.zip2[String, String](
+      _GenSegment(), _GenSegment())
 
   fun property(sample: (String, String), h: PropertyHelper) =>
     (let prefix_seg, let route_seg) = sample
@@ -54,14 +59,20 @@ class \nodoc\ iso _PropertyGroupPrefixMatches is
 
 class \nodoc\ iso _PropertyNestedGroupPrefixOrder is
   Property1[(String, String, String)]
-  """Nested group paths join as outer + inner + route."""
-  fun name(): String => "route-group/property/nested prefix order"
+  """
+  Nested group paths join as outer + inner + route.
+  """
+  fun name(): String =>
+    "route-group/property/nested prefix order"
 
   fun gen(): Generator[(String, String, String)] =>
     Generators.zip3[String, String, String](
       _GenSegment(), _GenSegment(), _GenSegment())
 
-  fun property(sample: (String, String, String), h: PropertyHelper) =>
+  fun property(
+    sample: (String, String, String),
+    h: PropertyHelper)
+  =>
     (let outer_seg, let inner_seg, let route_seg) = sample
     let joined: String val =
       "/" + outer_seg + "/" + inner_seg + "/" + route_seg
@@ -77,11 +88,15 @@ class \nodoc\ iso _PropertyNestedGroupPrefixOrder is
 
 class \nodoc\ iso _PropertyGroupFlattenEquivalence is
   Property1[(String, String)]
-  """Flattened group route matches the same as a manually built route."""
-  fun name(): String => "route-group/property/flatten equivalence"
+  """
+  Flattened group route matches the same as a manually built route.
+  """
+  fun name(): String =>
+    "route-group/property/flatten equivalence"
 
   fun gen(): Generator[(String, String)] =>
-    Generators.zip2[String, String](_GenSegment(), _GenSegment())
+    Generators.zip2[String, String](
+      _GenSegment(), _GenSegment())
 
   fun property(sample: (String, String), h: PropertyHelper) =>
     (let prefix_seg, let route_seg) = sample
@@ -100,44 +115,55 @@ class \nodoc\ iso _PropertyGroupFlattenEquivalence is
     builder2.add(stallion.GET, manual, _NoOpFactory, None)
     let router2 = builder2.build()
 
-    let r1_match = match router1.lookup(stallion.GET, joined)
-    | let _: _RouteMatch => true
-    else
-      false
-    end
-    let r2_match = match router2.lookup(stallion.GET, joined)
-    | let _: _RouteMatch => true
-    else
-      false
-    end
+    let r1_match =
+      match router1.lookup(stallion.GET, joined)
+      | let _: _RouteMatch => true
+      else
+        false
+      end
+    let r2_match =
+      match router2.lookup(stallion.GET, joined)
+      | let _: _RouteMatch => true
+      else
+        false
+      end
     h.assert_eq[Bool](r1_match, r2_match)
 
 // --- Example-based tests ---
-
 class \nodoc\ iso _TestJoinPath is UnitTest
-  """_JoinPath handles various prefix/path combinations."""
+  """
+  _JoinPath handles various prefix/path combinations.
+  """
   fun name(): String => "route-group/join path"
 
   fun apply(h: TestHelper) =>
     // Normal case
-    h.assert_eq[String]("/api/users", _JoinPath("/api", "/users"))
+    h.assert_eq[String](
+      "/api/users", _JoinPath("/api", "/users"))
     // Trailing slash on prefix
-    h.assert_eq[String]("/api/users", _JoinPath("/api/", "/users"))
+    h.assert_eq[String](
+      "/api/users", _JoinPath("/api/", "/users"))
     // Root prefix
-    h.assert_eq[String]("/health", _JoinPath("/", "/health"))
+    h.assert_eq[String](
+      "/health", _JoinPath("/", "/health"))
     // Empty prefix
-    h.assert_eq[String]("/health", _JoinPath("", "/health"))
+    h.assert_eq[String](
+      "/health", _JoinPath("", "/health"))
     // Root group with root route
     h.assert_eq[String]("/", _JoinPath("/", "/"))
     // Multi-segment prefix
-    h.assert_eq[String]("/api/v1/users",
+    h.assert_eq[String](
+      "/api/v1/users",
       _JoinPath("/api/v1", "/users"))
     // Multi-segment prefix with trailing slash
-    h.assert_eq[String]("/api/v1/users",
+    h.assert_eq[String](
+      "/api/v1/users",
       _JoinPath("/api/v1/", "/users"))
 
 class \nodoc\ iso _TestEmptyGroup is UnitTest
-  """An empty group flattens zero routes."""
+  """
+  An empty group flattens zero routes.
+  """
   fun name(): String => "route-group/empty group"
 
   fun apply(h: TestHelper) =>
@@ -148,16 +174,23 @@ class \nodoc\ iso _TestEmptyGroup is UnitTest
     h.assert_eq[USize](0, target.size())
 
 class \nodoc\ iso _TestMultipleGroupsOnApplication is UnitTest
-  """Two separate groups flatten independently into application routes."""
-  fun name(): String => "route-group/multiple groups on application"
+  """
+  Two separate groups flatten independently into application routes.
+  """
+  fun name(): String =>
+    "route-group/multiple groups on application"
 
   fun apply(h: TestHelper) =>
-    let f1: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "api")
-    } val
-    let f2: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "admin")
-    } val
+    let f1: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "api")
+      } val
+    let f2: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "admin")
+      } val
 
     let g1 = RouteGroup("/api")
     g1.get("/users", f1)
@@ -173,22 +206,33 @@ class \nodoc\ iso _TestMultipleGroupsOnApplication is UnitTest
 
     h.assert_eq[USize](2, target.size())
     try
-      h.assert_eq[String]("/api/users", target(0)?.path)
-      h.assert_is[HandlerFactory](f1, target(0)?.factory)
-      h.assert_eq[String]("/admin/dashboard", target(1)?.path)
-      h.assert_is[HandlerFactory](f2, target(1)?.factory)
+      h.assert_eq[String](
+        "/api/users", target(0)?.path)
+      h.assert_is[HandlerFactory](
+        f1, target(0)?.factory)
+      h.assert_eq[String](
+        "/admin/dashboard", target(1)?.path)
+      h.assert_is[HandlerFactory](
+        f2, target(1)?.factory)
     else
       h.fail("expected two routes")
     end
 
 class \nodoc\ iso _TestGroupInfoCollection is UnitTest
-  """Group info is collected with prefix and interceptors."""
-  fun name(): String => "route-group/group info collection"
+  """
+  Group info is collected with prefix and interceptors.
+  """
+  fun name(): String =>
+    "route-group/group info collection"
 
   fun apply(h: TestHelper) =>
     let interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _PassInterceptor] end
-    let g = RouteGroup("/api" where interceptors = interceptors)
+      recover val
+        [as RequestInterceptor val: _PassInterceptor]
+      end
+    let g =
+      RouteGroup(
+        "/api" where interceptors = interceptors)
     g.get("/users", _NoOpFactory)
 
     let infos = Array[_GroupInfo]
@@ -209,19 +253,36 @@ class \nodoc\ iso _TestGroupInfoCollection is UnitTest
     end
 
 class \nodoc\ iso _TestNestedGroupInfoCollection is UnitTest
-  """Nested group infos are collected with joined prefixes."""
-  fun name(): String => "route-group/nested group info collection"
+  """
+  Nested group infos are collected with joined prefixes.
+  """
+  fun name(): String =>
+    "route-group/nested group info collection"
 
   fun apply(h: TestHelper) =>
-    let outer_interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _PassInterceptor] end
-    let inner_interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _RejectInterceptor] end
+    let outer_interceptors:
+      Array[RequestInterceptor val] val
+    =
+      recover val
+        [as RequestInterceptor val: _PassInterceptor]
+      end
+    let inner_interceptors:
+      Array[RequestInterceptor val] val
+    =
+      recover val
+        [as RequestInterceptor val: _RejectInterceptor]
+      end
 
-    let inner = RouteGroup("/v1" where interceptors = inner_interceptors)
+    let inner =
+      RouteGroup(
+        "/v1"
+        where interceptors = inner_interceptors)
     inner.get("/users", _NoOpFactory)
 
-    let outer = RouteGroup("/api" where interceptors = outer_interceptors)
+    let outer =
+      RouteGroup(
+        "/api"
+        where interceptors = outer_interceptors)
     outer.get("/health", _NoOpFactory)
     outer.group(consume inner)
 
@@ -233,42 +294,73 @@ class \nodoc\ iso _TestNestedGroupInfoCollection is UnitTest
     h.assert_eq[USize](2, infos.size())
     try
       h.assert_eq[String]("/api", infos(0)?.prefix)
-      h.assert_eq[String]("/api/v1", infos(1)?.prefix)
+      h.assert_eq[String](
+        "/api/v1", infos(1)?.prefix)
     else
-      h.fail("expected two group infos with correct prefixes")
+      h.fail(
+        "expected two group infos with correct prefixes")
     end
 
 class \nodoc\ iso _TestTripleLevelGroupInfoCollection is UnitTest
-  """3-level nested group infos have fully joined prefixes."""
-  fun name(): String => "route-group/triple level group info collection"
+  """
+  3-level nested group infos have fully joined prefixes.
+  """
+  fun name(): String =>
+    "route-group/triple level group info collection"
 
   fun apply(h: TestHelper) =>
-    let deep_interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _PassInterceptor] end
-    let inner_interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _RejectInterceptor] end
-    let outer_interceptors: Array[RequestInterceptor val] val =
-      recover val [as RequestInterceptor val: _PassInterceptor] end
+    let deep_interceptors:
+      Array[RequestInterceptor val] val
+    =
+      recover val
+        [as RequestInterceptor val: _PassInterceptor]
+      end
+    let inner_interceptors:
+      Array[RequestInterceptor val] val
+    =
+      recover val
+        [as RequestInterceptor val: _RejectInterceptor]
+      end
+    let outer_interceptors:
+      Array[RequestInterceptor val] val
+    =
+      recover val
+        [as RequestInterceptor val: _PassInterceptor]
+      end
 
-    let deep = RouteGroup("/settings" where interceptors = deep_interceptors)
+    let deep =
+      RouteGroup(
+        "/settings"
+        where interceptors = deep_interceptors)
     deep.get("/profile", _NoOpFactory)
 
-    let inner = RouteGroup("/admin" where interceptors = inner_interceptors)
+    let inner =
+      RouteGroup(
+        "/admin"
+        where interceptors = inner_interceptors)
     inner.group(consume deep)
 
-    let outer = RouteGroup("/api" where interceptors = outer_interceptors)
+    let outer =
+      RouteGroup(
+        "/api"
+        where interceptors = outer_interceptors)
     outer.group(consume inner)
 
     let infos = Array[_GroupInfo]
     let outer_ref: RouteGroup ref = consume outer
     outer_ref._collect_group_infos(infos)
 
-    // Should have three infos: /api, /api/admin, /api/admin/settings
+    // Should have three infos:
+    // /api, /api/admin, /api/admin/settings
     h.assert_eq[USize](3, infos.size())
     try
       h.assert_eq[String]("/api", infos(0)?.prefix)
-      h.assert_eq[String]("/api/admin", infos(1)?.prefix)
-      h.assert_eq[String]("/api/admin/settings", infos(2)?.prefix)
+      h.assert_eq[String](
+        "/api/admin", infos(1)?.prefix)
+      h.assert_eq[String](
+        "/api/admin/settings", infos(2)?.prefix)
     else
-      h.fail("expected three group infos with correct prefixes")
+      h.fail(
+        "expected three group infos with correct " +
+        "prefixes")
     end

--- a/hobby/_test_router.pony
+++ b/hobby/_test_router.pony
@@ -55,54 +55,61 @@ primitive \nodoc\ _TestRouterList
     test(_TestMethodNotAllowedCarriesInterceptors)
 
 // --- Generators ---
-
 primitive \nodoc\ _GenPathSegment
-  """Generate a single path segment: letters or digits, length 1-10."""
+  """
+  Generate a single path segment: letters or digits, length 1-10.
+  """
   fun apply(): Generator[String] =>
     Generators.ascii(1, 10 where range = ASCIILetters)
       .union[String](Generators.ascii(1, 5 where range = ASCIIDigits))
 
 primitive \nodoc\ _GenStaticPath
-  """Generate a static path with 1 or 2 segments."""
+  """
+  Generate a static path with 1 or 2 segments.
+  """
   fun apply(): Generator[String] =>
     Generators.map2[String, String, String](
       _GenPathSegment(),
       _GenPathSegment(),
       {(a: String, b: String): String =>
         recover val
-          let s = String
-          s.append("/")
-          s.append(a)
-          s.append("/")
-          s.append(b)
-          s
+          String
+            .> append("/")
+            .> append(a)
+            .> append("/")
+            .> append(b)
         end
       }).union[String](
-    _GenPathSegment().map[String]({(a: String): String => "/" + a}))
+    _GenPathSegment().map[String]({(a: String): String => "/" + a }))
 
 primitive \nodoc\ _GenParamName
-  """Generate a parameter name: alphabetic, length 1-10."""
+  """
+  Generate a parameter name: alphabetic, length 1-10.
+  """
   fun apply(): Generator[String] =>
     Generators.ascii(1, 10 where range = ASCIILetters)
 
 primitive \nodoc\ _GenMethod
-  """Generate a random HTTP method."""
+  """
+  Generate a random HTTP method.
+  """
   fun apply(): Generator[stallion.Method] =>
-    Generators.one_of[stallion.Method]([
-      stallion.GET; stallion.POST; stallion.PUT; stallion.DELETE
-      stallion.PATCH; stallion.HEAD; stallion.OPTIONS
-    ])
+    Generators.one_of[stallion.Method](
+      [ stallion.GET; stallion.POST; stallion.PUT
+        stallion.DELETE; stallion.PATCH
+        stallion.HEAD; stallion.OPTIONS
+      ])
 
 // --- Test factory ---
-
 primitive \nodoc\ _NoOpFactory
   fun apply(ctx: HandlerContext iso): (HandlerReceiver tag | None) =>
     RequestHandler(consume ctx).respond(stallion.StatusOK, "ok")
 
 // --- Property tests ---
-
 class \nodoc\ iso _PropertyStaticRouteMatches is Property1[String]
-  """A registered static route always matches."""
+  """
+  A registered static route always matches.
+  """
   fun name(): String => "router/property/static route matches"
 
   fun gen(): Generator[String] => _GenStaticPath()
@@ -119,14 +126,16 @@ class \nodoc\ iso _PropertyStaticRouteMatches is Property1[String]
     end
 
 class \nodoc\ iso _PropertyUnregisteredReturnsMiss is Property1[String]
-  """An unregistered path returns _RouteMiss."""
+  """
+  An unregistered path returns _RouteMiss.
+  """
   fun name(): String => "router/property/unregistered returns miss"
 
   fun gen(): Generator[String] => _GenStaticPath()
 
   fun property(path: String, h: PropertyHelper) =>
     let router = _RouterBuilder.build()
-    match router.lookup(stallion.GET, path)
+    match \exhaustive\ router.lookup(stallion.GET, path)
     | let _: _RouteMiss => None
     | let _: _RouteMatch =>
       h.fail("expected miss for " + path + " on empty router")
@@ -136,7 +145,9 @@ class \nodoc\ iso _PropertyUnregisteredReturnsMiss is Property1[String]
 
 class \nodoc\ iso _PropertyParamExtraction is
   Property1[(String, String)]
-  """`:name` segments are captured correctly."""
+  """
+  `:name` segments are captured correctly.
+  """
   fun name(): String => "router/property/param extraction"
 
   fun gen(): Generator[(String, String)] =>
@@ -165,7 +176,9 @@ class \nodoc\ iso _PropertyParamExtraction is
 
 class \nodoc\ iso _PropertyMultipleParams is
   Property1[(String, String, String)]
-  """Multiple `:name` segments are all extracted."""
+  """
+  Multiple `:name` segments are all extracted.
+  """
   fun name(): String => "router/property/multiple params"
 
   fun gen(): Generator[(String, String, String)] =>
@@ -202,7 +215,9 @@ class \nodoc\ iso _PropertyMultipleParams is
 
 class \nodoc\ iso _PropertyMethodIsolation is
   Property1[stallion.Method]
-  """A route registered for one method does not match another."""
+  """
+  A route registered for one method does not match another.
+  """
   fun name(): String => "router/property/method isolation"
 
   fun gen(): Generator[stallion.Method] => _GenMethod()
@@ -223,12 +238,13 @@ class \nodoc\ iso _PropertyMethodIsolation is
     end
 
     // Should return 405 for a different method (excluding HEAD→GET)
-    let other: stallion.Method = if method is stallion.GET then
-      stallion.POST
-    else
-      stallion.GET
-    end
-    match router.lookup(other, "/test")
+    let other: stallion.Method =
+      if method is stallion.GET then
+        stallion.POST
+      else
+        stallion.GET
+      end
+    match \exhaustive\ router.lookup(other, "/test")
     | let _: _MethodNotAllowed => None
     | let _: _RouteMatch =>
       h.fail("should not match different method")
@@ -237,7 +253,9 @@ class \nodoc\ iso _PropertyMethodIsolation is
     end
 
 class \nodoc\ iso _PropertyWildcardCapture is Property1[String]
-  """`*name` captures the remainder of the path."""
+  """
+  `*name` captures the remainder of the path.
+  """
   fun name(): String => "router/property/wildcard capture"
 
   fun gen(): Generator[String] => _GenPathSegment()
@@ -261,33 +279,42 @@ class \nodoc\ iso _PropertyWildcardCapture is Property1[String]
     end
 
 // --- Example-based tests ---
-
 class \nodoc\ iso _TestStaticPriorityOverParam is UnitTest
-  """`/users/new` matches static before `/users/:id`."""
+  """
+  `/users/new` matches static before `/users/:id`.
+  """
   fun name(): String => "router/static priority over param"
 
   fun apply(h: TestHelper) =>
-    let static_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
-    } val
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
+    let static_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "static")
+      } val
+    let param_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "param")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/users/:id", param_factory, None)
-    builder.add(stallion.GET, "/users/new", static_factory, None)
+    builder.add(
+      stallion.GET, "/users/:id", param_factory, None)
+    builder.add(
+      stallion.GET, "/users/new", static_factory, None)
     let router = builder.build()
 
     match router.lookup(stallion.GET, "/users/new")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](static_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        static_factory, m.factory)
     | let _: _RouteMiss =>
       h.fail("expected match for /users/new")
     end
 
     match router.lookup(stallion.GET, "/users/42")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        param_factory, m.factory)
       try
         h.assert_eq[String]("42", m.params("id")?)
       else
@@ -298,7 +325,9 @@ class \nodoc\ iso _TestStaticPriorityOverParam is UnitTest
     end
 
 class \nodoc\ iso _TestRootPath is UnitTest
-  """Root path `/` matches."""
+  """
+  Root path `/` matches.
+  """
   fun name(): String => "router/root path"
 
   fun apply(h: TestHelper) =>
@@ -313,35 +342,47 @@ class \nodoc\ iso _TestRootPath is UnitTest
     end
 
 class \nodoc\ iso _TestOverlappingPrefixes is UnitTest
-  """Multiple routes with overlapping prefixes dispatch correctly."""
+  """
+  Multiple routes with overlapping prefixes dispatch correctly.
+  """
   fun name(): String => "router/overlapping prefixes"
 
   fun apply(h: TestHelper) =>
-    let f1: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "v1")
-    } val
-    let f2: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "v2")
-    } val
+    let f1: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "v1")
+      } val
+    let f2: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "v2")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/api/v1/users", f1, None)
-    builder.add(stallion.GET, "/api/v2/users", f2, None)
+    builder.add(
+      stallion.GET, "/api/v1/users", f1, None)
+    builder.add(
+      stallion.GET, "/api/v2/users", f2, None)
     let router = builder.build()
 
     match router.lookup(stallion.GET, "/api/v1/users")
-    | let m: _RouteMatch => h.assert_is[HandlerFactory](f1, m.factory)
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](f1, m.factory)
     | let _: _RouteMiss =>
       h.fail("expected match for /api/v1/users")
     end
 
     match router.lookup(stallion.GET, "/api/v2/users")
-    | let m: _RouteMatch => h.assert_is[HandlerFactory](f2, m.factory)
+    | let m: _RouteMatch =>
+      h.assert_is[HandlerFactory](f2, m.factory)
     | let _: _RouteMiss =>
       h.fail("expected match for /api/v2/users")
     end
 
 class \nodoc\ iso _TestWildcardSingleSegment is UnitTest
-  """Wildcard captures a single segment."""
+  """
+  Wildcard captures a single segment.
+  """
   fun name(): String => "router/wildcard single segment"
 
   fun apply(h: TestHelper) =>
@@ -363,11 +404,15 @@ class \nodoc\ iso _TestWildcardSingleSegment is UnitTest
     // /files/ normalizes to /files which has no remainder for the wildcard
     match router.lookup(stallion.GET, "/files/")
     | let _: _RouteMatch =>
-      h.fail("should not match /files/ (normalizes to /files, no wildcard content)")
+      h.fail(
+        "should not match /files/ "
+          + "(normalizes to /files, no wildcard content)")
     end
 
 class \nodoc\ iso _TestTrailingSlashNormalization is UnitTest
-  """`/users/` and `/users` match the same route."""
+  """
+  `/users/` and `/users` match the same route.
+  """
   fun name(): String => "router/trailing slash normalization"
 
   fun apply(h: TestHelper) =>
@@ -388,79 +433,119 @@ class \nodoc\ iso _TestTrailingSlashNormalization is UnitTest
     end
 
 class \nodoc\ iso _TestParamPriorityOverWildcard is UnitTest
-  """Param child is tried before wildcard at the same node."""
+  """
+  Param child is tried before wildcard at the same node.
+  """
   fun name(): String => "router/param priority over wildcard"
 
   fun apply(h: TestHelper) =>
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
-    let wildcard_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "wildcard")
-    } val
+    let param_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "param")
+      } val
+    let wildcard_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "wildcard")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/files/:id", param_factory, None)
-    builder.add(stallion.GET, "/files/*path", wildcard_factory, None)
+    builder.add(
+      stallion.GET, "/files/:id", param_factory, None)
+    builder.add(
+      stallion.GET,
+      "/files/*path",
+      wildcard_factory,
+      None)
     let router = builder.build()
 
     // Single segment — param wins over wildcard
-    match router.lookup(stallion.GET, "/files/readme.txt")
+    match router.lookup(
+      stallion.GET, "/files/readme.txt")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        param_factory, m.factory)
       try
-        h.assert_eq[String]("readme.txt", m.params("id")?)
+        h.assert_eq[String](
+          "readme.txt", m.params("id")?)
       else
         h.fail("param 'id' not found")
       end
     else
-      h.fail("expected param match for /files/readme.txt")
+      h.fail(
+        "expected param match for /files/readme.txt")
     end
 
-    // Multi-segment — param can't match (stops at /), wildcard takes it
-    match router.lookup(stallion.GET, "/files/css/style.css")
+    // Multi-segment — param can't match, wildcard takes it
+    match router.lookup(
+      stallion.GET, "/files/css/style.css")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](wildcard_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        wildcard_factory, m.factory)
       try
-        h.assert_eq[String]("css/style.css", m.params("path")?)
+        h.assert_eq[String](
+          "css/style.css", m.params("path")?)
       else
         h.fail("wildcard param 'path' not found")
       end
     else
-      h.fail("expected wildcard match for /files/css/style.css")
+      h.fail(
+        "expected wildcard match for /files/css/style.css")
     end
 
 class \nodoc\ iso _TestStaticParamWildcardPriority is UnitTest
-  """Full three-level priority: static > param > wildcard."""
+  """
+  Full three-level priority: static > param > wildcard.
+  """
   fun name(): String => "router/static param wildcard priority"
 
   fun apply(h: TestHelper) =>
-    let static_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
-    } val
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
-    let wildcard_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "wildcard")
-    } val
+    let static_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "static")
+      } val
+    let param_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "param")
+      } val
+    let wildcard_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "wildcard")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/files/special", static_factory, None)
-    builder.add(stallion.GET, "/files/:id", param_factory, None)
-    builder.add(stallion.GET, "/files/*path", wildcard_factory, None)
+    builder.add(
+      stallion.GET,
+      "/files/special",
+      static_factory,
+      None)
+    builder.add(
+      stallion.GET, "/files/:id", param_factory, None)
+    builder.add(
+      stallion.GET,
+      "/files/*path",
+      wildcard_factory,
+      None)
     let router = builder.build()
 
     // Exact static match — highest priority
-    match router.lookup(stallion.GET, "/files/special")
+    match router.lookup(
+      stallion.GET, "/files/special")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](static_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        static_factory, m.factory)
     else
-      h.fail("expected static match for /files/special")
+      h.fail(
+        "expected static match for /files/special")
     end
 
-    // Single segment, not "special" — param wins over wildcard
+    // Single segment, not "special" — param wins
     match router.lookup(stallion.GET, "/files/other")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        param_factory, m.factory)
     else
       h.fail("expected param match for /files/other")
     end
@@ -468,107 +553,149 @@ class \nodoc\ iso _TestStaticParamWildcardPriority is UnitTest
     // Multi-segment — only wildcard can match
     match router.lookup(stallion.GET, "/files/a/b/c")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](wildcard_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        wildcard_factory, m.factory)
     else
       h.fail("expected wildcard match for /files/a/b/c")
     end
 
 class \nodoc\ iso _Test405FallsBackToLowerPriorityMatch is UnitTest
   """
+
   405 from param falls back to wildcard match.
 
   POST /files/:id + GET /files/*path — GET /files/readme.txt should match
   the wildcard, not return 405 from the param branch.
   """
+
   fun name(): String => "router/405 falls back to lower priority match"
 
   fun apply(h: TestHelper) =>
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
-    let wildcard_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "wildcard")
-    } val
+    let param_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "param")
+      } val
+    let wildcard_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "wildcard")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.POST, "/files/:id", param_factory, None)
-    builder.add(stallion.GET, "/files/*path", wildcard_factory, None)
+    builder.add(
+      stallion.POST,
+      "/files/:id",
+      param_factory,
+      None)
+    builder.add(
+      stallion.GET,
+      "/files/*path",
+      wildcard_factory,
+      None)
     let router = builder.build()
 
-    // GET should fall through param (POST-only) to wildcard (GET)
-    match router.lookup(stallion.GET, "/files/readme.txt")
+    // GET should fall through param to wildcard
+    match \exhaustive\ router.lookup(
+      stallion.GET, "/files/readme.txt")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](wildcard_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        wildcard_factory, m.factory)
       try
-        h.assert_eq[String]("readme.txt", m.params("path")?)
+        h.assert_eq[String](
+          "readme.txt", m.params("path")?)
       else
         h.fail("wildcard param 'path' not found")
       end
     | let _: _MethodNotAllowed =>
-      h.fail("should match GET wildcard, not return 405 from POST param")
+      h.fail(
+        "should match GET wildcard, "
+          + "not return 405 from POST param")
     | let _: _RouteMiss =>
       h.fail("expected match")
     end
 
-    // POST should match param (higher priority than wildcard)
-    match router.lookup(stallion.POST, "/files/readme.txt")
+    // POST should match param (higher priority)
+    match router.lookup(
+      stallion.POST, "/files/readme.txt")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        param_factory, m.factory)
     else
       h.fail("expected POST param match")
     end
 
 class \nodoc\ iso _Test405FallsBackStaticToParam is UnitTest
   """
+
   405 from static falls back to param match.
 
   POST /users/new + GET /users/:id — GET /users/new should match the param
   with id="new", not return 405 from the static branch.
   """
+
   fun name(): String => "router/405 falls back static to param"
 
   fun apply(h: TestHelper) =>
-    let static_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "static")
-    } val
-    let param_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "param")
-    } val
+    let static_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "static")
+      } val
+    let param_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "param")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.POST, "/users/new", static_factory, None)
-    builder.add(stallion.GET, "/users/:id", param_factory, None)
+    builder.add(
+      stallion.POST,
+      "/users/new",
+      static_factory,
+      None)
+    builder.add(
+      stallion.GET, "/users/:id", param_factory, None)
     let router = builder.build()
 
-    // GET /users/new: static has POST-only → falls back to param GET
-    match router.lookup(stallion.GET, "/users/new")
+    // GET /users/new: POST-only → falls back to param
+    match \exhaustive\ router.lookup(
+      stallion.GET, "/users/new")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](param_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        param_factory, m.factory)
       try
-        h.assert_eq[String]("new", m.params("id")?)
+        h.assert_eq[String](
+          "new", m.params("id")?)
       else
         h.fail("param 'id' not found")
       end
     | let _: _MethodNotAllowed =>
-      h.fail("should match GET param, not return 405 from POST static")
+      h.fail(
+        "should match GET param, "
+          + "not return 405 from POST static")
     | let _: _RouteMiss =>
       h.fail("expected match")
     end
 
-    // POST /users/new: static matches (highest priority)
-    match router.lookup(stallion.POST, "/users/new")
+    // POST /users/new: static matches
+    match router.lookup(
+      stallion.POST, "/users/new")
     | let m: _RouteMatch =>
-      h.assert_is[HandlerFactory](static_factory, m.factory)
+      h.assert_is[HandlerFactory](
+        static_factory, m.factory)
     else
       h.fail("expected POST static match")
     end
 
 class \nodoc\ iso _Test405AllowHeaderScopedToEntryType is UnitTest
   """
+
   Allow header on 405 lists only methods from the matching entry type.
 
   GET /files + POST /files/*path → DELETE /files gets Allow: GET, HEAD
   (from exact-path entries only), not GET, HEAD, POST (which would leak
   wildcard methods).
   """
+
   fun name(): String => "router/405 allow header scoped to entry type"
 
   fun apply(h: TestHelper) =>
@@ -578,7 +705,7 @@ class \nodoc\ iso _Test405AllowHeaderScopedToEntryType is UnitTest
     let router = builder.build()
 
     // DELETE /files → 405 from exact-path entries (GET only)
-    match router.lookup(stallion.DELETE, "/files")
+    match \exhaustive\ router.lookup(stallion.DELETE, "/files")
     | let na: _MethodNotAllowed =>
       // Should have GET and HEAD (implicit), but NOT POST
       var has_get = false
@@ -591,8 +718,10 @@ class \nodoc\ iso _Test405AllowHeaderScopedToEntryType is UnitTest
       end
       h.assert_true(has_get, "Allow should include GET")
       h.assert_true(has_head, "Allow should include HEAD")
-      h.assert_false(has_post,
-        "Allow must NOT include POST (wildcard method, different resource)")
+      h.assert_false(
+        has_post,
+        "Allow must NOT include POST "
+          + "(wildcard method, different resource)")
     | let _: _RouteMatch =>
       h.fail("DELETE should not match")
     | let _: _RouteMiss =>
@@ -600,15 +729,16 @@ class \nodoc\ iso _Test405AllowHeaderScopedToEntryType is UnitTest
     end
 
 // --- Property test: insertion order invariance ---
-
 class \nodoc\ iso _PropertyInsertionOrderInvariance is
   Property1[(Array[USize] val, Array[USize] val)]
   """
+
   Route lookup results are independent of insertion order.
 
   Generates two permutations of the same route set and verifies that both
   produce identical lookup results for every registered path.
   """
+
   fun name(): String => "router/property/insertion order invariance"
 
   fun gen(): Generator[(Array[USize] val, Array[USize] val)] =>
@@ -616,52 +746,78 @@ class \nodoc\ iso _PropertyInsertionOrderInvariance is
     Generators.zip2[Array[USize] val, Array[USize] val](
       _GenPermutation(5), _GenPermutation(5))
 
-  fun property(sample: (Array[USize] val, Array[USize] val),
+  fun property(
+    sample: (Array[USize] val, Array[USize] val),
     h: PropertyHelper)
   =>
     (let perm_a, let perm_b) = sample
 
-    // Distinct factories per route so we can verify the same route matched
-    let f0: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "0")
-    } val
-    let f1: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "1")
-    } val
-    let f2: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "2")
-    } val
-    let f3: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "3")
-    } val
-    let f4: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "4")
-    } val
+    // Distinct factories per route
+    let f0: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "0")
+      } val
+    let f1: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "1")
+      } val
+    let f2: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "2")
+      } val
+    let f3: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "3")
+      } val
+    let f4: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "4")
+      } val
 
-    // Fixed route set mixing static, param, and wildcard patterns
-    let routes: Array[(String, String, HandlerFactory)] val = [
-      ("/api/v1/users", "/api/v1/users", f0)
-      ("/api/v1/users/:id", "/api/v1/users/42", f1)
-      ("/api/v1/items", "/api/v1/items", f2)
-      ("/api/v1/items/:id/detail", "/api/v1/items/7/detail", f3)
-      ("/api/v1/*rest", "/api/v1/anything/here", f4)
-    ]
+    // Fixed route set: static, param, wildcard
+    let routes:
+      Array[(String, String, HandlerFactory)] val
+    =
+      [ ("/api/v1/users", "/api/v1/users", f0)
+        ("/api/v1/users/:id", "/api/v1/users/42", f1)
+        ("/api/v1/items", "/api/v1/items", f2)
+        ( "/api/v1/items/:id/detail"
+        , "/api/v1/items/7/detail"
+        , f3)
+        ( "/api/v1/*rest"
+        , "/api/v1/anything/here"
+        , f4)
+      ]
 
     let router_a = _build_in_order(routes, perm_a)
     let router_b = _build_in_order(routes, perm_b)
 
-    // Both routers must agree on every lookup path AND match the same route
+    // Both must agree on every lookup path
     for (_, lookup_path, _) in routes.values() do
-      let result_a = router_a.lookup(stallion.GET, lookup_path)
-      let result_b = router_b.lookup(stallion.GET, lookup_path)
+      let result_a =
+        router_a.lookup(stallion.GET, lookup_path)
+      let result_b =
+        router_b.lookup(stallion.GET, lookup_path)
       match (result_a, result_b)
       | (let ma: _RouteMatch, let mb: _RouteMatch) =>
-        h.assert_true(ma.factory is mb.factory,
-          "insertion order changed matched route for " + lookup_path)
-      | (let _: _RouteMiss, let _: _RouteMiss) => None
-      | (let _: _MethodNotAllowed, let _: _MethodNotAllowed) => None
+        h.assert_true(
+          ma.factory is mb.factory,
+          "insertion order changed matched route for "
+            + lookup_path)
+      | (let _: _RouteMiss, let _: _RouteMiss) =>
+        None
+      | ( let _: _MethodNotAllowed
+        , let _: _MethodNotAllowed) =>
+        None
       else
-        h.fail("insertion order changed result type for " + lookup_path)
+        h.fail(
+          "insertion order changed result type for "
+            + lookup_path)
       end
     end
 
@@ -682,7 +838,9 @@ class \nodoc\ iso _PropertyInsertionOrderInvariance is
     builder.build()
 
 primitive \nodoc\ _GenPermutation
-  """Generate a random permutation of indices 0..n-1 as val array."""
+  """
+  Generate a random permutation of indices 0..n-1 as val array.
+  """
   fun apply(n: USize): Generator[Array[USize] val] =>
     Generator[Array[USize] val](
       object is GenObj[Array[USize] val]
@@ -701,22 +859,33 @@ primitive \nodoc\ _GenPermutation
       end)
 
 // --- New tests for shared path tree ---
-
 class \nodoc\ iso _TestHeadFallbackInRouter is UnitTest
-  """HEAD falls back to GET handler in a single tree traversal."""
+  """
+  HEAD falls back to GET handler in a single tree traversal.
+  """
   fun name(): String => "router/HEAD fallback in router"
 
   fun apply(h: TestHelper) =>
-    let get_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "get")
-    } val
-    let head_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "head")
-    } val
+    let get_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "get")
+      } val
+    let head_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "head")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/fallback", get_factory, None)
-    builder.add(stallion.HEAD, "/explicit", head_factory, None)
-    builder.add(stallion.GET, "/explicit", get_factory, None)
+    builder.add(
+      stallion.GET, "/fallback", get_factory, None)
+    builder.add(
+      stallion.HEAD,
+      "/explicit",
+      head_factory,
+      None)
+    builder.add(
+      stallion.GET, "/explicit", get_factory, None)
     let router = builder.build()
 
     // HEAD to /fallback should resolve to GET handler
@@ -736,7 +905,9 @@ class \nodoc\ iso _TestHeadFallbackInRouter is UnitTest
     end
 
 class \nodoc\ iso _TestInterceptorAccumulation is UnitTest
-  """Interceptors on a path node accumulate into matched routes under it."""
+  """
+  Interceptors on a path node accumulate into matched routes under it.
+  """
   fun name(): String => "router/interceptor accumulation"
 
   fun apply(h: TestHelper) =>
@@ -754,20 +925,25 @@ class \nodoc\ iso _TestInterceptorAccumulation is UnitTest
       | let ints: Array[RequestInterceptor val] val =>
         h.assert_eq[USize](1, ints.size())
         try
-          h.assert_true(ints(0)? is interceptor,
-            "accumulated interceptor should be the one registered on /api")
+          h.assert_true(
+            ints(0)? is interceptor,
+            "accumulated interceptor should be "
+              + "the one registered on /api")
         else
           h.fail("interceptor access failed")
         end
       else
-        h.fail("expected interceptors on matched route")
+        h.fail(
+          "expected interceptors on matched route")
       end
     | let _: _RouteMiss =>
       h.fail("expected match for /api/users")
     end
 
 class \nodoc\ iso _TestMissCarriesInterceptors is UnitTest
-  """A miss under a group carries the group's accumulated interceptors."""
+  """
+  A miss under a group carries the group's accumulated interceptors.
+  """
   fun name(): String => "router/miss carries interceptors"
 
   fun apply(h: TestHelper) =>
@@ -789,32 +965,40 @@ class \nodoc\ iso _TestMissCarriesInterceptors is UnitTest
       | let ints: Array[RequestInterceptor val] val =>
         h.assert_eq[USize](1, ints.size())
         try
-          h.assert_true(ints(0)? is interceptor,
-            "miss should carry the request interceptor from /api")
+          h.assert_true(
+            ints(0)? is interceptor,
+            "miss should carry the request "
+              + "interceptor from /api")
         else
           h.fail("interceptor access failed")
         end
       else
-        h.fail("expected request interceptors on miss")
+        h.fail(
+          "expected request interceptors on miss")
       end
       match miss.response_interceptors
       | let ris: Array[ResponseInterceptor val] val =>
         h.assert_eq[USize](1, ris.size())
         try
-          h.assert_true(ris(0)? is resp_interceptor,
-            "miss should carry the response interceptor from /api")
+          h.assert_true(
+            ris(0)? is resp_interceptor,
+            "miss should carry the response "
+              + "interceptor from /api")
         else
           h.fail("response interceptor access failed")
         end
       else
-        h.fail("expected response interceptors on miss")
+        h.fail(
+          "expected response interceptors on miss")
       end
     | let _: _RouteMatch =>
       h.fail("expected miss for /api/nonexistent")
     end
 
 class \nodoc\ iso _TestRootMissCarriesInterceptors is UnitTest
-  """A miss at the root carries root-level interceptors."""
+  """
+  A miss at the root carries root-level interceptors.
+  """
   fun name(): String => "router/root miss carries interceptors"
 
   fun apply(h: TestHelper) =>
@@ -832,8 +1016,10 @@ class \nodoc\ iso _TestRootMissCarriesInterceptors is UnitTest
       | let ints: Array[RequestInterceptor val] val =>
         h.assert_eq[USize](1, ints.size())
         try
-          h.assert_true(ints(0)? is interceptor,
-            "root miss should carry the root interceptor")
+          h.assert_true(
+            ints(0)? is interceptor,
+            "root miss should carry "
+              + "the root interceptor")
         else
           h.fail("interceptor access failed")
         end
@@ -845,7 +1031,9 @@ class \nodoc\ iso _TestRootMissCarriesInterceptors is UnitTest
     end
 
 class \nodoc\ iso _TestPerRouteInterceptorsMethodSpecific is UnitTest
-  """Per-route interceptors are method-specific at the same leaf."""
+  """
+  Per-route interceptors are method-specific at the same leaf.
+  """
   fun name(): String => "router/per-route interceptors method-specific"
 
   fun apply(h: TestHelper) =>
@@ -857,9 +1045,17 @@ class \nodoc\ iso _TestPerRouteInterceptorsMethodSpecific is UnitTest
       recover val [as RequestInterceptor val: post_interceptor] end
 
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/api/users", _NoOpFactory, None,
+    builder.add(
+      stallion.GET,
+      "/api/users",
+      _NoOpFactory,
+      None,
       get_interceptors)
-    builder.add(stallion.POST, "/api/users", _NoOpFactory, None,
+    builder.add(
+      stallion.POST,
+      "/api/users",
+      _NoOpFactory,
+      None,
       post_interceptors)
     let router = builder.build()
 
@@ -898,7 +1094,9 @@ class \nodoc\ iso _TestPerRouteInterceptorsMethodSpecific is UnitTest
     end
 
 class \nodoc\ iso _TestValidateGroupsDistinctPrefixes is UnitTest
-  """Distinct sibling and nested group prefixes pass validation."""
+  """
+  Distinct sibling and nested group prefixes pass validation.
+  """
   fun name(): String => "router/validate groups distinct prefixes"
 
   fun apply(h: TestHelper) =>
@@ -908,11 +1106,14 @@ class \nodoc\ iso _TestValidateGroupsDistinctPrefixes is UnitTest
     infos.push(_GroupInfo("/api", interceptors, None))
     infos.push(_GroupInfo("/admin", interceptors, None))
     infos.push(_GroupInfo("/api/v1", interceptors, None))
-    h.assert_true(_ValidateGroups(infos) is None,
+    h.assert_true(
+      _ValidateGroups(infos) is None,
       "distinct prefixes should pass validation")
 
 class \nodoc\ iso _TestValidateGroupsOverlappingPrefixes is UnitTest
-  """Overlapping group prefixes produce a ConfigError."""
+  """
+  Overlapping group prefixes produce a ConfigError.
+  """
   fun name(): String => "router/validate groups overlapping prefixes"
 
   fun apply(h: TestHelper) =>
@@ -929,7 +1130,9 @@ class \nodoc\ iso _TestValidateGroupsOverlappingPrefixes is UnitTest
     end
 
 class \nodoc\ iso _TestValidateGroupsEmptyPrefix is UnitTest
-  """Empty group prefix produces a ConfigError."""
+  """
+  Empty group prefix produces a ConfigError.
+  """
   fun name(): String => "router/validate groups empty prefix"
 
   fun apply(h: TestHelper) =>
@@ -945,7 +1148,9 @@ class \nodoc\ iso _TestValidateGroupsEmptyPrefix is UnitTest
     end
 
 class \nodoc\ iso _TestValidateGroupsRootPrefix is UnitTest
-  """RouteGroup("/") with interceptors produces a ConfigError."""
+  """
+  RouteGroup("/") with interceptors produces a ConfigError.
+  """
   fun name(): String => "router/validate groups root prefix"
 
   fun apply(h: TestHelper) =>
@@ -961,7 +1166,9 @@ class \nodoc\ iso _TestValidateGroupsRootPrefix is UnitTest
     end
 
 class \nodoc\ iso _TestValidateGroupsSpecialChars is UnitTest
-  """Special characters in group prefix produce a ConfigError."""
+  """
+  Special characters in group prefix produce a ConfigError.
+  """
   fun name(): String => "router/validate groups special chars"
 
   fun apply(h: TestHelper) =>
@@ -989,7 +1196,9 @@ class \nodoc\ iso _TestValidateGroupsSpecialChars is UnitTest
     end
 
 class \nodoc\ iso _TestParamNameConflictReturnsError is UnitTest
-  """Conflicting param names at the same position produce a ConfigError."""
+  """
+  Conflicting param names at the same position produce a ConfigError.
+  """
   fun name(): String => "router/param name conflict returns error"
 
   fun apply(h: TestHelper) =>
@@ -1007,12 +1216,14 @@ class \nodoc\ iso _TestParamNameConflictReturnsError is UnitTest
 
 class \nodoc\ iso _TestInterceptorSegmentBoundary is UnitTest
   """
+
   Group interceptors at /api must NOT leak to /api-docs.
 
   In the segment trie, `/api` and `/api-docs` are distinct children of the
   root node (`"api"` vs `"api-docs"`). Interceptors registered on the `/api`
   node propagate only to its children, not to sibling segments.
   """
+
   fun name(): String => "router/interceptor segment boundary"
 
   fun apply(h: TestHelper) =>
@@ -1030,29 +1241,37 @@ class \nodoc\ iso _TestInterceptorSegmentBoundary is UnitTest
     | let m: _RouteMatch =>
       match m.interceptors
       | let ints: Array[RequestInterceptor val] val =>
-        h.assert_eq[USize](1, ints.size(),
-          "/api/users should have group interceptors")
+        h.assert_eq[USize](
+          1,
+          ints.size(),
+          "/api/users should have "
+            + "group interceptors")
       else
-        h.fail("/api/users should have interceptors")
+        h.fail(
+          "/api/users should have interceptors")
       end
     | let _: _RouteMiss =>
       h.fail("expected match for /api/users")
     end
 
-    // /api-docs is NOT under the /api group — must NOT get interceptors
+    // /api-docs is NOT under /api — must NOT get interceptors
     match router.lookup(stallion.GET, "/api-docs")
     | let m: _RouteMatch =>
-      h.assert_true(m.interceptors is None,
-        "/api-docs must not inherit /api group interceptors")
+      h.assert_true(
+        m.interceptors is None,
+        "/api-docs must not inherit "
+          + "/api group interceptors")
     | let _: _RouteMiss =>
       h.fail("expected match for /api-docs")
     end
 
 class \nodoc\ iso _TestInterceptorSegmentBoundaryMiss is UnitTest
   """
+
   A 404 miss at a sibling path (/api-unknown) must NOT carry group
   interceptors from /api.
   """
+
   fun name(): String => "router/interceptor segment boundary miss"
 
   fun apply(h: TestHelper) =>
@@ -1070,10 +1289,15 @@ class \nodoc\ iso _TestInterceptorSegmentBoundaryMiss is UnitTest
     | let miss: _RouteMiss =>
       match miss.interceptors
       | let ints: Array[RequestInterceptor val] val =>
-        h.assert_eq[USize](1, ints.size(),
-          "/api/nonexistent should carry group interceptors")
+        h.assert_eq[USize](
+          1,
+          ints.size(),
+          "/api/nonexistent should carry "
+            + "group interceptors")
       else
-        h.fail("/api/nonexistent miss should have interceptors")
+        h.fail(
+          "/api/nonexistent miss should "
+            + "have interceptors")
       end
     | let _: _RouteMatch =>
       h.fail("expected miss for /api/nonexistent")
@@ -1082,17 +1306,21 @@ class \nodoc\ iso _TestInterceptorSegmentBoundaryMiss is UnitTest
     // Miss at /api-unknown — must NOT carry /api's interceptors
     match router.lookup(stallion.GET, "/api-unknown")
     | let miss: _RouteMiss =>
-      h.assert_true(miss.interceptors is None,
-        "/api-unknown miss must not inherit /api group interceptors")
+      h.assert_true(
+        miss.interceptors is None,
+        "/api-unknown miss must not inherit "
+          + "/api group interceptors")
     | let _: _RouteMatch =>
       h.fail("expected miss for /api-unknown")
     end
 
 class \nodoc\ iso _TestInterceptorSegmentBoundaryNestedGroups is UnitTest
   """
+
   App-level interceptors propagate everywhere. Group interceptors at /api
   propagate to /api/admin/users but not to /api-docs.
   """
+
   fun name(): String => "router/interceptor segment boundary nested groups"
 
   fun apply(h: TestHelper) =>
@@ -1115,30 +1343,40 @@ class \nodoc\ iso _TestInterceptorSegmentBoundaryNestedGroups is UnitTest
     | let m: _RouteMatch =>
       match m.interceptors
       | let ints: Array[RequestInterceptor val] val =>
-        h.assert_eq[USize](2, ints.size(),
-          "/api/users should have app + api interceptors")
+        h.assert_eq[USize](
+          2,
+          ints.size(),
+          "/api/users should have "
+            + "app + api interceptors")
       else
-        h.fail("/api/users should have interceptors")
+        h.fail(
+          "/api/users should have interceptors")
       end
     | let _: _RouteMiss =>
       h.fail("expected match for /api/users")
     end
 
-    // /api-docs gets ONLY app interceptors (1 total, not 2)
+    // /api-docs gets ONLY app interceptors (1 total)
     match router.lookup(stallion.GET, "/api-docs")
     | let m: _RouteMatch =>
       match m.interceptors
       | let ints: Array[RequestInterceptor val] val =>
-        h.assert_eq[USize](1, ints.size(),
-          "/api-docs should have only app interceptors")
+        h.assert_eq[USize](
+          1,
+          ints.size(),
+          "/api-docs should have only "
+            + "app interceptors")
         try
-          h.assert_true(ints(0)? is app_interceptor,
-            "/api-docs should have app interceptor, not api interceptor")
+          h.assert_true(
+            ints(0)? is app_interceptor,
+            "/api-docs should have app "
+              + "interceptor, not api interceptor")
         else
           h.fail("interceptor access failed")
         end
       else
-        h.fail("/api-docs should have app interceptors")
+        h.fail(
+          "/api-docs should have app interceptors")
       end
     | let _: _RouteMiss =>
       h.fail("expected match for /api-docs")
@@ -1146,6 +1384,7 @@ class \nodoc\ iso _TestInterceptorSegmentBoundaryNestedGroups is UnitTest
 
 class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
   """
+
   When static and param children both miss, the miss with richer interceptors
   wins.
 
@@ -1154,6 +1393,7 @@ class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
   /api/users/new/nonexistent — static child reaches depth with [A, B] but
   misses, param child :id misses with only [A]. The 404 must carry [A, B].
   """
+
   fun name(): String => "router/deepest miss preserves richer interceptors"
 
   fun apply(h: TestHelper) =>
@@ -1177,8 +1417,11 @@ class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
     | let miss: _RouteMiss =>
       match miss.interceptors
       | let ints: Array[RequestInterceptor val] val =>
-        h.assert_eq[USize](2, ints.size(),
-          "miss should carry [A, B] from deeper static traversal, not [A]")
+        h.assert_eq[USize](
+          2,
+          ints.size(),
+          "miss should carry [A, B] from "
+            + "deeper static traversal, not [A]")
       else
         h.fail("expected interceptors on miss")
       end
@@ -1188,11 +1431,13 @@ class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
 
 class \nodoc\ iso _TestSharedParamNameConsistent is UnitTest
   """
+
   Multiple methods at the same param position with the same name works.
 
   GET /users/:id and POST /users/:id share a param child — the name must
   match. Mismatched names (e.g., :userId vs :id) would panic at startup.
   """
+
   fun name(): String => "router/shared param name consistent"
 
   fun apply(h: TestHelper) =>
@@ -1225,9 +1470,11 @@ class \nodoc\ iso _TestSharedParamNameConsistent is UnitTest
 
 class \nodoc\ iso _TestDoubleSlashNormalization is UnitTest
   """
+
   Double slashes are normalized: `/users//42/details` matches
   `/users/:id/details` with `id` = `"42"`.
   """
+
   fun name(): String => "router/double slash normalization"
 
   fun apply(h: TestHelper) =>
@@ -1262,7 +1509,7 @@ class \nodoc\ iso _TestDoubleSlashNormalization is UnitTest
 
     // /users//details is 2 segments ["users", "details"] — misses the
     // 3-segment route /users/:id/details
-    match router.lookup(stallion.GET, "/users//details")
+    match \exhaustive\ router.lookup(stallion.GET, "/users//details")
     | let _: _RouteMiss => None
     | let _: _RouteMatch =>
       h.fail("/users//details should miss (only 2 segments)")
@@ -1271,12 +1518,14 @@ class \nodoc\ iso _TestDoubleSlashNormalization is UnitTest
 
 class \nodoc\ iso _TestWildcardDoubleSlashNormalization is UnitTest
   """
+
   Wildcard captures normalize double slashes in the captured value.
 
   A request for `/files/a//b/c` produces a wildcard value of `"a/b/c"`,
   not `"a//b/c"`, because `_SplitSegments` skips empty segments before
   the wildcard remainder is reconstructed.
   """
+
   fun name(): String => "router/wildcard double slash normalization"
 
   fun apply(h: TestHelper) =>
@@ -1288,8 +1537,11 @@ class \nodoc\ iso _TestWildcardDoubleSlashNormalization is UnitTest
     match router.lookup(stallion.GET, "/files/a//b/c")
     | let m: _RouteMatch =>
       try
-        h.assert_eq[String]("a/b/c", m.params("path")?,
-          "wildcard should normalize double slash to single")
+        h.assert_eq[String](
+          "a/b/c",
+          m.params("path")?,
+          "wildcard should normalize "
+            + "double slash to single")
       else
         h.fail("wildcard param 'path' not found")
       end
@@ -1301,7 +1553,9 @@ class \nodoc\ iso _TestWildcardDoubleSlashNormalization is UnitTest
     match router.lookup(stallion.GET, "/files/x///y")
     | let m: _RouteMatch =>
       try
-        h.assert_eq[String]("x/y", m.params("path")?,
+        h.assert_eq[String](
+          "x/y",
+          m.params("path")?,
           "wildcard should normalize triple slash")
       else
         h.fail("wildcard param 'path' not found")
@@ -1311,7 +1565,9 @@ class \nodoc\ iso _TestWildcardDoubleSlashNormalization is UnitTest
     end
 
 class \nodoc\ iso _TestMethodNotAllowed is UnitTest
-  """Path exists but method doesn't → _MethodNotAllowed, not _RouteMiss."""
+  """
+  Path exists but method doesn't → _MethodNotAllowed, not _RouteMiss.
+  """
   fun name(): String => "router/method not allowed"
 
   fun apply(h: TestHelper) =>
@@ -1320,7 +1576,7 @@ class \nodoc\ iso _TestMethodNotAllowed is UnitTest
     let router = builder.build()
 
     // GET to a POST-only path → 405
-    match router.lookup(stallion.GET, "/api/users")
+    match \exhaustive\ router.lookup(stallion.GET, "/api/users")
     | let na: _MethodNotAllowed => None
     | let _: _RouteMatch =>
       h.fail("should not match GET on POST-only route")
@@ -1329,7 +1585,7 @@ class \nodoc\ iso _TestMethodNotAllowed is UnitTest
     end
 
     // Nonexistent path → 404
-    match router.lookup(stallion.GET, "/api/nonexistent")
+    match \exhaustive\ router.lookup(stallion.GET, "/api/nonexistent")
     | let _: _RouteMiss => None
     | let _: _RouteMatch =>
       h.fail("should not match nonexistent path")
@@ -1338,7 +1594,9 @@ class \nodoc\ iso _TestMethodNotAllowed is UnitTest
     end
 
 class \nodoc\ iso _TestMethodNotAllowedAllowHeader is UnitTest
-  """_MethodNotAllowed carries the correct allowed methods list."""
+  """
+  _MethodNotAllowed carries the correct allowed methods list.
+  """
   fun name(): String => "router/method not allowed allow header"
 
   fun apply(h: TestHelper) =>
@@ -1348,7 +1606,7 @@ class \nodoc\ iso _TestMethodNotAllowedAllowHeader is UnitTest
     let router = builder.build()
 
     // DELETE to a GET+POST path → 405 with Allow: GET, POST, HEAD
-    match router.lookup(stallion.DELETE, "/api/users")
+    match \exhaustive\ router.lookup(stallion.DELETE, "/api/users")
     | let na: _MethodNotAllowed =>
       // Should have GET, POST, and HEAD (implicit from GET)
       h.assert_eq[USize](3, na.allowed_methods.size())
@@ -1370,15 +1628,23 @@ class \nodoc\ iso _TestMethodNotAllowedAllowHeader is UnitTest
     end
 
 class \nodoc\ iso _TestWildcardMethodIsolation is UnitTest
-  """Wildcard routes are method-isolated — POST wildcard doesn't match GET."""
+  """
+  Wildcard routes are method-isolated — POST wildcard doesn't match GET.
+  """
   fun name(): String => "router/wildcard method isolation"
 
   fun apply(h: TestHelper) =>
-    let post_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "post")
-    } val
+    let post_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "post")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.POST, "/files/*path", post_factory, None)
+    builder.add(
+      stallion.POST,
+      "/files/*path",
+      post_factory,
+      None)
     let router = builder.build()
 
     // POST matches
@@ -1395,7 +1661,7 @@ class \nodoc\ iso _TestWildcardMethodIsolation is UnitTest
     end
 
     // GET does not match — wildcard entries are method-keyed → 405
-    match router.lookup(stallion.GET, "/files/readme.txt")
+    match \exhaustive\ router.lookup(stallion.GET, "/files/readme.txt")
     | let na: _MethodNotAllowed =>
       var has_post = false
       for m in na.allowed_methods.values() do
@@ -1409,15 +1675,23 @@ class \nodoc\ iso _TestWildcardMethodIsolation is UnitTest
     end
 
 class \nodoc\ iso _TestWildcardHeadFallback is UnitTest
-  """HEAD falls back to GET for wildcard routes."""
+  """
+  HEAD falls back to GET for wildcard routes.
+  """
   fun name(): String => "router/wildcard HEAD fallback"
 
   fun apply(h: TestHelper) =>
-    let get_factory: HandlerFactory = {(ctx) =>
-      RequestHandler(consume ctx).respond(stallion.StatusOK, "get")
-    } val
+    let get_factory: HandlerFactory =
+      {(ctx) =>
+        RequestHandler(consume ctx)
+          .respond(stallion.StatusOK, "get")
+      } val
     let builder = _RouterBuilder
-    builder.add(stallion.GET, "/files/*path", get_factory, None)
+    builder.add(
+      stallion.GET,
+      "/files/*path",
+      get_factory,
+      None)
     let router = builder.build()
 
     // HEAD falls back to GET wildcard
@@ -1434,12 +1708,13 @@ class \nodoc\ iso _TestWildcardHeadFallback is UnitTest
     end
 
 // --- _SplitSegments / _JoinRemainingSegments tests ---
-
 class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
   """
+
   `_SplitSegments` edge cases: root, empty, single segment, double slashes,
   triple slashes, param/wildcard markers, and registration-path normalization.
   """
+
   fun name(): String => "router/split segments edge cases"
 
   fun apply(h: TestHelper) =>
@@ -1473,7 +1748,9 @@ class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
 
     // Double slash → empty segment skipped
     let double = _SplitSegments("/api//users")
-    h.assert_eq[USize](2, double.size(),
+    h.assert_eq[USize](
+      2,
+      double.size(),
       "double slash should collapse to 2 segments")
     try
       h.assert_eq[String]("api", double(0)?)
@@ -1484,7 +1761,9 @@ class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
 
     // Triple slash
     let triple = _SplitSegments("/a///b")
-    h.assert_eq[USize](2, triple.size(),
+    h.assert_eq[USize](
+      2,
+      triple.size(),
       "triple slash should collapse to 2 segments")
     try
       h.assert_eq[String]("a", triple(0)?)
@@ -1505,9 +1784,11 @@ class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
 
 class \nodoc\ iso _PropertySplitJoinRoundTrip is Property1[String]
   """
+
   Splitting a static path into segments and joining them all back produces
   the original path without the leading slash.
   """
+
   fun name(): String => "router/property/split join round-trip"
 
   fun gen(): Generator[String] => _GenStaticPath()
@@ -1521,9 +1802,11 @@ class \nodoc\ iso _PropertySplitJoinRoundTrip is Property1[String]
 
 class \nodoc\ iso _TestJoinRemainingSegments is UnitTest
   """
+
   `_JoinRemainingSegments` edge cases: past-end index, single segment,
   multiple segments, and mid-array start.
   """
+
   fun name(): String => "router/join remaining segments"
 
   fun apply(h: TestHelper) =>
@@ -1531,41 +1814,50 @@ class \nodoc\ iso _TestJoinRemainingSegments is UnitTest
       recover val ["api"; "v1"; "users"; "42"] end
 
     // from >= size → empty string
-    h.assert_eq[String]("",
+    h.assert_eq[String](
+      "",
       _JoinRemainingSegments(segments, 10),
       "past-end should return empty")
-    h.assert_eq[String]("",
+    h.assert_eq[String](
+      "",
       _JoinRemainingSegments(segments, 4),
       "at-size should return empty")
 
     // Empty array → empty string
-    let empty: Array[String] val = recover val Array[String] end
-    h.assert_eq[String]("",
+    let empty: Array[String] val =
+      recover val Array[String] end
+    h.assert_eq[String](
+      "",
       _JoinRemainingSegments(empty, 0),
       "empty array should return empty")
 
-    // Single remaining segment (fast path, no allocation)
-    h.assert_eq[String]("42",
+    // Single remaining segment (fast path)
+    h.assert_eq[String](
+      "42",
       _JoinRemainingSegments(segments, 3),
       "single remaining should return that segment")
 
     // Multiple remaining segments
-    h.assert_eq[String]("v1/users/42",
+    h.assert_eq[String](
+      "v1/users/42",
       _JoinRemainingSegments(segments, 1),
       "join from index 1")
 
     // All segments from start
-    h.assert_eq[String]("api/v1/users/42",
+    h.assert_eq[String](
+      "api/v1/users/42",
       _JoinRemainingSegments(segments, 0),
       "join all segments")
 
 class \nodoc\ iso _TestRoutesBeforeInterceptors is UnitTest
   """
+
   Routes registered before interceptors still get the interceptors.
 
   `add_interceptors` may be called after `add` — the tree traversal in
   `_ensure_path` must work on a tree that already has route nodes.
   """
+
   fun name(): String => "router/routes before interceptors"
 
   fun apply(h: TestHelper) =>
@@ -1634,7 +1926,9 @@ class \nodoc\ iso _TestRoutesBeforeInterceptors is UnitTest
     end
 
 class \nodoc\ iso _TestMethodNotAllowedCarriesInterceptors is UnitTest
-  """405 responses carry accumulated interceptors from the matched path."""
+  """
+  405 responses carry accumulated interceptors from the matched path.
+  """
   fun name(): String => "router/method not allowed carries interceptors"
 
   fun apply(h: TestHelper) =>
@@ -1651,26 +1945,31 @@ class \nodoc\ iso _TestMethodNotAllowedCarriesInterceptors is UnitTest
     let router = builder.build()
 
     // GET to POST-only path → 405 with /api's interceptors
-    match router.lookup(stallion.GET, "/api/users")
+    match \exhaustive\ router.lookup(stallion.GET, "/api/users")
     | let na: _MethodNotAllowed =>
       match na.interceptors
       | let ints: Array[RequestInterceptor val] val =>
         h.assert_eq[USize](1, ints.size())
         try
-          h.assert_true(ints(0)? is interceptor,
-            "405 should carry request interceptor from /api")
+          h.assert_true(
+            ints(0)? is interceptor,
+            "405 should carry request "
+              + "interceptor from /api")
         else
           h.fail("interceptor access failed")
         end
       else
-        h.fail("405 should have request interceptors")
+        h.fail(
+          "405 should have request interceptors")
       end
       match na.response_interceptors
       | let ris: Array[ResponseInterceptor val] val =>
         h.assert_eq[USize](1, ris.size())
         try
-          h.assert_true(ris(0)? is resp_interceptor,
-            "405 should carry response interceptor from /api")
+          h.assert_true(
+            ris(0)? is resp_interceptor,
+            "405 should carry response "
+              + "interceptor from /api")
         else
           h.fail("response interceptor access failed")
         end

--- a/hobby/_test_serve_files.pony
+++ b/hobby/_test_serve_files.pony
@@ -36,12 +36,13 @@ primitive \nodoc\ _TestServeFilesList
     test(_TestServeFilesHandlerBackpressure)
 
 // --- Test setup ---
-
 primitive \nodoc\ _ServeFilesTestSetup
   """
+
   Create a temporary directory with test files for ServeFiles integration
   tests. Idempotent — safe to call multiple times.
   """
+
   fun apply(env: Env): FilePath ? =>
     let file_auth = FileAuth(env.root)
     let root = FilePath(file_auth, "/tmp/hobby-test-serve")
@@ -54,14 +55,15 @@ primitive \nodoc\ _ServeFilesTestSetup
     _write_file(root, "style.css", "body { color: red; }")?
 
     // Large file for streaming tests (2 KB, exceeds chunk_threshold=1)
-    let large_content = recover val
-      let s = String(2048)
-      s.append("LARGE_FILE_MARKER:")
-      while s.size() < 2048 do
-        s.push('x')
+    let large_content =
+      recover val
+        let s = String(2048)
+        s.append("LARGE_FILE_MARKER:")
+        while s.size() < 2048 do
+          s.push('x')
+        end
+        s
       end
-      s
-    end
     _write_file(root, "large.txt", large_content)?
 
     // Subdirectory for directory test
@@ -78,15 +80,16 @@ primitive \nodoc\ _ServeFilesTestSetup
 
   fun _write_file(root: FilePath, name: String, content: String) ? =>
     let path = FilePath.from(root, name)?
-    let file = File(path)
-    file.set_length(0)
-    file.write(content)
-    file.dispose()
+    File(path)
+      .> set_length(0)
+      .> write(content)
+      .> dispose()
 
 // --- Integration tests ---
-
 class \nodoc\ iso _TestServeFilesSmallFile is UnitTest
-  """Small file served with correct Content-Type and body."""
+  """
+  Small file served with correct Content-Type and body.
+  """
   fun name(): String => "integration/serve-files/small file"
 
   fun label(): String => "integration"
@@ -94,10 +97,14 @@ class \nodoc\ iso _TestServeFilesSmallFile is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "Hello from test file")
     else
@@ -105,7 +112,9 @@ class \nodoc\ iso _TestServeFilesSmallFile is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesContentType is UnitTest
-  """Content-Type header matches file extension."""
+  """
+  Content-Type header matches file extension.
+  """
   fun name(): String => "integration/serve-files/content type"
 
   fun label(): String => "integration"
@@ -113,10 +122,14 @@ class \nodoc\ iso _TestServeFilesContentType is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/style.css HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "text/css")
     else
@@ -124,7 +137,9 @@ class \nodoc\ iso _TestServeFilesContentType is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesLargeFile is UnitTest
-  """Large file streamed with chunked transfer encoding."""
+  """
+  Large file streamed with chunked transfer encoding.
+  """
   fun name(): String => "integration/serve-files/large file streaming"
 
   fun label(): String => "integration"
@@ -133,10 +148,14 @@ class \nodoc\ iso _TestServeFilesLargeFile is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let handler = ServeFiles(root where chunk_threshold = 1)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/large.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "LARGE_FILE_MARKER:")
     else
@@ -144,7 +163,9 @@ class \nodoc\ iso _TestServeFilesLargeFile is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesMissing404 is UnitTest
-  """Missing file returns 404."""
+  """
+  Missing file returns 404.
+  """
   fun name(): String => "integration/serve-files/missing file 404"
 
   fun label(): String => "integration"
@@ -152,10 +173,14 @@ class \nodoc\ iso _TestServeFilesMissing404 is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/nonexistent.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "Not Found")
     else
@@ -163,7 +188,9 @@ class \nodoc\ iso _TestServeFilesMissing404 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesTraversal404 is UnitTest
-  """Path traversal attempt returns 404."""
+  """
+  Path traversal attempt returns 404.
+  """
   fun name(): String => "integration/serve-files/path traversal 404"
 
   fun label(): String => "integration"
@@ -171,10 +198,14 @@ class \nodoc\ iso _TestServeFilesTraversal404 is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/sub/../../etc/passwd HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "Not Found")
     else
@@ -182,7 +213,9 @@ class \nodoc\ iso _TestServeFilesTraversal404 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesDirectory404 is UnitTest
-  """Requesting a directory without index.html returns 404."""
+  """
+  Requesting a directory without index.html returns 404.
+  """
   fun name(): String => "integration/serve-files/directory 404"
 
   fun label(): String => "integration"
@@ -190,10 +223,14 @@ class \nodoc\ iso _TestServeFilesDirectory404 is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/subdir HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "Not Found")
     else
@@ -201,7 +238,9 @@ class \nodoc\ iso _TestServeFilesDirectory404 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesLargeFileHTTP10 is UnitTest
-  """HTTP/1.0 client requesting a large file gets 505."""
+  """
+  HTTP/1.0 client requesting a large file gets 505.
+  """
   fun name(): String => "integration/serve-files/large file HTTP 1.0 505"
 
   fun label(): String => "integration"
@@ -210,10 +249,14 @@ class \nodoc\ iso _TestServeFilesLargeFileHTTP10 is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let handler = ServeFiles(root where chunk_threshold = 1)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/large.txt HTTP/1.0\r\nHost: localhost\r\n\r\n",
         "HTTP Version Not Supported")
     else
@@ -221,7 +264,9 @@ class \nodoc\ iso _TestServeFilesLargeFileHTTP10 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesHeadSmallFile is UnitTest
-  """HEAD for small file: Content-Length header present, body absent."""
+  """
+  HEAD for small file: Content-Length header present, body absent.
+  """
   fun name(): String => "integration/serve-files/HEAD small file"
 
   fun label(): String => "integration"
@@ -229,19 +274,26 @@ class \nodoc\ iso _TestServeFilesHeadSmallFile is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
       // Headers go through stallion.Headers which lowercases names.
-      _HeadIntegrationHelpers.run_head_test(h, router,
+      _HeadIntegrationHelpers.run_head_test(
+        h,
+        router,
         "HEAD /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "content-length: 20", "Hello from test file")
+        "content-length: 20",
+        "Hello from test file")
     else
       h.fail("test setup failed")
     end
 
 class \nodoc\ iso _TestServeFilesHeadLargeFile is UnitTest
-  """HEAD for large file: Content-Length from stat, body absent."""
+  """
+  HEAD for large file: Content-Length from stat, body absent.
+  """
   fun name(): String => "integration/serve-files/HEAD large file"
 
   fun label(): String => "integration"
@@ -250,21 +302,27 @@ class \nodoc\ iso _TestServeFilesHeadLargeFile is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let handler = ServeFiles(root where chunk_threshold = 1)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
       // Headers go through stallion.Headers which lowercases names.
-      _HeadIntegrationHelpers.run_head_test(h, router,
+      _HeadIntegrationHelpers.run_head_test(
+        h,
+        router,
         "HEAD /static/large.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "content-length: 2048", "LARGE_FILE_MARKER:")
+        "content-length: 2048",
+        "LARGE_FILE_MARKER:")
     else
       h.fail("test setup failed")
     end
 
 // --- Cache header helpers ---
-
 primitive \nodoc\ _ServeFilesTestETag
-  """Compute the expected ETag for a test file."""
+  """
+  Compute the expected ETag for a test file.
+  """
   fun apply(root: FilePath, name': String): String ? =>
     let path = FilePath.from(root, name')?
     let info = FileInfo(path)?
@@ -275,12 +333,13 @@ primitive \nodoc\ _ServeFilesTestETag
     let path = FilePath.from(root, name')?
     let info = FileInfo(path)?
     (let mod_secs, _) = info.modified_time
-    _HttpDate(mod_secs)
+    _HTTPDate(mod_secs)
 
 // --- Cache header integration tests ---
-
 class \nodoc\ iso _TestServeFilesCacheHeadersPresent is UnitTest
-  """GET response includes ETag header."""
+  """
+  GET response includes ETag header.
+  """
   fun name(): String => "integration/serve-files/cache headers present"
 
   fun label(): String => "integration"
@@ -289,11 +348,15 @@ class \nodoc\ iso _TestServeFilesCacheHeadersPresent is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "hello.txt")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
       // stallion.Headers lowercases header names
-      _IntegrationHelpers.run_test(h, router,
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "etag: " + etag)
     else
@@ -301,7 +364,9 @@ class \nodoc\ iso _TestServeFilesCacheHeadersPresent is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesETag304 is UnitTest
-  """GET with matching If-None-Match returns 304."""
+  """
+  GET with matching If-None-Match returns 304.
+  """
   fun name(): String => "integration/serve-files/ETag 304"
 
   fun label(): String => "integration"
@@ -310,10 +375,14 @@ class \nodoc\ iso _TestServeFilesETag304 is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "hello.txt")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n" +
           "If-None-Match: " + etag + "\r\n\r\n",
         "304 Not Modified")
@@ -322,7 +391,9 @@ class \nodoc\ iso _TestServeFilesETag304 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesIfModifiedSince304 is UnitTest
-  """GET with matching If-Modified-Since returns 304."""
+  """
+  GET with matching If-Modified-Since returns 304.
+  """
   fun name(): String => "integration/serve-files/If-Modified-Since 304"
 
   fun label(): String => "integration"
@@ -331,10 +402,14 @@ class \nodoc\ iso _TestServeFilesIfModifiedSince304 is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let last_mod = _ServeFilesTestETag.last_modified(root, "hello.txt")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n" +
           "If-Modified-Since: " + last_mod + "\r\n\r\n",
         "304 Not Modified")
@@ -343,7 +418,9 @@ class \nodoc\ iso _TestServeFilesIfModifiedSince304 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesETagMismatch200 is UnitTest
-  """GET with non-matching If-None-Match returns 200 with body."""
+  """
+  GET with non-matching If-None-Match returns 200 with body.
+  """
   fun name(): String => "integration/serve-files/ETag mismatch 200"
 
   fun label(): String => "integration"
@@ -351,10 +428,14 @@ class \nodoc\ iso _TestServeFilesETagMismatch200 is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n" +
           "If-None-Match: W/\"0-0-0\"\r\n\r\n",
         "Hello from test file")
@@ -363,7 +444,9 @@ class \nodoc\ iso _TestServeFilesETagMismatch200 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesHeadCacheHeaders is UnitTest
-  """HEAD response includes ETag header, body absent."""
+  """
+  HEAD response includes ETag header, body absent.
+  """
   fun name(): String => "integration/serve-files/HEAD cache headers"
 
   fun label(): String => "integration"
@@ -372,18 +455,25 @@ class \nodoc\ iso _TestServeFilesHeadCacheHeaders is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "hello.txt")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _HeadIntegrationHelpers.run_head_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _HeadIntegrationHelpers.run_head_test(
+        h,
+        router,
         "HEAD /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "etag: " + etag, "Hello from test file")
+        "etag: " + etag,
+        "Hello from test file")
     else
       h.fail("test setup failed")
     end
 
 class \nodoc\ iso _TestServeFilesHead304 is UnitTest
-  """HEAD with matching If-None-Match returns 304."""
+  """
+  HEAD with matching If-None-Match returns 304.
+  """
   fun name(): String => "integration/serve-files/HEAD ETag 304"
 
   fun label(): String => "integration"
@@ -392,10 +482,14 @@ class \nodoc\ iso _TestServeFilesHead304 is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "hello.txt")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "HEAD /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n" +
           "If-None-Match: " + etag + "\r\n\r\n",
         "304 Not Modified")
@@ -404,7 +498,9 @@ class \nodoc\ iso _TestServeFilesHead304 is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesCacheControlCustom is UnitTest
-  """Custom cache_control value appears in response."""
+  """
+  Custom cache_control value appears in response.
+  """
   fun name(): String => "integration/serve-files/custom cache-control"
 
   fun label(): String => "integration"
@@ -412,12 +508,18 @@ class \nodoc\ iso _TestServeFilesCacheControlCustom is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let handler = ServeFiles(root
-        where cache_control = "private, max-age=600")
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let handler =
+        ServeFiles(
+          root
+          where cache_control = "private, max-age=600")
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "cache-control: private, max-age=600")
     else
@@ -425,7 +527,9 @@ class \nodoc\ iso _TestServeFilesCacheControlCustom is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesCacheControlDisabled is UnitTest
-  """cache_control = None omits Cache-Control header."""
+  """
+  cache_control = None omits Cache-Control header.
+  """
   fun name(): String => "integration/serve-files/cache-control disabled"
 
   fun label(): String => "integration"
@@ -434,41 +538,68 @@ class \nodoc\ iso _TestServeFilesCacheControlDisabled is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let handler = ServeFiles(root where cache_control = None)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _ServeFilesCacheControlDisabledHelper.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _ServeFilesCacheControlDisabledHelper.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "Hello from test file", "cache-control:")
+        "Hello from test file",
+        "cache-control:")
     else
       h.fail("test setup failed")
     end
 
 primitive \nodoc\ _ServeFilesCacheControlDisabledHelper
   """
+
   Run a test that checks for a required string AND verifies a forbidden
   string is absent.
   """
-  fun run_test(h: TestHelper, router: _Router val,
-    request: String, expected: String, forbidden: String)
+
+  fun run_test(
+    h: TestHelper,
+    router: _Router val,
+    request: String,
+    expected: String,
+    forbidden: String)
   =>
     h.long_test(5_000_000_000)
     let host = _TestHost()
     let config = stallion.ServerConfig(host, "0")
     let auth = lori.TCPListenAuth(h.env.root)
     let connect_auth = lori.TCPConnectAuth(h.env.root)
-    _TestIntegrationListener(auth, config, router, h,
-      {(h': TestHelper, port: String,
+    _TestIntegrationListener(
+      auth,
+      config,
+      router,
+      h,
+      {(h': TestHelper,
+        port: String,
         listener: _TestIntegrationListener) =>
-        _TestNoCacheControlClient(connect_auth, host, port, h',
-          request, expected, forbidden, listener)
+        _TestNoCacheControlClient(
+          connect_auth,
+          host,
+          port,
+          h',
+          request,
+          expected,
+          forbidden,
+          listener)
       })
 
-actor \nodoc\ _TestNoCacheControlClient is (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+actor \nodoc\ _TestNoCacheControlClient is
+  (lori.TCPConnectionActor &
+    lori.ClientLifecycleEventReceiver)
   """
+
   TCP client that checks a required string is present and a forbidden
   string is absent.
   """
+
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   let _h: TestHelper
   let _request: String
@@ -477,8 +608,14 @@ actor \nodoc\ _TestNoCacheControlClient is (lori.TCPConnectionActor & lori.Clien
   let _listener: _TestIntegrationListener
   var _response: String iso = recover iso String end
 
-  new create(auth: lori.TCPConnectAuth, host: String, port: String,
-    h: TestHelper, request: String, expected: String, forbidden: String,
+  new create(
+    auth: lori.TCPConnectAuth,
+    host: String,
+    port: String,
+    h: TestHelper,
+    request: String,
+    expected: String,
+    forbidden: String,
     listener: _TestIntegrationListener)
   =>
     _h = h
@@ -486,7 +623,9 @@ actor \nodoc\ _TestNoCacheControlClient is (lori.TCPConnectionActor & lori.Clien
     _expected = expected
     _forbidden = forbidden
     _listener = listener
-    _tcp_connection = lori.TCPConnection.client(auth, host, port, "", this, this)
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth, host, port, "", this, this)
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
@@ -497,7 +636,8 @@ actor \nodoc\ _TestNoCacheControlClient is (lori.TCPConnectionActor & lori.Clien
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expected) then
-      _h.assert_false(response_str.contains(_forbidden),
+      _h.assert_false(
+        response_str.contains(_forbidden),
         "Response must not contain: " + _forbidden)
       _tcp_connection.close()
       _listener.dispose()
@@ -512,7 +652,9 @@ actor \nodoc\ _TestNoCacheControlClient is (lori.TCPConnectionActor & lori.Clien
     _h.complete(false)
 
 class \nodoc\ iso _TestServeFilesLargeFileCacheHeaders is UnitTest
-  """Large file streaming response includes ETag header."""
+  """
+  Large file streaming response includes ETag header.
+  """
   fun name(): String => "integration/serve-files/large file cache headers"
 
   fun label(): String => "integration"
@@ -522,10 +664,14 @@ class \nodoc\ iso _TestServeFilesLargeFileCacheHeaders is UnitTest
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "large.txt")?
       let handler = ServeFiles(root where chunk_threshold = 1)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/large.txt HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "etag: " + etag)
     else
@@ -534,9 +680,11 @@ class \nodoc\ iso _TestServeFilesLargeFileCacheHeaders is UnitTest
 
 class \nodoc\ iso _TestServeFilesLargeFileETag304 is UnitTest
   """
+
   Large file with matching If-None-Match returns 304 (conditional check
   happens before size branch).
   """
+
   fun name(): String => "integration/serve-files/large file ETag 304"
 
   fun label(): String => "integration"
@@ -546,10 +694,14 @@ class \nodoc\ iso _TestServeFilesLargeFileETag304 is UnitTest
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "large.txt")?
       let handler = ServeFiles(root where chunk_threshold = 1)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/large.txt HTTP/1.1\r\nHost: localhost\r\n" +
           "If-None-Match: " + etag + "\r\n\r\n",
         "304 Not Modified")
@@ -559,9 +711,11 @@ class \nodoc\ iso _TestServeFilesLargeFileETag304 is UnitTest
 
 class \nodoc\ iso _TestServeFilesETagPrecedence is UnitTest
   """
+
   If-None-Match takes precedence over If-Modified-Since per RFC 7232 section 3.
   Matching ETag + non-matching If-Modified-Since still returns 304.
   """
+
   fun name(): String => "integration/serve-files/ETag precedence"
 
   fun label(): String => "integration"
@@ -570,11 +724,15 @@ class \nodoc\ iso _TestServeFilesETagPrecedence is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "hello.txt")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
       // Matching ETag but non-matching If-Modified-Since
-      _IntegrationHelpers.run_test(h, router,
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/hello.txt HTTP/1.1\r\nHost: localhost\r\n" +
           "If-None-Match: " + etag + "\r\n" +
           "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT\r\n\r\n",
@@ -584,9 +742,10 @@ class \nodoc\ iso _TestServeFilesETagPrecedence is UnitTest
     end
 
 // --- Directory index tests ---
-
 class \nodoc\ iso _TestServeFilesDirectoryIndex is UnitTest
-  """Directory with index.html serves the index file content."""
+  """
+  Directory with index.html serves the index file content.
+  """
   fun name(): String => "integration/serve-files/directory index"
 
   fun label(): String => "integration"
@@ -594,10 +753,14 @@ class \nodoc\ iso _TestServeFilesDirectoryIndex is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/indexed HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "<h1>Index</h1>")
     else
@@ -605,7 +768,9 @@ class \nodoc\ iso _TestServeFilesDirectoryIndex is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesDirectoryIndexContentType is UnitTest
-  """Directory index response has text/html Content-Type."""
+  """
+  Directory index response has text/html Content-Type.
+  """
   fun name(): String => "integration/serve-files/directory index content type"
 
   fun label(): String => "integration"
@@ -613,10 +778,14 @@ class \nodoc\ iso _TestServeFilesDirectoryIndexContentType is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/indexed HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "text/html")
     else
@@ -624,7 +793,9 @@ class \nodoc\ iso _TestServeFilesDirectoryIndexContentType is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesDirectoryIndexCacheHeaders is UnitTest
-  """Directory index response has ETag based on index.html metadata."""
+  """
+  Directory index response has ETag based on index.html metadata.
+  """
   fun name(): String => "integration/serve-files/directory index cache headers"
 
   fun label(): String => "integration"
@@ -633,10 +804,14 @@ class \nodoc\ iso _TestServeFilesDirectoryIndexCacheHeaders is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "indexed/index.html")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/indexed HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "etag: " + etag)
     else
@@ -644,7 +819,9 @@ class \nodoc\ iso _TestServeFilesDirectoryIndexCacheHeaders is UnitTest
     end
 
 class \nodoc\ iso _TestServeFilesDirectoryIndexHead is UnitTest
-  """HEAD for directory index: Content-Length present, body absent."""
+  """
+  HEAD for directory index: Content-Length present, body absent.
+  """
   fun name(): String => "integration/serve-files/HEAD directory index"
 
   fun label(): String => "integration"
@@ -652,18 +829,25 @@ class \nodoc\ iso _TestServeFilesDirectoryIndexHead is UnitTest
   fun apply(h: TestHelper) =>
     try
       let root = _ServeFilesTestSetup(h.env)?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _HeadIntegrationHelpers.run_head_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _HeadIntegrationHelpers.run_head_test(
+        h,
+        router,
         "HEAD /static/indexed HTTP/1.1\r\nHost: localhost\r\n\r\n",
-        "content-length:", "<h1>Index</h1>")
+        "content-length:",
+        "<h1>Index</h1>")
     else
       h.fail("test setup failed")
     end
 
 class \nodoc\ iso _TestServeFilesDirectoryIndex304 is UnitTest
-  """Directory index with matching If-None-Match returns 304."""
+  """
+  Directory index with matching If-None-Match returns 304.
+  """
   fun name(): String => "integration/serve-files/directory index 304"
 
   fun label(): String => "integration"
@@ -672,10 +856,14 @@ class \nodoc\ iso _TestServeFilesDirectoryIndex304 is UnitTest
     try
       let root = _ServeFilesTestSetup(h.env)?
       let etag = _ServeFilesTestETag(root, "indexed/index.html")?
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", ServeFiles(root))]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", ServeFiles(root))]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/indexed HTTP/1.1\r\nHost: localhost\r\n" +
           "If-None-Match: " + etag + "\r\n\r\n",
         "304 Not Modified")
@@ -684,9 +872,10 @@ class \nodoc\ iso _TestServeFilesDirectoryIndex304 is UnitTest
     end
 
 // --- Custom content types ---
-
 class \nodoc\ iso _TestServeFilesCustomContentType is UnitTest
-  """Custom content type mapping is used for file responses."""
+  """
+  Custom content type mapping is used for file responses.
+  """
   fun name(): String => "integration/serve-files/custom content type"
 
   fun label(): String => "integration"
@@ -696,10 +885,14 @@ class \nodoc\ iso _TestServeFilesCustomContentType is UnitTest
       let root = _ServeFilesTestSetup(h.env)?
       let types = ContentTypes.add("custom", "application/x-custom")
       let handler = ServeFiles(root where content_types = types)
-      let router = _IntegrationHelpers.build_router(recover val
-        [(stallion.GET, "/static/*filepath", handler)]
-      end)
-      _IntegrationHelpers.run_test(h, router,
+      let router =
+        _IntegrationHelpers.build_router(
+          recover val
+            [(stallion.GET, "/static/*filepath", handler)]
+          end)
+      _IntegrationHelpers.run_test(
+        h,
+        router,
         "GET /static/image.custom HTTP/1.1\r\nHost: localhost\r\n\r\n",
         "application/x-custom")
     else
@@ -707,9 +900,10 @@ class \nodoc\ iso _TestServeFilesCustomContentType is UnitTest
     end
 
 // --- FileStreamer pause/resume test ---
-
 class \nodoc\ iso _TestFileStreamerPauseResume is UnitTest
-  """Pause stops the read loop; resume restarts it through to completion."""
+  """
+  Pause stops the read loop; resume restarts it through to completion.
+  """
   fun name(): String => "integration/serve-files/file streamer pause resume"
 
   fun label(): String => "integration"
@@ -728,16 +922,22 @@ class \nodoc\ iso _TestFileStreamerPauseResume is UnitTest
     file.write(chunk)
     file.dispose()
 
-    let read_file: File iso = recover iso
-      File.open(FilePath(file_auth, "/tmp/hobby-test-pause-resume.bin"))
-    end
+    let read_file: File iso =
+      recover iso
+        File.open(
+          FilePath(
+            file_auth,
+            "/tmp/hobby-test-pause-resume.bin"))
+      end
     _PauseResumeTarget(h, consume read_file, path)
 
 actor \nodoc\ _PauseResumeTarget is _FileTarget
   """
+
   On first chunk, pauses the streamer. A short timer resumes it.
   Verifies that _file_done arrives after the pause/resume cycle.
   """
+
   let _h: TestHelper
   var _streamer: (_FileStreamer | None) = None
   let _timers: Timers
@@ -761,8 +961,11 @@ actor \nodoc\ _PauseResumeTarget is _FileTarget
       end
       // Resume after 100ms
       let resume_target: _PauseResumeTarget tag = this
-      let timer = Timer(
-        _PauseResumeNotify(resume_target), 100_000_000, 0)
+      let timer =
+        Timer(
+          _PauseResumeNotify(resume_target),
+          100_000_000,
+          0)
       _timers(consume timer)
     end
 
@@ -772,9 +975,12 @@ actor \nodoc\ _PauseResumeTarget is _FileTarget
     end
 
   be _file_done() =>
-    _h.assert_true(_chunks_received >= 2,
-      "expected multiple chunks, got " + _chunks_received.string())
-    _h.assert_true(_paused, "pause should have been triggered")
+    _h.assert_true(
+      _chunks_received >= 2,
+      "expected multiple chunks, got "
+        + _chunks_received.string())
+    _h.assert_true(
+      _paused, "pause should have been triggered")
     _timers.dispose()
     // Clean up temp file
     _path.remove()
@@ -791,9 +997,10 @@ class \nodoc\ iso _PauseResumeNotify is TimerNotify
     false
 
 // --- ServeFilesHandler backpressure test ---
-
 class \nodoc\ iso _TestServeFilesHandlerBackpressure is UnitTest
-  """throttled()/unthrottled() on _ServeFilesHandler pauses/resumes the streamer."""
+  """
+  throttled()/unthrottled() on _ServeFilesHandler pauses/resumes the streamer.
+  """
   fun name(): String =>
     "integration/serve-files/handler backpressure"
 
@@ -813,21 +1020,31 @@ class \nodoc\ iso _TestServeFilesHandlerBackpressure is UnitTest
     file.write(chunk)
     file.dispose()
 
-    let read_file: File iso = recover iso
-      File.open(FilePath(file_auth, "/tmp/hobby-test-bp-handler.bin"))
-    end
+    let read_file: File iso =
+      recover iso
+        File.open(
+          FilePath(
+            file_auth,
+            "/tmp/hobby-test-bp-handler.bin"))
+      end
     let mock = _BackpressureMockConnection(h, path)
     let headers: stallion.Headers val =
       recover val stallion.Headers end
-    let handler = _ServeFilesHandler(_MockHandlerContext(mock),
-      consume read_file, stallion.StatusOK, headers)
+    let handler =
+      _ServeFilesHandler(
+        _MockHandlerContext(mock),
+        consume read_file,
+        stallion.StatusOK,
+        headers)
     mock.set_handler(handler)
 
 actor \nodoc\ _BackpressureMockConnection is _ConnectionProtocol
   """
+
   Mock connection that throttles on first chunk and unthrottles after a timer.
   Verifies that chunks continue to arrive after unthrottling.
   """
+
   let _h: TestHelper
   let _path: FilePath
   let _timers: Timers
@@ -843,12 +1060,17 @@ actor \nodoc\ _BackpressureMockConnection is _ConnectionProtocol
   be set_handler(handler: _ServeFilesHandler) =>
     _handler = handler
 
-  be _handler_respond(token: U64, status: stallion.Status,
-    headers: (stallion.Headers val | None), body: ByteSeq)
+  be _handler_respond(
+    token: U64,
+    status: stallion.Status,
+    headers: (stallion.Headers val | None),
+    body: ByteSeq)
   =>
     None
 
-  be _handler_start_streaming(token: U64, status: stallion.Status,
+  be _handler_start_streaming(
+    token: U64,
+    status: stallion.Status,
     headers: (stallion.Headers val | None))
   =>
     None
@@ -862,8 +1084,11 @@ actor \nodoc\ _BackpressureMockConnection is _ConnectionProtocol
       end
       // Resume after 100ms
       let self: _BackpressureMockConnection tag = this
-      let timer = Timer(
-        _BackpressureResumeNotify(self), 100_000_000, 0)
+      let timer =
+        Timer(
+          _BackpressureResumeNotify(self),
+          100_000_000,
+          0)
       _timers(consume timer)
     end
 
@@ -873,9 +1098,12 @@ actor \nodoc\ _BackpressureMockConnection is _ConnectionProtocol
     end
 
   be _handler_finish(token: U64) =>
-    _h.assert_true(_chunks_received >= 2,
-      "expected multiple chunks, got " + _chunks_received.string())
-    _h.assert_true(_paused, "pause should have been triggered")
+    _h.assert_true(
+      _chunks_received >= 2,
+      "expected multiple chunks, got "
+        + _chunks_received.string())
+    _h.assert_true(
+      _paused, "pause should have been triggered")
     _timers.dispose()
     _path.remove()
     _h.complete(true)

--- a/hobby/_test_signed_cookie.pony
+++ b/hobby/_test_signed_cookie.pony
@@ -169,9 +169,11 @@ class \nodoc\ iso _TestSignedCookieInvalidBase64 is UnitTest
 
 class \nodoc\ iso _TestSignedCookieKeyBoundary is UnitTest
   """
+
   The minimum key length is 32 bytes. A 31-byte key must be rejected;
   a 32-byte key must be accepted.
   """
+
 
   fun name(): String => "SignedCookie/key-boundary"
 
@@ -193,9 +195,11 @@ class \nodoc\ iso _TestSignedCookieKeyBoundary is UnitTest
 
 class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
   """
+
   RFC 4231 Test Case 2: HMAC-SHA256 with "Jefe" key and "what do ya want
   for nothing?" data. Verifies our HMAC matches the known digest.
   """
+
 
   fun name(): String => "SignedCookie/rfc-4231-vector"
 
@@ -219,6 +223,7 @@ class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
 
 class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
   """
+
   Cross-language test vector: a known key, value, and expected signed
   output verified against `openssl dgst -sha256 -hmac`.
 
@@ -235,8 +240,9 @@ class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
 
   Key: 32 bytes of 0xAB
   Value: "hello"
-  Expected signed output: "hello.7GT0SrIsQCeVHsMIKW5wg_p2huSb8nTFCUeO-QsJ_Ak="
+  Expected signed output: "hello.7GT0SrIsQCeVHsMIKW5wg_p2huSb8nTFCUeO-QsJ_Ak=
   """
+
 
   fun name(): String => "SignedCookie/cross-language-vector"
 
@@ -256,8 +262,10 @@ class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
 
 class \nodoc\ iso _PropSignedCookieRoundTrip is Property1[String]
   """
+
   For any printable ASCII value, sign then verify returns the original.
   """
+
 
   fun name(): String => "SignedCookie/prop-round-trip"
 
@@ -277,8 +285,10 @@ class \nodoc\ iso _PropSignedCookieRoundTrip is Property1[String]
 
 class \nodoc\ iso _PropSignedCookieDeterministic is Property1[String]
   """
+
   Signing the same value with the same key always produces the same output.
   """
+
 
   fun name(): String => "SignedCookie/prop-deterministic"
 
@@ -297,8 +307,10 @@ class \nodoc\ iso _PropSignedCookieDeterministic is Property1[String]
 class \nodoc\ iso _PropSignedCookieTamperDetection is
   Property1[(String, USize)]
   """
+
   Flipping any byte in a signed value causes verification to fail.
   """
+
 
   fun name(): String => "SignedCookie/prop-tamper-detection"
 
@@ -340,8 +352,10 @@ class \nodoc\ iso _PropSignedCookieTamperDetection is
 
 class \nodoc\ iso _PropSignedCookieKeyIndependence is Property1[String]
   """
+
   A value signed with one key does not verify with a different key.
   """
+
 
   fun name(): String => "SignedCookie/prop-key-independence"
 
@@ -363,11 +377,13 @@ class \nodoc\ iso _PropSignedCookieKeyIndependence is Property1[String]
 
 class \nodoc\ iso _PropSignedCookieCookieOctetValidity is Property1[String]
   """
+
   The separator and signature portion of a signed cookie contain only
   valid cookie-octet bytes (RFC 6265 section 4.1.1): US-ASCII excluding
   control characters, whitespace, double quote, comma, semicolon, and
   backslash. The value portion is the caller's responsibility.
   """
+
 
   fun name(): String => "SignedCookie/prop-cookie-octet-validity"
 
@@ -405,9 +421,11 @@ class \nodoc\ iso _PropSignedCookieCookieOctetValidity is Property1[String]
 
 class \nodoc\ iso _PropSignedCookieSignatureLength is Property1[String]
   """
+
   The signature portion (after the last `.`) is always 44 characters —
   the Base64-URL encoding of a 32-byte HMAC with padding.
   """
+
 
   fun name(): String => "SignedCookie/prop-signature-length"
 

--- a/hobby/_unreachable.pony
+++ b/hobby/_unreachable.pony
@@ -4,16 +4,18 @@ use @pony_os_stderr[Pointer[None]]()
 
 primitive _Unreachable
   """
+
   To be used in places that the compiler can't prove is unreachable but we are
   certain is unreachable and if we reach it, we'd be silently hiding a bug.
   """
+
   fun apply(loc: SourceLoc = __loc) =>
     @fprintf(
       @pony_os_stderr(),
       ("The unreachable was reached in %s at line %s\n" +
-       "Please open an issue at " +
-       "https://github.com/ponylang/hobby/issues")
-       .cstring(),
+        "Please open an issue at " +
+        "https://github.com/ponylang/hobby/issues")
+        .cstring(),
       loc.file().cstring(),
       loc.line().string().cstring())
     @exit(1)

--- a/hobby/application.pony
+++ b/hobby/application.pony
@@ -3,6 +3,7 @@ use lori = "lori"
 
 class iso Application
   """
+
   The public API for the Hobby web framework.
 
   Register routes via `.>` method chaining (`get`, `post`, etc.), then call
@@ -18,11 +19,11 @@ class iso Application
       let auth = lori.TCPListenAuth(env.root)
       match
         hobby.Application
-          .>get("/", {(ctx) =>
+          .> get("/", {(ctx) =>
             hobby.RequestHandler(consume ctx)
               .respond(stallion.StatusOK, "Hello!")
           } val)
-          .>get("/greet/:name", {(ctx) =>
+          .> get("/greet/:name", {(ctx) =>
             let handler = hobby.RequestHandler(consume ctx)
             try
               handler.respond(stallion.StatusOK,
@@ -43,6 +44,7 @@ class iso Application
   through). Call `.serve()` last — it consumes the Application and returns
   the routes.
   """
+
   embed _routes: Array[_RouteDefinition]
   embed _app_interceptors: Array[RequestInterceptor val]
   embed _app_response_interceptors: Array[ResponseInterceptor val]
@@ -54,81 +56,162 @@ class iso Application
     _app_response_interceptors = Array[ResponseInterceptor val]
     _group_infos = Array[_GroupInfo]
 
-  fun ref get(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a GET route."""
-    _routes.push(
-      _RouteDefinition(stallion.GET, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref post(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a POST route."""
-    _routes.push(
-      _RouteDefinition(stallion.POST, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref put(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a PUT route."""
-    _routes.push(
-      _RouteDefinition(stallion.PUT, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref delete(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a DELETE route."""
-    _routes.push(
-      _RouteDefinition(stallion.DELETE, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref patch(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a PATCH route."""
-    _routes.push(
-      _RouteDefinition(stallion.PATCH, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref head(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a HEAD route."""
-    _routes.push(
-      _RouteDefinition(stallion.HEAD, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref options(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register an OPTIONS route."""
-    _routes.push(
-      _RouteDefinition(stallion.OPTIONS, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref route(method: stallion.Method, path: String,
+  fun ref get(
+    path: String,
     factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
   =>
-    """Register a route with an arbitrary HTTP method."""
+    """
+    Register a GET route.
+    """
     _routes.push(
-      _RouteDefinition(method, path, factory, response_interceptors,
+      _RouteDefinition(
+        stallion.GET,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref post(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a POST route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.POST,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref put(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a PUT route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.PUT,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref delete(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a DELETE route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.DELETE,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref patch(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a PATCH route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.PATCH,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref head(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a HEAD route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.HEAD,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref options(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register an OPTIONS route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.OPTIONS,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref route(
+    method: stallion.Method,
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a route with an arbitrary HTTP method.
+    """
+    _routes.push(
+      _RouteDefinition(
+        method,
+        path,
+        factory,
+        response_interceptors,
         interceptors))
 
   fun ref add_request_interceptor(interceptor: RequestInterceptor val) =>
     """
+
     Add an application-level request interceptor.
 
     Request interceptors run before the handler on every request. Application
@@ -138,10 +221,12 @@ class iso Application
 
     App-level interceptors also run on 404 responses where no route matched.
     """
+
     _app_interceptors.push(interceptor)
 
   fun ref add_response_interceptor(interceptor: ResponseInterceptor val) =>
     """
+
     Add an application-level response interceptor.
 
     Response interceptors run after the handler responds, before the response
@@ -152,10 +237,12 @@ class iso Application
     App-level response interceptors also run on 404 responses where no route
     matched.
     """
+
     _app_response_interceptors.push(interceptor)
 
   fun ref group(g: RouteGroup iso) =>
     """
+
     Consume a route group, flattening its routes into this application.
 
     The group's prefix is applied to each of its routes. Group-level
@@ -163,16 +250,20 @@ class iso Application
     registered on path nodes, not concatenated onto routes. The group is
     consumed — no further registration on it is possible.
     """
-    let g_ref: RouteGroup ref = consume g
-    g_ref._collect_group_infos(_group_infos)
-    g_ref._flatten_routes_into(_routes)
 
-  fun iso serve(auth: lori.TCPListenAuth, config: stallion.ServerConfig,
+    (consume g)
+      .> _collect_group_infos(_group_infos)
+      .> _flatten_routes_into(_routes)
+
+  fun iso serve(
+    auth: lori.TCPListenAuth,
+    config: stallion.ServerConfig,
     out: OutStream,
     handler_timeout: (U64 | None) = 30_000)
     : ServeResult
   =>
     """
+
     Freeze routes, validate configuration, and start listening.
 
     Consumes the Application — no further route registration is possible
@@ -185,6 +276,7 @@ class iso Application
     handler fails to respond within the timeout, the framework sends 504
     Gateway Timeout (or closes the connection for active streams).
     """
+
     let self: Application ref = consume this
 
     // Validate group configuration before building
@@ -207,7 +299,8 @@ class iso Application
 
     // Build app-level response interceptors as a val array (or None if empty)
     let app_response_interceptors:
-      (Array[ResponseInterceptor val] val | None) =
+      (Array[ResponseInterceptor val] val | None)
+    =
       if self._app_response_interceptors.size() > 0 then
         let ri_iso: Array[ResponseInterceptor val] iso =
           recover iso Array[ResponseInterceptor val] end
@@ -222,18 +315,25 @@ class iso Application
     let builder = _RouterBuilder
 
     // Register app-level interceptors on the root node
-    builder.add_interceptors("", app_interceptors, app_response_interceptors)
+    builder.add_interceptors(
+      "", app_interceptors, app_response_interceptors)
 
     // Register group-level interceptors on their prefix nodes
     for gi in self._group_infos.values() do
-      builder.add_interceptors(gi.prefix, gi.interceptors,
+      builder.add_interceptors(
+        gi.prefix,
+        gi.interceptors,
         gi.response_interceptors)
     end
 
     // Register routes with per-route interceptors only
     for r in self._routes.values() do
-      builder.add(r.method, r.path, r.factory,
-        r.response_interceptors, r.interceptors)
+      builder.add(
+        r.method,
+        r.path,
+        r.factory,
+        r.response_interceptors,
+        r.interceptors)
     end
 
     // Check for tree-level errors (e.g., conflicting param names)
@@ -243,11 +343,12 @@ class iso Application
     let router: _Router val = builder.build()
 
     // Convert millisecond timeout to nanoseconds
-    let timeout_ns: U64 = match handler_timeout
-    | let ms: U64 => ms * 1_000_000
-    else
-      0
-    end
+    let timeout_ns: U64 =
+      match handler_timeout
+      | let ms: U64 => ms * 1_000_000
+      else
+        0
+      end
 
     _Listener(auth, config, router, out, timeout_ns)
     Serving

--- a/hobby/body_not_needed.pony
+++ b/hobby/body_not_needed.pony
@@ -1,5 +1,6 @@
 primitive BodyNotNeeded
   """
+
   Returned by `RequestHandler.start_streaming()` when streaming cannot begin.
 
   This happens in two cases: the request is HEAD (the framework sends a
@@ -7,3 +8,4 @@ primitive BodyNotNeeded
   In either case, the handler should not start a producer — there is no
   stream to write to.
   """
+

--- a/hobby/content_types.pony
+++ b/hobby/content_types.pony
@@ -2,8 +2,10 @@ use "collections"
 
 primitive _ContentTypeDefaults
   """
+
   Build the default content-type map with 17 common file extensions.
   """
+
   fun apply(): Map[String, String] ref^ =>
     let m = Map[String, String](24)
     m("html") = "text/html"
@@ -27,6 +29,7 @@ primitive _ContentTypeDefaults
 
 class val ContentTypes
   """
+
   Map file extensions to MIME content types.
 
   Ships with 17 common defaults (html, css, js, json, xml, txt, png, jpg,
@@ -44,42 +47,52 @@ class val ContentTypes
   Lookups are case-insensitive — both the default keys and user-provided keys
   are lowercased. Unknown extensions return `application/octet-stream`.
   """
+
   let _map: Map[String, String] val
 
   new val create() =>
     """
+
     Create a `ContentTypes` with the 17 standard defaults.
     """
+
     _map = recover val _ContentTypeDefaults() end
 
   new val _from_map(map: Map[String, String] val) =>
     """
+
     Create a `ContentTypes` from a pre-built map.
     """
+
     _map = map
 
   fun val add(ext: String, mime: String): ContentTypes val =>
     """
+
     Return a new `ContentTypes` with the given mapping added. If `ext`
     already exists, the new MIME type replaces the previous one. The
     extension is lowercased before insertion so lookups are always
     case-insensitive.
     """
-    let new_map = recover val
-      let m = Map[String, String](_map.size() + 1)
-      for (k, v) in _map.pairs() do
-        m(k) = v
+
+    let new_map =
+      recover val
+        let m = Map[String, String](_map.size() + 1)
+        for (k, v) in _map.pairs() do
+          m(k) = v
+        end
+        m(ext.lower()) = mime
+        m
       end
-      m(ext.lower()) = mime
-      m
-    end
     ContentTypes._from_map(new_map)
 
   fun apply(ext: String): String =>
     """
+
     Look up the MIME type for `ext`. Returns `application/octet-stream` when
     the extension is not in the map.
     """
+
     try
       _map(ext.lower())?
     else

--- a/hobby/cookie_signing_key.pony
+++ b/hobby/cookie_signing_key.pony
@@ -2,30 +2,38 @@ use crypto = "ssl/crypto"
 
 class val CookieSigningKey
   """
+
   An HMAC-SHA256 signing key for use with `SignedCookie`.
 
   Keys must be at least 32 bytes. Use `generate` to create a random key
   or `create` to wrap an existing one.
   """
 
+
   let _key: Array[U8] val
 
   new val create(key: Array[U8] val) ? =>
     """
+
     Wrap an existing key. Errors if `key` is shorter than 32 bytes.
     """
+
     if key.size() < 32 then error end
     _key = key
 
   new val generate() ? =>
     """
+
     Generate a 32-byte key from a cryptographically secure random source.
     Errors if the runtime cannot produce secure random bytes.
     """
+
     _key = crypto.RandBytes(32)?
 
   fun _bytes(): Array[U8] val =>
     """
+
     Return the raw key bytes.
     """
+
     _key

--- a/hobby/handler_context.pony
+++ b/hobby/handler_context.pony
@@ -3,6 +3,7 @@ use stallion = "stallion"
 
 class iso HandlerContext
   """
+
   Request context consumed by a handler factory to create a handler.
 
   Carries the HTTP request, route parameters, and request body. Created by
@@ -13,6 +14,7 @@ class iso HandlerContext
   package-private and used by `RequestHandler` to communicate with the
   connection.
   """
+
   let request: stallion.Request val
   let params: Map[String, String] val
   let body: Array[U8] val
@@ -20,9 +22,13 @@ class iso HandlerContext
   let _token: U64
   let _is_head: Bool
 
-  new iso _create(request': stallion.Request val,
-    params': Map[String, String] val, body': Array[U8] val,
-    conn': _ConnectionProtocol tag, token': U64, is_head': Bool)
+  new iso _create(
+    request': stallion.Request val,
+    params': Map[String, String] val,
+    body': Array[U8] val,
+    conn': _ConnectionProtocol tag,
+    token': U64,
+    is_head': Bool)
   =>
     request = request'
     params = params'

--- a/hobby/handler_factory.pony
+++ b/hobby/handler_factory.pony
@@ -1,9 +1,13 @@
-type HandlerFactory is {(HandlerContext iso): (HandlerReceiver tag | None)} val
+type HandlerFactory is
+  {(HandlerContext iso): (HandlerReceiver tag | None)} val
   """
+
   A handler factory creates request handlers for incoming HTTP requests.
 
   `HandlerFactory` is a `val` lambda that receives an iso handler context and
   optionally returns a handler actor reference. Inline handlers respond via
   `RequestHandler` and return `None`. Async handlers create an actor and return
-  it as `HandlerReceiver tag` for lifecycle notifications (dispose, backpressure).
+  it as `HandlerReceiver tag` for lifecycle notifications
+  (dispose, backpressure).
   """
+

--- a/hobby/handler_receiver.pony
+++ b/hobby/handler_receiver.pony
@@ -9,6 +9,15 @@ interface tag HandlerReceiver
   - `throttled()`: TCP send buffer is full; pause chunk production.
   - `unthrottled()`: TCP send buffer drained; resume chunk production.
   """
+
   be dispose()
+
   be throttled()
+    """
+    TCP send buffer is full. Pause producing chunks until `unthrottled()`.
+    """
+
   be unthrottled()
+    """
+    TCP send buffer drained. Resume producing chunks.
+    """

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -1,4 +1,5 @@
 """
+
 # Hobby
 
 A simple HTTP web framework for Pony, powered by
@@ -19,11 +20,11 @@ actor Main
     let auth = lori.TCPListenAuth(env.root)
     match
       hobby.Application
-        .>get("/", {(ctx) =>
+        .> get("/", {(ctx) =>
           hobby.RequestHandler(consume ctx)
             .respond(stallion.StatusOK, "Hello!")
         } val)
-        .>get("/greet/:name", {(ctx) =>
+        .> get("/greet/:name", {(ctx) =>
           let handler = hobby.RequestHandler(consume ctx)
           try
             handler.respond(stallion.StatusOK,
@@ -73,7 +74,8 @@ actor MyHandler is hobby.HandlerReceiver
   be unthrottled() => None
 ```
 
-Register the factory: `.>get("/data", {(ctx)(db) => MyHandler(consume ctx, db)} val)`
+Register the factory:
+`.> get("/data", {(ctx)(db) => MyHandler(consume ctx, db)} val)`
 
 ## Routing
 
@@ -96,13 +98,13 @@ An interceptor returns `InterceptPass` to let the request through or
 ```pony
 let auth: Array[hobby.RequestInterceptor val] val =
   recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
-app.>get("/private", private_factory where interceptors = auth)
+app.> get("/private", private_factory where interceptors = auth)
 ```
 
 Application-level interceptors run on every request, including 404s:
 
 ```pony
-app.>add_request_interceptor(RequiredHeadersInterceptor(
+app.> add_request_interceptor(RequiredHeadersInterceptor(
   recover val ["accept"] end))
 ```
 
@@ -122,8 +124,8 @@ class val CorsInterceptor is hobby.ResponseInterceptor
 Register at the application, group, or route level:
 
 ```pony
-app.>add_response_interceptor(CorsInterceptor)
-app.>get("/cached", handler
+app.> add_response_interceptor(CorsInterceptor)
+app.> get("/cached", handler
   where response_interceptors = cache_interceptors)
 ```
 
@@ -138,9 +140,9 @@ Group related routes under a shared prefix and interceptors with `RouteGroup`:
 let auth: Array[hobby.RequestInterceptor val] val =
   recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
 let api = hobby.RouteGroup("/api" where interceptors = auth)
-api.>get("/users", users_factory)
-api.>get("/users/:id", user_factory)
-app.>group(consume api)
+api.> get("/users", users_factory)
+api.> get("/users/:id", user_factory)
+app.> group(consume api)
 ```
 
 Groups can be nested — inner groups inherit the outer group's prefix and
@@ -205,7 +207,7 @@ actor Main
     let root = FilePath(FileAuth(env.root), "./public")
     match
       hobby.Application
-        .>get("/static/*filepath", hobby.ServeFiles(root))
+        .> get("/static/*filepath", hobby.ServeFiles(root))
         .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
     | let err: hobby.ConfigError =>
       env.err.print(err.message)
@@ -230,3 +232,4 @@ Users import up to four packages:
 - **`lori`**: `TCPListenAuth(env.root)` for network access
 - **`files`**: `FilePath`, `FileAuth` (only needed when using `ServeFiles`)
 """
+

--- a/hobby/intercept_response.pony
+++ b/hobby/intercept_response.pony
@@ -2,11 +2,12 @@ use stallion = "stallion"
 
 primitive InterceptPass
   """
+
   Returned by a request interceptor to pass the request through to the handler.
   """
-
 class ref InterceptRespond
   """
+
   Returned by a request interceptor to short-circuit with an HTTP response.
 
   The handler is not created — the interceptor's response goes directly to
@@ -22,9 +23,10 @@ class ref InterceptRespond
 
   // Short-circuit with custom headers
   InterceptRespond(stallion.StatusTooManyRequests, "Rate limited")
-    .>set_header("retry-after", "60")
+    .> set_header("retry-after", "60")
   ```
   """
+
   let _status: stallion.Status
   let _body: ByteSeq
   embed _headers: Array[(String, String)]
@@ -36,11 +38,13 @@ class ref InterceptRespond
 
   fun ref set_header(name: String, value: String) =>
     """
+
     Set a response header, replacing any existing header with the same name.
 
     The name is lowercased for consistency with HTTP's case-insensitive
     header names.
     """
+
     let lower_name: String val = name.lower()
     var i: USize = 0
     while i < _headers.size() do
@@ -58,22 +62,28 @@ class ref InterceptRespond
 
   fun ref add_header(name: String, value: String) =>
     """
+
     Add a response header without removing existing entries.
 
     The name is lowercased for consistency. Use for multi-value headers like
     `Set-Cookie`.
     """
+
     _headers.push((name.lower(), value))
 
   // --- Package-private accessors for _Connection ---
-
   fun box _response_status(): stallion.Status => _status
+
   fun box _response_body(): ByteSeq => _body
+
   fun box _headers_size(): USize => _headers.size()
+
   fun box _header_at(i: USize): (String, String) ? => _headers(i)?
 
 type InterceptResult is (InterceptPass | InterceptRespond)
   """
+
   The result of a request interceptor: either pass the request through or
   short-circuit with a response.
   """
+

--- a/hobby/request_handler.pony
+++ b/hobby/request_handler.pony
@@ -3,6 +3,7 @@ use stallion = "stallion"
 
 class ref RequestHandler
   """
+
   The handler's interface to the connection.
 
   Embedded in a user's handler actor (or used inline). Hides the connection
@@ -35,6 +36,7 @@ class ref RequestHandler
     be unthrottled() => None
   ```
   """
+
   let _conn: _ConnectionProtocol tag
   let _token: U64
   let _request: stallion.Request val
@@ -46,10 +48,12 @@ class ref RequestHandler
 
   new create(ctx: HandlerContext iso) =>
     """
+
     Create a handler from a consumed handler context.
 
     Extracts all request data and protocol references from the context.
     """
+
     _request = ctx.request
     _params = ctx.params
     _body = ctx.body
@@ -59,27 +63,33 @@ class ref RequestHandler
 
   fun ref respond(status: stallion.Status, body': ByteSeq) =>
     """
+
     Send a complete response with the given status and body.
 
     Idempotent — the first call sends the response, subsequent calls are
     silently ignored. `Content-Length` is set automatically by the connection.
     For HEAD requests, the body is suppressed but `Content-Length` is preserved.
     """
+
     if not _responded then
       _responded = true
       _conn._handler_respond(_token, status, None, body')
     end
 
-  fun ref respond_with_headers(status: stallion.Status,
-    headers: stallion.Headers val, body': ByteSeq)
+  fun ref respond_with_headers(
+    status: stallion.Status,
+    headers: stallion.Headers val,
+    body': ByteSeq)
   =>
     """
+
     Send a complete response with explicit headers and body.
 
     The caller is responsible for including `Content-Length` or any other
     required headers. For HEAD requests, the body is suppressed but all
     headers are preserved.
     """
+
     if not _responded then
       _responded = true
       _conn._handler_respond(_token, status, headers, body')
@@ -90,6 +100,7 @@ class ref RequestHandler
     : (StreamingStarted | stallion.ChunkedNotSupported | BodyNotNeeded)
   =>
     """
+
     Begin a streaming response using chunked transfer encoding.
 
     Returns `StreamingStarted` on success, `ChunkedNotSupported` for
@@ -101,6 +112,7 @@ class ref RequestHandler
 
     For `ChunkedNotSupported`, `respond()` can still be called as a fallback.
     """
+
     if _responded then
       return BodyNotNeeded
     end
@@ -119,22 +131,26 @@ class ref RequestHandler
 
   fun ref send_chunk(data: ByteSeq) =>
     """
+
     Send a streaming chunk.
 
     Only effective after `start_streaming()` returned `StreamingStarted`.
     Silently ignored otherwise.
     """
+
     if _streaming then
       _conn._handler_send_chunk(_token, data)
     end
 
   fun ref finish() =>
     """
+
     End the streaming response.
 
     Sends the terminal chunk and signals completion. Only effective after
     `start_streaming()` returned `StreamingStarted`.
     """
+
     if _streaming then
       _streaming = false
       _conn._handler_finish(_token)
@@ -142,21 +158,29 @@ class ref RequestHandler
 
   fun box param(key: String): String ? =>
     """
+
     Get a route parameter by name.
 
     Errors if the parameter does not exist. Parameter names come from route
     definitions — `:id` in `/users/:id` is accessed as `param("id")`.
     """
+
     _params(key)?
 
   fun box body(): Array[U8] val =>
-    """Return the accumulated request body bytes."""
+    """
+    Return the accumulated request body bytes.
+    """
     _body
 
   fun box request(): stallion.Request val =>
-    """Return the HTTP request."""
+    """
+    Return the HTTP request.
+    """
     _request
 
   fun box is_head(): Bool =>
-    """Return `true` if this is a HEAD request."""
+    """
+    Return `true` if this is a HEAD request.
+    """
     _is_head

--- a/hobby/request_interceptor.pony
+++ b/hobby/request_interceptor.pony
@@ -2,6 +2,7 @@ use stallion = "stallion"
 
 interface val RequestInterceptor
   """
+
   Synchronous request interceptor that runs before the handler is created.
 
   Interceptors inspect the request and return `InterceptPass` to let it
@@ -14,4 +15,11 @@ interface val RequestInterceptor
   should do only cheap work (header checks, size limits). Expensive or
   async work belongs in the handler.
   """
+
   fun apply(request: stallion.Request box): InterceptResult
+    """
+
+    Evaluate the request. Return `InterceptPass` to continue to the handler,
+    or `InterceptRespond` to short-circuit with a response.
+    """
+

--- a/hobby/response_context.pony
+++ b/hobby/response_context.pony
@@ -2,6 +2,7 @@ use stallion = "stallion"
 
 class ref ResponseContext
   """
+
   Context for response interceptors.
 
   Provides read access to the response status, body, streaming state, and the
@@ -13,6 +14,7 @@ class ref ResponseContext
   silently ignored — headers and status are already on the wire, and body
   chunks have already been sent.
   """
+
   let _buf: _BufferedResponse ref
   let _request: stallion.Request val
 
@@ -21,39 +23,51 @@ class ref ResponseContext
     _request = request'
 
   fun box status(): stallion.Status =>
-    """Return the response status."""
+    """
+    Return the response status.
+    """
     _buf.status
 
   fun box body(): (ByteSeq | None) =>
-    """Return the response body, or `None` for streaming responses."""
+    """
+    Return the response body, or `None` for streaming responses.
+    """
     _buf.body
 
   fun box is_streaming(): Bool =>
-    """Return `true` if this was a streaming response."""
+    """
+    Return `true` if this was a streaming response.
+    """
     _buf.is_streaming
 
   fun box request(): stallion.Request val =>
-    """Return the original HTTP request."""
+    """
+    Return the original HTTP request.
+    """
     _request
 
   fun ref set_status(status': stallion.Status) =>
     """
+
     Replace the response status.
 
     No-op for streaming responses (status already on wire).
     """
+
     if not _buf.is_streaming then
       _buf.status = status'
     end
 
   fun ref set_header(name: String, value: String) =>
     """
+
     Set or replace a response header.
 
     Removes any existing entries with the same name (case-insensitive per
     RFC 7230 section 3.2) and adds a new one with the name lowercased.
     No-op for streaming responses (headers already on wire).
     """
+
     if not _buf.is_streaming then
       let lower_name: String val = name.lower()
       var i: USize = 0
@@ -73,22 +87,26 @@ class ref ResponseContext
 
   fun ref add_header(name: String, value: String) =>
     """
+
     Add a response header without removing existing entries.
 
     The name is lowercased for consistency. Use for multi-value headers like
     `Set-Cookie`. No-op for streaming responses.
     """
+
     if not _buf.is_streaming then
       _buf.headers.push((name.lower(), value))
     end
 
   fun ref set_body(body': ByteSeq) =>
     """
+
     Replace the response body.
 
     Content-Length is recalculated automatically at serialization time.
     No-op for streaming responses (chunks already sent).
     """
+
     if not _buf.is_streaming then
       _buf.body = body'
     end

--- a/hobby/response_interceptor.pony
+++ b/hobby/response_interceptor.pony
@@ -2,6 +2,7 @@ use stallion = "stallion"
 
 interface val ResponseInterceptor
   """
+
   Synchronous response interceptor that runs after the handler responds but
   before the response goes to the wire.
 
@@ -18,4 +19,11 @@ interface val ResponseInterceptor
   are already on the wire. The interceptor still runs for logging and
   metrics; check `ctx.is_streaming()` to branch on streaming state.
   """
+
   fun apply(ctx: ResponseContext ref)
+    """
+
+    Process the response. Inspect or modify status, headers, and body
+    via the provided `ResponseContext`.
+    """
+

--- a/hobby/route_group.pony
+++ b/hobby/route_group.pony
@@ -2,6 +2,7 @@ use stallion = "stallion"
 
 class iso RouteGroup
   """
+
   A group of routes sharing a common path prefix and optional interceptors.
 
   Route groups let you factor out repeated prefixes and interceptors instead of
@@ -13,9 +14,9 @@ class iso RouteGroup
   let auth_interceptors: Array[hobby.RequestInterceptor val] val =
     recover val [as hobby.RequestInterceptor val: AuthInterceptor] end
   let api = hobby.RouteGroup("/api" where interceptors = auth_interceptors)
-  api.>get("/users", users_factory)
-  api.>get("/users/:id", user_factory)
-  app.>group(consume api)
+  api.> get("/users", users_factory)
+  api.> get("/users/:id", user_factory)
+  app.> group(consume api)
   ```
 
   Route methods are `fun ref` — automatic receiver recovery allows calling
@@ -24,17 +25,22 @@ class iso RouteGroup
   `RouteGroup.group()` when done — this consumes the group and flattens its
   routes.
   """
+
   let _prefix: String
   let _interceptors: (Array[RequestInterceptor val] val | None)
   let _response_interceptors: (Array[ResponseInterceptor val] val | None)
   embed _routes: Array[_RouteDefinition]
   embed _group_infos: Array[_GroupInfo]
 
-  new iso create(prefix: String,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
+  new iso create(
+    prefix: String,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
   =>
     """
+
     Create a route group with a path prefix and optional interceptors.
 
     The prefix must be a static path segment — no `:param` or `*wildcard`
@@ -44,132 +50,232 @@ class iso RouteGroup
     interceptors. Response interceptors, if provided, run before each
     route's own response interceptors.
     """
+
     _prefix = prefix
     _interceptors = interceptors
     _response_interceptors = response_interceptors
     _routes = Array[_RouteDefinition]
     _group_infos = Array[_GroupInfo]
 
-  fun ref get(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a GET route."""
-    _routes.push(
-      _RouteDefinition(stallion.GET, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref post(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a POST route."""
-    _routes.push(
-      _RouteDefinition(stallion.POST, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref put(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a PUT route."""
-    _routes.push(
-      _RouteDefinition(stallion.PUT, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref delete(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a DELETE route."""
-    _routes.push(
-      _RouteDefinition(stallion.DELETE, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref patch(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a PATCH route."""
-    _routes.push(
-      _RouteDefinition(stallion.PATCH, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref head(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register a HEAD route."""
-    _routes.push(
-      _RouteDefinition(stallion.HEAD, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref options(path: String, factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
-  =>
-    """Register an OPTIONS route."""
-    _routes.push(
-      _RouteDefinition(stallion.OPTIONS, path, factory, response_interceptors,
-        interceptors))
-
-  fun ref route(method: stallion.Method, path: String,
+  fun ref get(
+    path: String,
     factory: HandlerFactory,
-    interceptors: (Array[RequestInterceptor val] val | None) = None,
-    response_interceptors: (Array[ResponseInterceptor val] val | None) = None)
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
   =>
-    """Register a route with an arbitrary HTTP method."""
+    """
+    Register a GET route.
+    """
     _routes.push(
-      _RouteDefinition(method, path, factory, response_interceptors,
+      _RouteDefinition(
+        stallion.GET,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref post(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a POST route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.POST,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref put(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a PUT route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.PUT,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref delete(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a DELETE route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.DELETE,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref patch(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a PATCH route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.PATCH,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref head(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a HEAD route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.HEAD,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref options(
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register an OPTIONS route.
+    """
+    _routes.push(
+      _RouteDefinition(
+        stallion.OPTIONS,
+        path,
+        factory,
+        response_interceptors,
+        interceptors))
+
+  fun ref route(
+    method: stallion.Method,
+    path: String,
+    factory: HandlerFactory,
+    interceptors:
+      (Array[RequestInterceptor val] val | None) = None,
+    response_interceptors:
+      (Array[ResponseInterceptor val] val | None) = None)
+  =>
+    """
+    Register a route with an arbitrary HTTP method.
+    """
+    _routes.push(
+      _RouteDefinition(
+        method,
+        path,
+        factory,
+        response_interceptors,
         interceptors))
 
   fun ref group(inner: RouteGroup iso) =>
     """
+
     Consume a nested route group, flattening its routes into this group.
 
     The inner group's prefix is appended to this group's prefix, and the inner
     group's interceptors are preserved separately for tree building. The inner
     group is consumed — no further registration on it is possible.
     """
-    let inner_ref: RouteGroup ref = consume inner
-    inner_ref._collect_group_infos(_group_infos, _prefix)
-    inner_ref._flatten_routes_into(_routes, _prefix)
 
-  fun box _flatten_routes_into(target: Array[_RouteDefinition] ref,
+    (consume inner)
+      .> _collect_group_infos(_group_infos, _prefix)
+      .> _flatten_routes_into(_routes, _prefix)
+
+  fun box _flatten_routes_into(
+    target: Array[_RouteDefinition] ref,
     outer_prefix: String = "")
   =>
     """
+
     Flatten routes into target, joining paths with outer prefix.
 
     Per-route interceptors are passed through unchanged — no concatenation
     with group interceptors. Group interceptors are handled separately via
     `_collect_group_infos()` and registered on tree nodes.
     """
+
     let full_prefix = _JoinPath(outer_prefix, _prefix)
     for r in _routes.values() do
       let joined_path = _JoinPath(full_prefix, r.path)
-      target.push(_RouteDefinition(r.method, joined_path, r.factory,
-        r.response_interceptors, r.interceptors))
+      target.push(
+        _RouteDefinition(
+          r.method,
+          joined_path,
+          r.factory,
+          r.response_interceptors,
+          r.interceptors))
     end
 
-  fun box _collect_group_infos(target: Array[_GroupInfo] ref,
+  fun box _collect_group_infos(
+    target: Array[_GroupInfo] ref,
     outer_prefix: String = "")
   =>
     """
+
     Collect this group's info and any nested group infos into target.
 
     Prefixes are joined through all nesting levels. Only emits a `_GroupInfo`
     if this group has interceptors.
     """
+
     let full_prefix = _JoinPath(outer_prefix, _prefix)
     if (_interceptors isnt None) or (_response_interceptors isnt None) then
-      target.push(_GroupInfo(full_prefix, _interceptors,
-        _response_interceptors))
+      target.push(
+        _GroupInfo(
+          full_prefix,
+          _interceptors,
+          _response_interceptors))
     end
     // Re-prefix nested group infos with our outer prefix, since they were
     // collected relative to this group's prefix, not the full path.
     for gi in _group_infos.values() do
       let adjusted_prefix = _JoinPath(outer_prefix, gi.prefix)
-      target.push(_GroupInfo(adjusted_prefix, gi.interceptors,
-        gi.response_interceptors))
+      target.push(
+        _GroupInfo(
+          adjusted_prefix,
+          gi.interceptors,
+          gi.response_interceptors))
     end

--- a/hobby/serve_files.pony
+++ b/hobby/serve_files.pony
@@ -4,6 +4,7 @@ use stallion = "stallion"
 
 class val ServeFiles
   """
+
   Serve files from a directory on disk.
 
   Structurally matches `HandlerFactory` — pass directly to route methods.
@@ -17,24 +18,28 @@ class val ServeFiles
   small files are still served normally, but large files are rejected
   with 505 HTTP Version Not Supported to prevent memory exhaustion.
 
-  HEAD requests are optimized: the handler responds with `Content-Type` and
-  `Content-Length` headers without reading the file, regardless of file size.
+  HEAD requests are optimized: the handler responds with `Content-Type`
+  and `Content-Length` headers without reading the file, regardless of
+  file size.
 
   Responses include caching headers:
 
-  - **ETag**: Weak ETag computed from file metadata (`W/"<inode>-<size>-<mtime>"`).
-    On Windows, `FileInfo.inode` is always 0, reducing collision resistance
-    to size+mtime only.
-  - **Last-Modified**: RFC 7231 IMF-fixdate from the file's modification time.
+  - **ETag**: Weak ETag computed from file metadata
+    (`W/"<inode>-<size>-<mtime>"`). On Windows, `FileInfo.inode` is
+    always 0, reducing collision resistance to size+mtime only.
+  - **Last-Modified**: RFC 7231 IMF-fixdate from the file's modification
+    time.
   - **Cache-Control**: Configurable via the `cache_control` constructor
-    parameter. Defaults to `"public, max-age=3600"`. Pass `None` to omit.
+    parameter. Defaults to `"public, max-age=3600"`. Pass `None` to
+    omit.
 
   Conditional requests are supported per RFC 7232:
 
-  - `If-None-Match` is checked first (ETag comparison using weak matching).
+  - `If-None-Match` is checked first (ETag comparison using weak
+    matching).
   - `If-Modified-Since` is checked only when `If-None-Match` is absent.
-  - When either matches, the handler responds with 304 Not Modified (cache
-    headers included, no body).
+  - When either matches, the handler responds with 304 Not Modified
+    (cache headers included, no body).
 
   Custom content types can be added via the `content_types` parameter:
 
@@ -58,8 +63,11 @@ class val ServeFiles
       let auth = lori.TCPListenAuth(env.root)
       let root = FilePath(FileAuth(env.root), "./public")
       hobby.Application
-        .>get("/static/*filepath", hobby.ServeFiles(root))
-        .serve(auth, stallion.ServerConfig("0.0.0.0", "8080"), env.out)
+        .> get("/static/*filepath", hobby.ServeFiles(root))
+        .serve(
+          auth,
+          stallion.ServerConfig("0.0.0.0", "8080"),
+          env.out)
   ```
 
   Path traversal is prevented by Pony's `FilePath.from()`, which rejects
@@ -70,16 +78,20 @@ class val ServeFiles
   correct `text/html` content type and caching headers. If no `index.html`
   exists, the directory request returns 404.
   """
+
   let _root: FilePath
   let _chunk_threshold: USize
   let _cache_control: (String | None)
   let _content_types: ContentTypes
 
-  new val create(root: FilePath, chunk_threshold: USize = 1024,
+  new val create(
+    root: FilePath,
+    chunk_threshold: USize = 1024,
     cache_control: (String | None) = "public, max-age=3600",
     content_types: ContentTypes = ContentTypes)
   =>
     """
+
     Create a handler factory that serves files under `root`.
 
     `root` must have `FileLookup`, `FileStat`, and `FileRead` capabilities.
@@ -97,6 +109,7 @@ class val ServeFiles
     If the route uses a wildcard name other than `*filepath`, param lookup
     will fail and the handler will return 500. Always use `*filepath`.
     """
+
     _root = root
     _chunk_threshold = chunk_threshold * 1024
     _cache_control = cache_control
@@ -109,14 +122,16 @@ class val ServeFiles
     let params = ctx.params
 
     // Resolve the file action without consuming ctx
-    match _resolve(request, params)
+    match \exhaustive\ _resolve(request, params)
     | let r: _ServeInline =>
       _do_inline(consume ctx, r)
     | let r: _ServeStream =>
       _do_stream(consume ctx, r)
     end
 
-  fun _do_inline(ctx: HandlerContext iso, r: _ServeInline)
+  fun _do_inline(
+    ctx: HandlerContext iso,
+    r: _ServeInline)
     : (HandlerReceiver tag | None)
   =>
     let handler = RequestHandler(consume ctx)
@@ -128,72 +143,89 @@ class val ServeFiles
     end
     None
 
-  fun _do_stream(ctx: HandlerContext iso, r: _ServeStream)
+  fun _do_stream(
+    ctx: HandlerContext iso,
+    r: _ServeStream)
     : (HandlerReceiver tag | None)
   =>
-    let file_result: (File iso | None) = try
-      recover iso
-        let f = File.open(r.resolved)
-        if f.errno() isnt FileOK then error end
-        f
+    let file_result: (File iso | None) =
+      try
+        recover iso
+          let f = File.open(r.resolved)
+          if f.errno() isnt FileOK then error end
+          f
+        end
+      else
+        None
       end
-    else
-      None
-    end
     match consume file_result
     | let file: File iso =>
-      _ServeFilesHandler(consume ctx, consume file, r.status, r.headers)
+      _ServeFilesHandler(
+        consume ctx, consume file, r.status, r.headers)
     else
       RequestHandler(consume ctx).respond(
-        stallion.StatusInternalServerError, "Internal Server Error")
+        stallion.StatusInternalServerError,
+        "Internal Server Error")
       None
     end
 
-  fun _resolve(request: stallion.Request val,
+  fun _resolve(
+    request: stallion.Request val,
     params: Map[String, String] val)
     : (_ServeInline | _ServeStream)
   =>
     let is_head = request.method is stallion.HEAD
 
     // Extract wildcard param
-    let filepath = try
-      params("filepath")?
-    else
-      return _ServeInline._error(stallion.StatusInternalServerError,
-        "Internal Server Error")
-    end
+    let filepath =
+      try
+        params("filepath")?
+      else
+        return _ServeInline._error(
+          stallion.StatusInternalServerError,
+          "Internal Server Error")
+      end
 
     // Resolve path safely
-    var resolved = try
-      FilePath.from(_root, filepath)?
-    else
-      return _ServeInline._error(stallion.StatusNotFound, "Not Found")
-    end
+    var resolved =
+      try
+        FilePath.from(_root, filepath)?
+      else
+        return _ServeInline._error(
+          stallion.StatusNotFound, "Not Found")
+      end
 
     // Stat the file
-    var info = try
-      FileInfo(resolved)?
-    else
-      return _ServeInline._error(stallion.StatusNotFound, "Not Found")
-    end
+    var info =
+      try
+        FileInfo(resolved)?
+      else
+        return _ServeInline._error(
+          stallion.StatusNotFound, "Not Found")
+      end
 
     // Directory → try serving index.html
     if info.directory then
-      resolved = try
-        FilePath.from(resolved, "index.html")?
-      else
-        return _ServeInline._error(stallion.StatusNotFound, "Not Found")
-      end
-      info = try
-        FileInfo(resolved)?
-      else
-        return _ServeInline._error(stallion.StatusNotFound, "Not Found")
-      end
+      resolved =
+        try
+          FilePath.from(resolved, "index.html")?
+        else
+          return _ServeInline._error(
+            stallion.StatusNotFound, "Not Found")
+        end
+      info =
+        try
+          FileInfo(resolved)?
+        else
+          return _ServeInline._error(
+            stallion.StatusNotFound, "Not Found")
+        end
     end
 
     // After index fallback, non-file entries still 404
     if not info.file then
-      return _ServeInline._error(stallion.StatusNotFound, "Not Found")
+      return _ServeInline._error(
+        stallion.StatusNotFound, "Not Found")
     end
 
     let content_type = _content_types(Path.ext(resolved.path))
@@ -201,74 +233,85 @@ class val ServeFiles
     // Compute cache identifiers
     (let mod_secs, _) = info.modified_time
     let etag = _ETag(info.inode, info.size, mod_secs)
-    let last_modified = _HttpDate(mod_secs)
+    let last_modified = _HTTPDate(mod_secs)
 
     // Conditional request validation (RFC 7232 §3)
-    let not_modified = match request.headers.get("if-none-match")
-    | let inm: String => _ETag.matches(inm, etag)
-    else
-      match request.headers.get("if-modified-since")
-      | let ims: String => ims == last_modified
+    let not_modified =
+      match request.headers.get("if-none-match")
+      | let inm: String => _ETag.matches(inm, etag)
       else
-        false
+        match request.headers.get("if-modified-since")
+        | let ims: String => ims == last_modified
+        else
+          false
+        end
       end
-    end
 
     if not_modified then
-      let headers = recover val
-        let h = stallion.Headers
-          .>set("ETag", etag)
-          .>set("Last-Modified", last_modified)
-        match _cache_control
-        | let cc: String => h.>set("Cache-Control", cc)
+      let headers =
+        recover val
+          let h = stallion.Headers
+            .> set("ETag", etag)
+            .> set("Last-Modified", last_modified)
+          match _cache_control
+          | let cc: String =>
+            h .> set("Cache-Control", cc)
+          end
+          h
         end
-        h
-      end
       return _ServeInline._with_headers(
         stallion.StatusNotModified, headers, "")
     end
 
     // HEAD optimization: headers only, skip file I/O
     if is_head then
-      let headers = recover val
-        let h = stallion.Headers
-          .>set("Content-Type", content_type)
-          .>set("Content-Length", info.size.string())
-          .>set("ETag", etag)
-          .>set("Last-Modified", last_modified)
-        match _cache_control
-        | let cc: String => h.>set("Cache-Control", cc)
+      let headers =
+        recover val
+          let h = stallion.Headers
+            .> set("Content-Type", content_type)
+            .> set("Content-Length", info.size.string())
+            .> set("ETag", etag)
+            .> set("Last-Modified", last_modified)
+          match _cache_control
+          | let cc: String =>
+            h .> set("Cache-Control", cc)
+          end
+          h
         end
-        h
-      end
-      return _ServeInline._with_headers(stallion.StatusOK, headers, "")
+      return _ServeInline._with_headers(
+        stallion.StatusOK, headers, "")
     end
 
     if info.size < _chunk_threshold then
       // Small file: read and respond inline
-      let file = try
-        let f = File.open(resolved)
-        if f.errno() isnt FileOK then error end
-        f
-      else
-        return _ServeInline._error(stallion.StatusInternalServerError,
-          "Internal Server Error")
-      end
+      let file =
+        try
+          let f = File.open(resolved)
+          if f.errno() isnt FileOK then error end
+          f
+        else
+          return _ServeInline._error(
+            stallion.StatusInternalServerError,
+            "Internal Server Error")
+        end
       let body = file.read(info.size)
       file.dispose()
       let body_size = body.size()
-      let headers = recover val
-        let h = stallion.Headers
-          .>set("Content-Type", content_type)
-          .>set("Content-Length", body_size.string())
-          .>set("ETag", etag)
-          .>set("Last-Modified", last_modified)
-        match _cache_control
-        | let cc: String => h.>set("Cache-Control", cc)
+      let headers =
+        recover val
+          let h = stallion.Headers
+            .> set("Content-Type", content_type)
+            .> set("Content-Length", body_size.string())
+            .> set("ETag", etag)
+            .> set("Last-Modified", last_modified)
+          match _cache_control
+          | let cc: String =>
+            h .> set("Cache-Control", cc)
+          end
+          h
         end
-        h
-      end
-      _ServeInline._with_headers(stallion.StatusOK, headers, consume body)
+      _ServeInline._with_headers(
+        stallion.StatusOK, headers, consume body)
     else
       // Large file: check HTTP version first
       if request.version is stallion.HTTP10 then
@@ -277,16 +320,18 @@ class val ServeFiles
           "HTTP Version Not Supported")
       end
 
-      let headers = recover val
-        let h = stallion.Headers
-          .>set("Content-Type", content_type)
-          .>set("ETag", etag)
-          .>set("Last-Modified", last_modified)
-        match _cache_control
-        | let cc: String => h.>set("Cache-Control", cc)
+      let headers =
+        recover val
+          let h = stallion.Headers
+            .> set("Content-Type", content_type)
+            .> set("ETag", etag)
+            .> set("Last-Modified", last_modified)
+          match _cache_control
+          | let cc: String =>
+            h .> set("Cache-Control", cc)
+          end
+          h
         end
-        h
-      end
 
       _ServeStream(resolved, stallion.StatusOK, headers)
     end
@@ -302,8 +347,10 @@ class val _ServeInline
     headers = None
     body = body'
 
-  new val _with_headers(status': stallion.Status,
-    headers': stallion.Headers val, body': ByteSeq)
+  new val _with_headers(
+    status': stallion.Status,
+    headers': stallion.Headers val,
+    body': ByteSeq)
   =>
     status = status'
     headers = headers'
@@ -314,7 +361,9 @@ class val _ServeStream
   let status: stallion.Status
   let headers: stallion.Headers val
 
-  new val create(resolved': FilePath, status': stallion.Status,
+  new val create(
+    resolved': FilePath,
+    status': stallion.Status,
     headers': stallion.Headers val)
   =>
     resolved = resolved'

--- a/hobby/serve_result.pony
+++ b/hobby/serve_result.pony
@@ -4,7 +4,6 @@ primitive Serving
 
   The listener is running and accepting connections.
   """
-
 class val ConfigError
   """
   Returned by `Application.serve()` when a configuration error prevented

--- a/hobby/signed_cookie.pony
+++ b/hobby/signed_cookie.pony
@@ -3,16 +3,20 @@ use "encode/base64"
 
 primitive SignedCookie
   """
+
   Signs and verifies cookie values using HMAC-SHA256.
 
   The signed format is `value.base64url(hmac)`. The value is readable
   (not encrypted); the signature proves integrity.
   """
 
+
   fun sign(key: CookieSigningKey, value: String val): String val =>
     """
+
     Sign `value` and return the signed string `value.signature`.
     """
+
     let hmac: Array[U8] val = crypto.HmacSha256(key._bytes(), value)
     let sig: String val =
       Base64.encode_url[String iso](hmac where pad = true)
@@ -29,9 +33,11 @@ primitive SignedCookie
     : (String val | SignedCookieError)
   =>
     """
+
     Verify the signature on `signed_value`. Returns the original value
     on success, or a `SignedCookieError` describing the failure.
     """
+
     let pos: ISize =
       try
         signed_value.rfind(".")?

--- a/hobby/signed_cookie_error.pony
+++ b/hobby/signed_cookie_error.pony
@@ -1,23 +1,29 @@
 primitive MalformedSignedValue
   """
+
   The signed cookie value is structurally invalid: it is missing the `.`
   separator between the value and signature, or the signature portion is
   empty or not valid Base64.
   """
+
 
   fun string(): String iso^ =>
     "malformed signed value".clone()
 
 primitive InvalidSignature
   """
+
   The signature did not match the value. The cookie was tampered with or
   signed with a different key.
   """
+
 
   fun string(): String iso^ =>
     "invalid signature".clone()
 
 type SignedCookieError is (MalformedSignedValue | InvalidSignature)
   """
+
   Errors that can occur when verifying a signed cookie value.
   """
+

--- a/hobby/streaming_started.pony
+++ b/hobby/streaming_started.pony
@@ -1,8 +1,10 @@
 primitive StreamingStarted
   """
+
   Returned by `RequestHandler.start_streaming()` on success.
 
   Indicates that chunked streaming has begun. The handler should proceed to
   send chunks via `RequestHandler.send_chunk()` and signal completion with
   `RequestHandler.finish()`.
   """
+


### PR DESCRIPTION
Adds pony-lint CI matching the pattern from courier:

- `pony-lint.yml` — runs on PRs when `.pony` files change (release image)
- `lint-against-pony-lint-latest.yml` — runs on shared Docker builder updates with Zulip failure alerts (nightly image)
- `make lint` target in the Makefile

Fixes all 949 pony-lint violations across the codebase: formatting (call-argument-format, assignment-indent, method-declaration-format, dot-spacing, blank-lines, docstring-format, line-length, control-structure-alignment, array-literal-format, match-case-indent, indentation-size, lambda-spacing), safety (exhaustive-match), naming (acronym-casing, file-naming, package-docstring), documentation (public-docstring), and style (prefer-chaining).

Updates CLAUDE.md to reflect the three file renames required by the file-naming lint rule.

Closes #61