### PR TITLE
Detect conflicting wildcard parameter names

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -113,7 +113,7 @@ api.>post("/users", create_user_factory
   where interceptors = recover val [as hobby.RequestInterceptor val: CsrfInterceptor] end)
 ```
 
-`Application.serve()` now returns `ServeResult` — either `Serving` on success or `ConfigError` with a message describing the problem. Configuration errors (overlapping group prefixes, empty group prefix, special characters in group prefix, conflicting param names) are detected at `serve()` time and reported as data instead of panicking:
+`Application.serve()` now returns `ServeResult` — either `Serving` on success or `ConfigError` with a message describing the problem. Configuration errors (overlapping group prefixes, empty group prefix, special characters in group prefix, conflicting param names, conflicting wildcard names) are detected at `serve()` time and reported as data instead of panicking:
 
 ```pony
 match

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,10 @@ make ssl=libressl       # use LibreSSL (CI uses this)
 make config=debug       # debug build (combine with ssl=...)
 make examples ssl=3.0.x # examples only
 make clean              # clean build artifacts + corral cache
+make lint               # run pony-lint (must pass before pushing)
 ```
+
+All code changes must pass `make lint` locally before pushing. The linter enforces 80-column line limits and other style rules.
 
 The `ssl` option is required — Stallion transitively depends on the `ssl` package. Valid values: `3.0.x` (OpenSSL 3.x), `1.1.x` (OpenSSL 1.1.x), `libressl` (LibreSSL).
 
@@ -38,7 +41,7 @@ Users interact with these types:
 
 - **`Application`** (`class iso`): Route registration via `.>` chaining (`get`, `post`, etc.), `group()` for route groups, `add_request_interceptor()` for app-level request interceptors, `add_response_interceptor()` for app-level response interceptors. Route methods accept optional `response_interceptors` parameter. `serve()` consumes the Application, validates configuration, freezes routes into an immutable router, and starts listening. Returns `ServeResult` — `Serving` on success or `ConfigError` with a description of the problem. `handler_timeout` parameter on `serve()` controls inactivity timeout (default 30 seconds, `None` to disable).
 - **`Serving`** (`primitive`): Returned by `serve()` when the server started successfully.
-- **`ConfigError`** (`class val`): Returned by `serve()` when a configuration error prevented startup. Carries a `message: String` describing the error. Detected errors: overlapping group prefixes, empty group prefix, special characters in group prefix, conflicting param names.
+- **`ConfigError`** (`class val`): Returned by `serve()` when a configuration error prevented startup. Carries a `message: String` describing the error. Detected errors: overlapping group prefixes, empty group prefix, special characters in group prefix, conflicting param names, conflicting wildcard names.
 - **`ServeResult`** (type alias): `(Serving | ConfigError)`. Return type of `serve()`.
 - **`RouteGroup`** (`class iso`): Groups routes under a shared prefix and optional response interceptors. Constructor accepts `response_interceptors` parameter. Supports nesting via `group()`. Consumed by `Application.group()` or outer `RouteGroup.group()`.
 - **`RequestInterceptor`** (`interface val`): Synchronous request gate. `apply(request: Request box): InterceptResult` returns `InterceptPass` or `InterceptRespond`. The return type forces an explicit decision — the compiler won't accept an interceptor that forgets to decide. The first interceptor that responds wins.

--- a/hobby/_router.pony
+++ b/hobby/_router.pony
@@ -8,8 +8,8 @@ class ref _RouterBuilder
 
   Accumulates route definitions and group interceptors into a single shared
   path tree, then freezes it into an immutable router via `build()`.
-  Configuration errors (e.g., conflicting param names) are accumulated in
-  `_errors` and available via `first_error()`.
+  Configuration errors (e.g., conflicting param or wildcard names) are
+  accumulated in `_errors` and available via `first_error()`.
   """
 
   var _root: _BuildNode ref
@@ -250,12 +250,23 @@ class ref _BuildNode
         interceptors,
         errors)
     elseif first == '*' then
+      let name = segment.trim(1)
       _wildcard_entries(method) =
         _BuildMethodEntry(
           factory,
           interceptors,
           response_interceptors)
-      _wildcard_name = segment.trim(1)
+      if (_wildcard_name.size() > 0)
+        and (_wildcard_name != name)
+      then
+        errors.push(
+          "Conflicting wildcard names at the same path " +
+          "position: '*" + _wildcard_name +
+          "' vs '*" + name +
+          "'. All methods at the same path must use " +
+          "the same wildcard name.")
+      end
+      _wildcard_name = name
     else
       let child =
         try _children(segment)? else

--- a/hobby/_test_router.pony
+++ b/hobby/_test_router.pony
@@ -55,6 +55,8 @@ primitive \nodoc\ _TestRouterList
     test(_TestJoinRemainingSegments)
     test(_TestRoutesBeforeInterceptors)
     test(_TestMethodNotAllowedCarriesInterceptors)
+    test(_TestWildcardNameConflictReturnsError)
+    test(_TestSharedWildcardNameConsistent)
 
 // --- Generators ---
 primitive \nodoc\ _GenPathSegment
@@ -2085,4 +2087,69 @@ class \nodoc\ iso _TestMethodNotAllowedCarriesInterceptors is UnitTest
       h.fail("should not match GET on POST-only route")
     | let _: _RouteMiss =>
       h.fail("should be 405, not 404")
+    end
+
+class \nodoc\ iso _TestWildcardNameConflictReturnsError is UnitTest
+  """
+  Conflicting wildcard names at the same position produce a ConfigError.
+  """
+  fun name(): String => "router/wildcard name conflict returns error"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files/*path", _NoOpFactory, None)
+    builder.add(stallion.POST, "/files/*filepath", _NoOpFactory, None)
+    match builder.first_error()
+    | let err: ConfigError =>
+      h.assert_true(
+        err.message.contains("Conflicting wildcard names"))
+      h.assert_true(err.message.contains("'*path'"))
+      h.assert_true(err.message.contains("'*filepath'"))
+    else
+      h.fail(
+        "conflicting wildcard names should produce ConfigError")
+    end
+
+class \nodoc\ iso _TestSharedWildcardNameConsistent is UnitTest
+  """
+
+  Multiple methods at the same wildcard position with the same name works.
+
+  GET /files/*path and POST /files/*path share a wildcard node — the name
+  must match. Verifies no error is produced and both methods route correctly
+  with correct wildcard param extraction.
+  """
+
+  fun name(): String => "router/shared wildcard name consistent"
+
+  fun apply(h: TestHelper) =>
+    let builder = _RouterBuilder
+    builder.add(stallion.GET, "/files/*path", _NoOpFactory, None)
+    builder.add(stallion.POST, "/files/*path", _NoOpFactory, None)
+    h.assert_true(
+      builder.first_error() is None,
+      "same wildcard name should not produce error")
+    let router = builder.build()
+
+    match router.lookup(stallion.GET, "/files/readme.txt")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String]("readme.txt", m.params("path")?)
+      else
+        h.fail("param 'path' not found on GET")
+      end
+    else
+      h.fail("expected match for GET /files/readme.txt")
+    end
+
+    match router.lookup(stallion.POST, "/files/docs/guide.md")
+    | let m: _RouteMatch =>
+      try
+        h.assert_eq[String](
+          "docs/guide.md", m.params("path")?)
+      else
+        h.fail("param 'path' not found on POST")
+      end
+    else
+      h.fail("expected match for POST /files/docs/guide.md")
     end

--- a/hobby/application.pony
+++ b/hobby/application.pony
@@ -269,7 +269,7 @@ class iso Application
     Consumes the Application — no further route registration is possible
     after this call. Returns `Serving` on success or `ConfigError` if
     a configuration error was detected (overlapping group prefixes,
-    invalid group prefix, conflicting param names).
+    invalid group prefix, conflicting param or wildcard names).
 
     `handler_timeout` is the handler inactivity timeout in milliseconds.
     Defaults to 30 seconds. Pass `None` to disable the timeout. When a
@@ -336,7 +336,7 @@ class iso Application
         r.interceptors)
     end
 
-    // Check for tree-level errors (e.g., conflicting param names)
+    // Check for tree-level errors (e.g., conflicting param or wildcard names)
     match builder.first_error()
     | let err: ConfigError => return err
     end

--- a/hobby/serve_result.pony
+++ b/hobby/serve_result.pony
@@ -14,6 +14,7 @@ class val ConfigError
   - Empty group prefix (use `add_request_interceptor()` instead)
   - Special characters in group prefix (`:` or `*`)
   - Conflicting param names at the same path position across methods
+  - Conflicting wildcard names at the same path position across methods
   """
   let message: String
 


### PR DESCRIPTION
When two routes register wildcards at the same path node with different names (e.g., `GET /files/*path` and `POST /files/*filepath`), `_wildcard_name` was silently overwritten by whichever was registered last. Both method entries ended up using the last-registered name for param extraction, so a handler looking for `params("path")?` would fail if a later registration overwrote the name.

Adds conflict detection parallel to the existing param name check — detected at `serve()` time and reported as `ConfigError`. Also documents the `make lint` requirement in CLAUDE.md.

Also filed two pre-existing issues found during review:
- #72 — Segments after wildcard are silently dropped
- #73 — Empty wildcard or param name bypasses conflict detection

Closes #65