### PR TITLE
Fix pony-lint blank-lines violations

### DIFF
--- a/hobby/handler_timeout.pony
+++ b/hobby/handler_timeout.pony
@@ -45,6 +45,7 @@ type HandlerTimeout is Constrained[U64, HandlerTimeoutValidator]
   `(HandlerTimeout | ValidationFailure)`. Pass to `Server` or
   `Server.ssl` to set the timeout, or pass `None` to disable it.
   """
+
 type MakeHandlerTimeout is
   MakeConstrained[U64, HandlerTimeoutValidator]
   """

--- a/hobby/intercept_response.pony
+++ b/hobby/intercept_response.pony
@@ -2,9 +2,9 @@ use stallion = "stallion"
 
 primitive InterceptPass
   """
-
   Returned by a request interceptor to pass the request through to the handler.
   """
+
 class ref InterceptRespond
   """
 


### PR DESCRIPTION
A leading blank line inside InterceptPass's docstring caused pony-lint's `style/blank-lines` rule to miscount blank lines between entities — `end_pos()` fell back to `node.line()`, so the blank line inside the docstring got counted as a blank line between entities. Removing the leading blank line fixes the false positive (see ponylang/ponyc#5120 for the upstream lint gap).

The handler_timeout.pony change adds the missing blank line between consecutive type alias entities.