### PR TITLE
Fix pony-lint docstring-leading-blank and blank-lines violations

### DIFF
--- a/examples/async-handler/async_handler.pony
+++ b/examples/async-handler/async_handler.pony
@@ -1,5 +1,4 @@
 """
-
 Async handler example.
 """
 

--- a/examples/async-handler/main.pony
+++ b/examples/async-handler/main.pony
@@ -6,7 +6,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Async handler example.
 
   Demonstrates actor-based handlers that do async work before responding.
@@ -22,7 +21,6 @@ actor Main is hobby.ServerNotify
     curl http://localhost:8080/
     curl http://localhost:8080/slow
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/custom-content-types/custom_content_types.pony
+++ b/examples/custom-content-types/custom_content_types.pony
@@ -1,5 +1,4 @@
 """
-
 Custom content types example.
 """
 

--- a/examples/custom-content-types/main.pony
+++ b/examples/custom-content-types/main.pony
@@ -7,7 +7,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Custom content type mapping example.
 
   Starts an HTTP server on 0.0.0.0:8080 that serves files from `public/`
@@ -24,7 +23,6 @@ actor Main is hobby.ServerNotify
     curl -I http://localhost:8080/static/photo.avif
     curl -I http://localhost:8080/static/index.html
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/hello/hello.pony
+++ b/examples/hello/hello.pony
@@ -1,5 +1,4 @@
 """
-
 Hello world example.
 """
 

--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -16,7 +16,6 @@ actor Main is hobby.ServerNotify
     curl http://localhost:8080/
     curl http://localhost:8080/greet/World
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/https/https.pony
+++ b/examples/https/https.pony
@@ -1,5 +1,4 @@
 """
-
 HTTPS example using Server.ssl() with a self-signed certificate.
 """
 

--- a/examples/https/main.pony
+++ b/examples/https/main.pony
@@ -17,7 +17,6 @@ actor Main is hobby.ServerNotify
     curl -k https://localhost:8443/
     curl -k https://localhost:8443/greet/World
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/request-interceptors/main.pony
+++ b/examples/request-interceptors/main.pony
@@ -6,7 +6,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Demonstrates request interceptors for synchronous request short-circuiting.
 
   Interceptors run before the handler is created. An interceptor returns
@@ -20,7 +19,6 @@ actor Main is hobby.ServerNotify
   - GET /admin         → requires X-Admin and Authorization headers
 
   """
-
   let _env: Env
 
   new create(env: Env) =>
@@ -107,14 +105,12 @@ actor Main is hobby.ServerNotify
 
 class val AuthInterceptor is hobby.RequestInterceptor
   """
-
   Rejects requests that lack an Authorization header.
 
   This is a cheap synchronous check — it only verifies the header is present,
   not that the credentials are valid. Real credential validation requires
   async work and belongs in the handler actor.
   """
-
   fun apply(request: stallion.Request box): hobby.InterceptResult =>
     match request.headers.get("authorization")
     | let _: String => hobby.InterceptPass
@@ -124,10 +120,8 @@ class val AuthInterceptor is hobby.RequestInterceptor
 
 class val ContentTypeInterceptor is hobby.RequestInterceptor
   """
-
   Rejects requests whose Content-Type header doesn't match the expected value.
   """
-
   let _expected: String
 
   new val create(expected: String) => _expected = expected
@@ -143,10 +137,8 @@ class val ContentTypeInterceptor is hobby.RequestInterceptor
 
 class val MaxBodySizeInterceptor is hobby.RequestInterceptor
   """
-
   Rejects requests whose Content-Length exceeds a maximum size in bytes.
   """
-
   let _max: USize
 
   new val create(max: USize) => _max = max
@@ -166,10 +158,8 @@ class val MaxBodySizeInterceptor is hobby.RequestInterceptor
 
 class val RequiredHeadersInterceptor is hobby.RequestInterceptor
   """
-
   Rejects requests that are missing any of the required headers.
   """
-
   let _headers: Array[String] val
 
   new val create(headers: Array[String] val) => _headers = headers

--- a/examples/request-interceptors/request_interceptors.pony
+++ b/examples/request-interceptors/request_interceptors.pony
@@ -1,5 +1,4 @@
 """
-
 Request interceptors example.
 """
 

--- a/examples/response-interceptors/main.pony
+++ b/examples/response-interceptors/main.pony
@@ -6,7 +6,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Response interceptors example.
 
   Demonstrates three response interceptor patterns:
@@ -29,7 +28,6 @@ actor Main is hobby.ServerNotify
     curl -v http://localhost:8080/api/42 -H "Authorization: Bearer secret"
     curl -v http://localhost:8080/nonexistent
   """
-
   let _env: Env
 
   new create(env: Env) =>
@@ -90,13 +88,11 @@ actor Main is hobby.ServerNotify
 // --- Response interceptors ---
 class val CorsResponseInterceptor is hobby.ResponseInterceptor
   """
-
   Adds CORS headers to every response.
 
   Captures the allowed origin at construction time. The interceptor is `val`
   and shareable across connections.
   """
-
   let _origin: String
 
   new val create(origin: String) => _origin = origin
@@ -112,10 +108,8 @@ class val CorsResponseInterceptor is hobby.ResponseInterceptor
 
 primitive SecurityHeadersInterceptor is hobby.ResponseInterceptor
   """
-
   Adds common security headers to every response.
   """
-
   fun apply(ctx: hobby.ResponseContext ref) =>
     ctx.set_header("x-content-type-options", "nosniff")
     ctx.set_header("x-frame-options", "DENY")
@@ -125,14 +119,12 @@ primitive SecurityHeadersInterceptor is hobby.ResponseInterceptor
 
 class val LogResponseInterceptor is hobby.ResponseInterceptor
   """
-
   Logs the request method, path, and response status after handling.
 
   A read-only interceptor — it doesn't modify the response. For streaming
   responses, the status is still available for logging even though header
   modifications would be no-ops.
   """
-
   let _out: OutStream
 
   new val create(out: OutStream) => _out = out

--- a/examples/response-interceptors/response_interceptors.pony
+++ b/examples/response-interceptors/response_interceptors.pony
@@ -1,5 +1,4 @@
 """
-
 Response interceptors example.
 """
 

--- a/examples/route-groups/main.pony
+++ b/examples/route-groups/main.pony
@@ -6,7 +6,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Route groups example.
 
   Demonstrates route grouping with shared prefixes and interceptors:
@@ -30,7 +29,6 @@ actor Main is hobby.ServerNotify
     curl -H "Authorization: Bearer secret" \
       http://localhost:8080/api/admin/dashboard
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/route-groups/route_groups.pony
+++ b/examples/route-groups/route_groups.pony
@@ -1,5 +1,4 @@
 """
-
 Route groups example.
 """
 

--- a/examples/serve-files/main.pony
+++ b/examples/serve-files/main.pony
@@ -7,7 +7,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Static file serving example.
 
   Starts an HTTP server on 0.0.0.0:8080 that serves files from a directory
@@ -25,7 +24,6 @@ actor Main is hobby.ServerNotify
     curl http://localhost:8080/static/style.css
     curl http://localhost:8080/static/docs/
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/serve-files/serve_files.pony
+++ b/examples/serve-files/serve_files.pony
@@ -1,5 +1,4 @@
 """
-
 Static file serving example.
 """
 

--- a/examples/signed-cookie/main.pony
+++ b/examples/signed-cookie/main.pony
@@ -6,7 +6,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Signed cookie example.
 
   Demonstrates signing and verifying cookie values using HMAC-SHA256 to
@@ -24,7 +23,6 @@ actor Main is hobby.ServerNotify
     curl -c cookies.txt -b cookies.txt http://localhost:8080/clear
     curl -c cookies.txt -b cookies.txt http://localhost:8080/
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/signed-cookie/signed_cookie.pony
+++ b/examples/signed-cookie/signed_cookie.pony
@@ -1,5 +1,4 @@
 """
-
 Signed cookie example.
 """
 

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -6,7 +6,6 @@ use lori = "lori"
 
 actor Main is hobby.ServerNotify
   """
-
   Streaming response example.
 
   Starts an HTTP server on 0.0.0.0:8080 with two routes:
@@ -21,7 +20,6 @@ actor Main is hobby.ServerNotify
     curl http://localhost:8080/stream
     curl --head http://localhost:8080/stream
   """
-
   let _env: Env
 
   new create(env: Env) =>

--- a/examples/streaming/streaming.pony
+++ b/examples/streaming/streaming.pony
@@ -1,5 +1,4 @@
 """
-
 Streaming response example.
 """
 

--- a/hobby/_buffered_response.pony
+++ b/hobby/_buffered_response.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 class ref _BufferedResponse
   """
-
   Mutable response buffer for response interceptor modification.
 
   Created by `_Connection` when a response is produced (from handler, request
@@ -15,7 +14,6 @@ class ref _BufferedResponse
   Content-Length header is already present (from explicit user headers or an
   interceptor), `_build()` does not override it.
   """
-
   var status: stallion.Status
   embed headers: Array[(String, String)]
   var body: (ByteSeq | None)
@@ -87,7 +85,6 @@ class ref _BufferedResponse
 
   fun box _build(): Array[U8] val =>
     """
-
     Serialize this buffered response into HTTP bytes for the wire.
 
     For non-streaming responses, auto-adds Content-Length from the final body
@@ -95,7 +92,6 @@ class ref _BufferedResponse
     response interceptors, so interceptors that call `set_body()` get correct
     Content-Length automatically.
     """
-
     let builder = stallion.ResponseBuilder(status)
     for (name, value) in headers.values() do
       builder.add_header(name, value)

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -15,7 +15,6 @@ type _PendingRequest is
 
 actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   """
-
   Internal connection actor that handles a single HTTP connection.
 
   Implements Stallion's `HTTPServerActor` to receive HTTP events and
@@ -23,7 +22,6 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   runs through: request interceptors (synchronous) → handler factory →
   handler actor (async) → response interceptors (synchronous) → wire.
   """
-
   var _http: stallion.HTTPServer = stallion.HTTPServer.none()
   let _router: _Router val
   let _timers: Timers tag
@@ -374,11 +372,9 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
   // --- Helpers ---
   fun ref _run_after_and_send(buf: _BufferedResponse ref) =>
     """
-
     Run response interceptors on the buffered response, send to wire,
     clean up.
     """
-
     match _current_request
     | let req: stallion.Request val =>
       let ctx = ResponseContext._create(buf, req)

--- a/hobby/_connection_protocol.pony
+++ b/hobby/_connection_protocol.pony
@@ -2,12 +2,10 @@ use stallion = "stallion"
 
 trait tag _ConnectionProtocol
   """
-
   Protocol behaviors that `RequestHandler` sends to `_Connection`.
 
   Package-private — users interact with `RequestHandler`, not this interface.
   """
-
   be _handler_respond(
     token: U64,
     status: stallion.Status,

--- a/hobby/_e_tag.pony
+++ b/hobby/_e_tag.pony
@@ -1,6 +1,5 @@
 primitive _ETag
   """
-
   Compute and match weak ETags from file metadata.
 
   ETags use the weak format `W/"<inode>-<size>-<mtime_secs>"`, matching the
@@ -10,13 +9,10 @@ primitive _ETag
   On Windows, `FileInfo.inode` is always 0, reducing collision resistance to
   size+mtime only. This is a known limitation.
   """
-
   fun apply(inode: U64, size: USize, mtime: I64): String =>
     """
-
     Compute a weak ETag from file metadata.
     """
-
     let inode_str: String val = inode.string()
     let size_str: String val = size.string()
     let mtime_str: String val = mtime.string()
@@ -35,13 +31,11 @@ primitive _ETag
 
   fun matches(if_none_match: String, server_etag: String): Bool =>
     """
-
     Check if an `If-None-Match` header value matches the server's ETag.
 
     Uses weak comparison per RFC 7232 section 2.3.2: strip the `W/` prefix and
     compare opaque-tags. Handles the `*` wildcard and comma-separated lists.
     """
-
     let trimmed = if_none_match.clone() .> strip()
     if trimmed == "*" then return true end
 
@@ -60,13 +54,11 @@ primitive _ETag
 
   fun _opaque_tag(etag: String): String =>
     """
-
     Extract the opaque-tag from an ETag value.
 
     Strips the optional `W/` weak indicator prefix (case-insensitive), then
     strips surrounding double quotes.
     """
-
     var s = etag.clone() .> strip()
     // Strip W/ prefix (case-insensitive)
     if (s.size() >= 2) and

--- a/hobby/_file_streamer.pony
+++ b/hobby/_file_streamer.pony
@@ -2,7 +2,6 @@ use "files"
 
 actor _FileStreamer
   """
-
   Read a file in chunks and send them to a `_FileTarget`.
 
   Reads 64 KB chunks using self-directed `_read_next()` messages so the Pony
@@ -16,7 +15,6 @@ actor _FileStreamer
   off. The connection's `throttled()`/`unthrottled()` signals drive this —
   see `_ServeFilesHandler` for the wiring.
   """
-
   let _file: File
   let _target: _FileTarget tag
   var _disposed: Bool = false

--- a/hobby/_file_target.pony
+++ b/hobby/_file_target.pony
@@ -1,12 +1,10 @@
 trait tag _FileTarget
   """
-
   Internal interface for `_FileStreamer` to send file chunks to.
 
   Replaces the public `StreamSender` interface for file streaming. The handler
   actor (`_ServeFilesHandler`) implements this and forwards chunks through
   `RequestHandler`.
   """
-
   be _file_chunk(data: Array[U8] val)
   be _file_done()

--- a/hobby/_flatten.pony
+++ b/hobby/_flatten.pony
@@ -1,13 +1,11 @@
 primitive _SplitSegments
   """
-
   Split a normalized path into an array of path segments.
 
   Strips the leading slash and splits on `/`, skipping empty segments
   (which normalizes double slashes). `/api/users/:id` → `["api", "users",
   ":id"]`. `/` → `[]`. `/api//users` → `["api", "users"]`.
   """
-
   fun apply(path: String): Array[String] val =>
     if path.size() <= 1 then
       return recover val Array[String] end
@@ -35,12 +33,10 @@ primitive _SplitSegments
 
 primitive _JoinRemainingSegments
   """
-
   Join segments from a start index onward with `/` separators.
 
   Used to reconstruct the captured value for wildcard parameters.
   """
-
   fun apply(
     segments: Array[String] val,
     from: USize,
@@ -74,7 +70,6 @@ primitive _JoinRemainingSegments
 
 primitive _JoinPath
   """
-
   Join a group prefix with a route path.
 
   Strips any trailing slash from the prefix, then concatenates with the route
@@ -84,7 +79,6 @@ primitive _JoinPath
   Examples: `("/api/", "/users")` -> `"/api/users"`,
   `("/", "/health")` -> `"/health"`, `("", "/health")` -> `"/health"`.
   """
-
   fun apply(prefix: String, path: String): String =>
     if prefix.size() == 0 then
       return path
@@ -113,7 +107,6 @@ primitive _TrimTrailingSlash
 
 primitive _ValidateGroups
   """
-
   Validate group configuration before tree insertion.
 
   Called in `Application.build()` where the original full prefix strings
@@ -123,7 +116,6 @@ primitive _ValidateGroups
   - Special characters in prefix (`:` or `*`)
   - Overlapping prefixes (two groups with the same prefix)
   """
-
   fun apply(infos: Array[_GroupInfo] box): (ConfigError | None) =>
     for gi in infos.values() do
       if (gi.prefix.size() == 0) or (gi.prefix == "/") then
@@ -180,14 +172,12 @@ primitive _HasSpecialChars
 
 primitive _ConcatResponseInterceptors
   """
-
   Concatenate two optional response interceptor arrays.
 
   Returns a combined array with outer interceptors first, then inner.
   When one side is `None`, returns the other directly (no allocation).
   When both are `None`, returns `None`.
   """
-
   fun apply(
     outer: (Array[ResponseInterceptor val] val | None),
     inner: (Array[ResponseInterceptor val] val | None))
@@ -216,14 +206,12 @@ primitive _ConcatResponseInterceptors
 
 primitive _ConcatInterceptors
   """
-
   Concatenate two optional interceptor arrays.
 
   Returns a combined array with outer interceptors first, then inner.
   When one side is `None`, returns the other directly (no allocation).
   When both are `None`, returns `None`.
   """
-
   fun apply(
     outer: (Array[RequestInterceptor val] val | None),
     inner: (Array[RequestInterceptor val] val | None))

--- a/hobby/_group_info.pony
+++ b/hobby/_group_info.pony
@@ -1,6 +1,5 @@
 class val _GroupInfo
   """
-
   Group metadata preserved for tree building.
 
   Carries the fully-joined prefix and interceptors for a route group. Created
@@ -8,7 +7,6 @@ class val _GroupInfo
   `Application.build()` to tag intermediate tree nodes with group-level
   interceptors via `_RouterBuilder.add_interceptors()`.
   """
-
   let prefix: String
   let interceptors: (Array[RequestInterceptor val] val | None)
   let response_interceptors: (Array[ResponseInterceptor val] val | None)

--- a/hobby/_handler_timeout_notify.pony
+++ b/hobby/_handler_timeout_notify.pony
@@ -2,7 +2,6 @@ use "time"
 
 class iso _HandlerTimeoutNotify is TimerNotify
   """
-
   Timer notify that sends `_handler_timeout(token)` to the connection on
   each interval fire.
 
@@ -10,7 +9,6 @@ class iso _HandlerTimeoutNotify is TimerNotify
   constitute a timeout. The interval-based approach avoids per-chunk timer
   allocation overhead during high-throughput streaming.
   """
-
   let _conn: _Connection tag
   let _token: U64
 

--- a/hobby/_http_date.pony
+++ b/hobby/_http_date.pony
@@ -2,7 +2,6 @@ use "time"
 
 primitive _HTTPDate
   """
-
   Format epoch seconds as an RFC 7231 IMF-fixdate HTTP-date.
 
   The output is always 29 characters in the form:
@@ -13,7 +12,6 @@ primitive _HTTPDate
   `ponyc/src/libponyrt/lang/time.c`), so `day_of_week` is 0=Sunday,
   1=Monday, ..., 6=Saturday.
   """
-
   fun apply(seconds: I64): String =>
     let date = PosixDate(seconds)
 

--- a/hobby/_method_entry.pony
+++ b/hobby/_method_entry.pony
@@ -1,6 +1,5 @@
 class val _MethodEntry
   """
-
   A handler and its per-route interceptors for a specific HTTP method at a
   path node.
 
@@ -8,7 +7,6 @@ class val _MethodEntry
   final pre-computed arrays: accumulated path interceptors concatenated with
   per-route interceptors, computed at freeze time.
   """
-
   let factory: HandlerFactory
   let interceptors: (Array[RequestInterceptor val] val | None)
   let response_interceptors: (Array[ResponseInterceptor val] val | None)

--- a/hobby/_route_definition.pony
+++ b/hobby/_route_definition.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 class val _RouteDefinition
   """
-
   A route registration captured during route setup.
 
   Stores the HTTP method, path pattern, handler factory, and optional
@@ -12,7 +11,6 @@ class val _RouteDefinition
   interceptors are registered separately on tree nodes — the interceptors
   here are per-route only.
   """
-
   let method: stallion.Method
   let path: String
   let factory: HandlerFactory

--- a/hobby/_route_match.pony
+++ b/hobby/_route_match.pony
@@ -2,14 +2,12 @@ use "collections"
 
 class val _RouteMatch
   """
-
   Result of a successful route lookup.
 
   Contains the handler factory, optional response interceptor and request
   interceptor chains, and extracted route parameters. Produced by
   `_Router.lookup()` when a request path matches a registered route.
   """
-
   let factory: HandlerFactory
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)
@@ -27,7 +25,6 @@ class val _RouteMatch
 
 class val _RouteMiss
   """
-
   Result of a failed route lookup.
 
   Carries accumulated request and response interceptors from the deepest
@@ -35,7 +32,6 @@ class val _RouteMiss
   group prefixes to run on 404 responses — e.g., an auth interceptor on
   `/api` can reject unauthenticated requests to `/api/nonexistent`.
   """
-
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)
 
@@ -66,7 +62,6 @@ class val _RouteMiss
 
 class val _MethodNotAllowed
   """
-
   Result of a lookup where the path exists but no handler matches the
   requested method.
 
@@ -75,7 +70,6 @@ class val _MethodNotAllowed
   still run on 405 responses — an auth interceptor should reject before
   revealing which methods are allowed.
   """
-
   let allowed_methods: Array[String] val
   let response_interceptors: (Array[ResponseInterceptor val] val | None)
   let interceptors: (Array[RequestInterceptor val] val | None)

--- a/hobby/_router.pony
+++ b/hobby/_router.pony
@@ -3,7 +3,6 @@ use stallion = "stallion"
 
 class ref _RouterBuilder
   """
-
   Mutable builder for constructing a `_Router`.
 
   Accumulates route definitions and group interceptors into a single shared
@@ -11,7 +10,6 @@ class ref _RouterBuilder
   Configuration errors (e.g., conflicting param or wildcard names) are
   accumulated in `_errors` and available via `first_error()`.
   """
-
   var _root: _BuildNode ref
   embed _errors: Array[String]
 
@@ -29,13 +27,11 @@ class ref _RouterBuilder
       (Array[RequestInterceptor val] val | None) = None)
   =>
     """
-
     Register a route handler for a specific method and path.
 
     Per-route interceptors are stored in the method entry at the leaf node.
     Path-level interceptors are registered separately via `add_interceptors()`.
     """
-
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
     let segments = _SplitSegments(normalized)
@@ -53,7 +49,6 @@ class ref _RouterBuilder
     response_interceptors: (Array[ResponseInterceptor val] val | None))
   =>
     """
-
     Register path-level interceptors on a tree node.
 
     Used for app-level interceptors (on the root node, path `""`) and
@@ -61,7 +56,6 @@ class ref _RouterBuilder
     happens earlier in `Application.build()` via `_ValidateGroups`.
     `_set_interceptors` concatenates as defense-in-depth.
     """
-
     if (interceptors is None) and (response_interceptors is None) then
       return
     end
@@ -82,11 +76,9 @@ class ref _RouterBuilder
 
   fun box first_error(): (ConfigError | None) =>
     """
-
     Return the first configuration error detected during route registration,
     or `None` if no errors were found.
     """
-
     if _errors.size() > 0 then
       try
         ConfigError(_errors(0)?)
@@ -100,14 +92,12 @@ class ref _RouterBuilder
 
 class val _Router
   """
-
   Immutable segment trie router with a single shared path tree.
 
   Handlers are keyed by HTTP method at leaf nodes. Interceptors live on
   shared path nodes and are method-independent. `lookup()` finds the matching
   handler, accumulated interceptors, and extracted parameters.
   """
-
   let _root: _TreeNode val
 
   new val _create(root: _TreeNode val) =>
@@ -117,7 +107,6 @@ class val _Router
     (_RouteMatch | _RouteMiss | _MethodNotAllowed)
   =>
     """
-
     Look up a route for the given method and path.
 
     Returns `_RouteMatch` on success, `_RouteMiss` when the path doesn't
@@ -125,7 +114,6 @@ class val _Router
     matches the method. For HEAD requests, automatically falls back to GET
     if no explicit HEAD handler exists.
     """
-
     let normalized = _NormalizePath(path)
     let method_key: String val = method.string()
     let is_head = method is stallion.HEAD
@@ -149,7 +137,6 @@ primitive _NormalizePath
 // --- Mutable build-time node ---
 class ref _BuildNode
   """
-
   Mutable segment trie node for route construction.
 
   Used by `_RouterBuilder` during route registration, then frozen into a
@@ -159,7 +146,6 @@ class ref _BuildNode
   - Method-keyed handler entries (from route registration)
   - Static children, param child, and wildcard entries for tree structure
   """
-
   var _interceptors: (Array[RequestInterceptor val] val | None) = None
   var _response_interceptors:
     (Array[ResponseInterceptor val] val | None) = None
@@ -179,7 +165,6 @@ class ref _BuildNode
       (Array[ResponseInterceptor val] val | None))
   =>
     """
-
     Set path-level interceptors on this node.
 
     Overlap detection happens earlier in `Application.build()` via
@@ -187,7 +172,6 @@ class ref _BuildNode
     available for a clear error message. As defense-in-depth,
     concatenates rather than overwrites if interceptors already exist.
     """
-
     _interceptors = _ConcatInterceptors(_interceptors, interceptors)
     _response_interceptors =
       _ConcatResponseInterceptors(
@@ -312,10 +296,8 @@ class ref _BuildNode
       (Array[ResponseInterceptor val] val | None))
   =>
     """
-
     Traverse or create nodes to reach the given path and set interceptors.
     """
-
     if idx >= segments.size() then
       _set_interceptors(interceptors, response_interceptors)
       return
@@ -343,14 +325,12 @@ class ref _BuildNode
     : _TreeNode val
   =>
     """
-
     Create an immutable deep copy of this node tree.
 
     Pre-computes accumulated interceptor arrays from root to each node.
     Per-route interceptors in method entries are concatenated with the
     accumulated path interceptors at freeze time, so lookup is zero-allocation.
     """
-
     // Accumulate this node's interceptors with ancestors'
     let new_accumulated =
       _ConcatInterceptors(accumulated_interceptors, _interceptors)
@@ -424,13 +404,11 @@ class ref _BuildNode
 // --- Build-time method entry (mutable) ---
 class ref _BuildMethodEntry
   """
-
   Mutable method entry during tree construction.
 
   Holds the handler factory and per-route interceptors before freeze-time
   concatenation with accumulated path interceptors.
   """
-
   let factory: HandlerFactory
   let interceptors: (Array[RequestInterceptor val] val | None)
   let response_interceptors:
@@ -450,7 +428,6 @@ class ref _BuildMethodEntry
 // --- Immutable lookup node ---
 class val _TreeNode
   """
-
   Immutable segment trie node for route lookup.
 
   Produced by freezing a `_BuildNode`. Each node stores pre-computed
@@ -462,7 +439,6 @@ class val _TreeNode
   concatenated at freeze time). Lookup is zero-allocation for both hits
   and misses.
   """
-
   let _accumulated_interceptors:
     (Array[RequestInterceptor val] val | None)
   let _accumulated_response_interceptors:
@@ -537,7 +513,6 @@ class val _TreeNode
       _RouteMiss | _MethodNotAllowed)
   =>
     """
-
     Recursive lookup returning method entry and accumulated params on hit,
     `_RouteMiss` when the path doesn't exist, or `_MethodNotAllowed` when
     the path exists but no handler matches the requested method.
@@ -552,7 +527,6 @@ class val _TreeNode
     reports methods from a single entries map; this function merges across
     calls.
     """
-
     if idx >= segments.size() then
       match _resolve_or_405(
         method_key, is_head, _method_entries)
@@ -727,7 +701,6 @@ class val _TreeNode
     : (_MethodEntry val | _MethodNotAllowed | None)
   =>
     """
-
     Try to resolve a method entry from the given entries map.
 
     Returns the entry on match, `_MethodNotAllowed` if the map has entries
@@ -738,7 +711,6 @@ class val _TreeNode
     multiple `_resolve_or_405` calls when multiple priority branches each
     return 405.
     """
-
     try
       return entries(method_key)?
     end

--- a/hobby/_run_request_interceptors.pony
+++ b/hobby/_run_request_interceptors.pony
@@ -2,14 +2,12 @@ use stallion = "stallion"
 
 primitive _RunRequestInterceptors
   """
-
   Run request interceptors in order on a request.
 
   Calls each interceptor and inspects the result. Stops on the first
   `InterceptRespond`. Returns the response if any interceptor short-circuited,
   or `None` if all passed.
   """
-
   fun apply(request: stallion.Request val,
     interceptors: (Array[RequestInterceptor val] val | None))
     : (InterceptRespond | None)

--- a/hobby/_run_response_interceptors.pony
+++ b/hobby/_run_response_interceptors.pony
@@ -1,12 +1,10 @@
 primitive _RunResponseInterceptors
   """
-
   Run response interceptors in order on a ResponseContext.
 
   All interceptors run — there is no short-circuiting. Each interceptor
   sees the response as modified by previous interceptors.
   """
-
   fun apply(ctx: ResponseContext ref,
     interceptors: (Array[ResponseInterceptor val] val | None))
   =>

--- a/hobby/_serve_files_handler.pony
+++ b/hobby/_serve_files_handler.pony
@@ -9,7 +9,6 @@ actor _ServeFilesHandler is (HandlerReceiver & _FileTarget)
   Implements `HandlerReceiver` for lifecycle notifications and `_FileTarget`
   for receiving file data from the streamer.
   """
-
   embed _handler: RequestHandler
   var _streamer: (_FileStreamer | None) = None
 

--- a/hobby/_server_state.pony
+++ b/hobby/_server_state.pony
@@ -6,7 +6,6 @@ trait _ServerState
   events — the state machine is the single place to understand
   what happens in each state.
   """
-
   fun ref dispose(server: Server ref): _ServerState
 
   fun ref on_accept(
@@ -34,7 +33,6 @@ class _ServerStarting is _ServerState
   """
   Server constructed, waiting for bind result from lori.
   """
-
   fun ref dispose(server: Server ref): _ServerState =>
     server._do_dispose()
     _ServerDisposed
@@ -79,7 +77,6 @@ class _ServerListening is _ServerState
   """
   Server bound and accepting connections.
   """
-
   fun ref dispose(server: Server ref): _ServerState =>
     server._do_dispose()
     _ServerDisposed
@@ -122,7 +119,6 @@ class _ServerDisposed is _ServerState
   """
   Server shut down. All events are no-ops.
   """
-
   fun ref dispose(server: Server ref): _ServerState =>
     this
 

--- a/hobby/_test_http_date.pony
+++ b/hobby/_test_http_date.pony
@@ -32,11 +32,9 @@ class \nodoc\ iso _TestHTTPDateEpochZero is UnitTest
 
 class \nodoc\ iso _TestHTTPDateSunday is UnitTest
   """
-
   Known Sunday date guards against day_of_week indexing bugs.
   Jan 4, 1970 (epoch 259200) is a Sunday.
   """
-
   fun name(): String => "http-date/sunday"
 
   fun apply(h: TestHelper) =>

--- a/hobby/_test_integration.pony
+++ b/hobby/_test_integration.pony
@@ -522,11 +522,9 @@ class \nodoc\ iso _TestStreamingResponse is UnitTest
 
 class \nodoc\ iso _TestPipelinedStreaming is UnitTest
   """
-
   Pipelined streaming request is buffered and processed after first stream
   finishes.
   """
-
   fun name(): String => "integration/pipelined streaming"
 
   fun label(): String => "integration"
@@ -550,11 +548,9 @@ actor \nodoc\ _TestHeadClient is
   (lori.TCPConnectionActor &
     lori.ClientLifecycleEventReceiver)
   """
-
   TCP client for HEAD tests: checks that an expected header is present
   AND a forbidden body string is absent.
   """
-
   var _tcp_connection: lori.TCPConnection =
     lori.TCPConnection.none()
   let _h: TestHelper
@@ -762,11 +758,9 @@ class \nodoc\ iso _TestHeadPostOnlyRoute is UnitTest
 
 class \nodoc\ iso _TestHeadStreamingPipelinedGet is UnitTest
   """
-
   HEAD to streaming handler followed by pipelined GET: HEAD completes without
   setting streaming mode, so the GET is NOT buffered and processes immediately.
   """
-
   fun name(): String => "integration/HEAD streaming + pipelined GET"
 
   fun label(): String => "integration"
@@ -808,7 +802,6 @@ primitive \nodoc\ _TimeoutTestHelpers
   Helpers for timeout integration tests. Creates a Server with a
   500ms handler timeout.
   """
-
   fun run_timeout_test(
     h: TestHelper,
     router: _Router val,

--- a/hobby/_test_request_handler.pony
+++ b/hobby/_test_request_handler.pony
@@ -18,7 +18,6 @@ actor \nodoc\ _MockConnection is _ConnectionProtocol
   """
   Mock connection that accepts all protocol messages as no-ops.
   """
-
   be _handler_respond(
     token: U64,
     status: stallion.Status,

--- a/hobby/_test_response_interceptor.pony
+++ b/hobby/_test_response_interceptor.pony
@@ -542,11 +542,9 @@ actor \nodoc\ _TestStreamingNoOpClient is
   (lori.TCPConnectionActor &
     lori.ClientLifecycleEventReceiver)
   """
-
   TCP client for streaming no-op test: expects chunk data
   present AND a forbidden header absent.
   """
-
   var _tcp_connection: lori.TCPConnection =
     lori.TCPConnection.none()
   let _h: TestHelper

--- a/hobby/_test_router.pony
+++ b/hobby/_test_router.pony
@@ -568,13 +568,11 @@ class \nodoc\ iso _TestStaticParamWildcardPriority is UnitTest
 
 class \nodoc\ iso _Test405FallsBackToLowerPriorityMatch is UnitTest
   """
-
   405 from param falls back to wildcard match.
 
   POST /files/:id + GET /files/*path — GET /files/readme.txt should match
   the wildcard, not return 405 from the param branch.
   """
-
   fun name(): String => "router/405 falls back to lower priority match"
 
   fun apply(h: TestHelper) =>
@@ -633,13 +631,11 @@ class \nodoc\ iso _Test405FallsBackToLowerPriorityMatch is UnitTest
 
 class \nodoc\ iso _Test405FallsBackStaticToParam is UnitTest
   """
-
   405 from static falls back to param match.
 
   POST /users/new + GET /users/:id — GET /users/new should match the param
   with id="new", not return 405 from the static branch.
   """
-
   fun name(): String => "router/405 falls back static to param"
 
   fun apply(h: TestHelper) =>
@@ -695,7 +691,6 @@ class \nodoc\ iso _Test405FallsBackStaticToParam is UnitTest
 
 class \nodoc\ iso _Test405ExactPathDoesNotIncludeWildcard is UnitTest
   """
-
   Exact-path 405 does not include wildcard methods.
 
   GET /files + POST /files/*path → DELETE /files gets Allow: GET, HEAD
@@ -704,7 +699,6 @@ class \nodoc\ iso _Test405ExactPathDoesNotIncludeWildcard is UnitTest
   (the early return at `idx >= segments.size()` resolves before the
   priority branch loop runs).
   """
-
   fun name(): String =>
     "router/405 exact path does not include wildcard"
 
@@ -740,14 +734,12 @@ class \nodoc\ iso _Test405ExactPathDoesNotIncludeWildcard is UnitTest
 
 class \nodoc\ iso _Test405MergesMethodsAcrossBranches is UnitTest
   """
-
   Allow header merges methods from all priority branches.
 
   POST /files/:id + GET /files/*path → DELETE /files/readme.txt hits the
   param branch first (405 with POST) then the wildcard branch (405 with
   GET, HEAD). The merged Allow header should include all three.
   """
-
   fun name(): String =>
     "router/405 merges methods across branches"
 
@@ -792,14 +784,12 @@ class \nodoc\ iso _Test405MergesMethodsAcrossBranches is UnitTest
 class \nodoc\ iso _Test405MergeDeduplicatesOverlappingMethods
   is UnitTest
   """
-
   Allow header deduplicates methods that appear in multiple branches.
 
   GET /users/new + GET /users/:id → DELETE /users/new hits the static
   branch (405 with GET, HEAD) then the param branch (405 with GET, HEAD).
   The merged Allow header should contain each method only once.
   """
-
   fun name(): String =>
     "router/405 merge deduplicates overlapping methods"
 
@@ -842,13 +832,11 @@ class \nodoc\ iso _Test405MergeDeduplicatesOverlappingMethods
 class \nodoc\ iso _PropertyInsertionOrderInvariance is
   Property1[(Array[USize] val, Array[USize] val)]
   """
-
   Route lookup results are independent of insertion order.
 
   Generates two permutations of the same route set and verifies that both
   produce identical lookup results for every registered path.
   """
-
   fun name(): String => "router/property/insertion order invariance"
 
   fun gen(): Generator[(Array[USize] val, Array[USize] val)] =>
@@ -1326,14 +1314,12 @@ class \nodoc\ iso _TestParamNameConflictReturnsError is UnitTest
 
 class \nodoc\ iso _TestInterceptorSegmentBoundary is UnitTest
   """
-
   Group interceptors at /api must NOT leak to /api-docs.
 
   In the segment trie, `/api` and `/api-docs` are distinct children of the
   root node (`"api"` vs `"api-docs"`). Interceptors registered on the `/api`
   node propagate only to its children, not to sibling segments.
   """
-
   fun name(): String => "router/interceptor segment boundary"
 
   fun apply(h: TestHelper) =>
@@ -1377,11 +1363,9 @@ class \nodoc\ iso _TestInterceptorSegmentBoundary is UnitTest
 
 class \nodoc\ iso _TestInterceptorSegmentBoundaryMiss is UnitTest
   """
-
   A 404 miss at a sibling path (/api-unknown) must NOT carry group
   interceptors from /api.
   """
-
   fun name(): String => "router/interceptor segment boundary miss"
 
   fun apply(h: TestHelper) =>
@@ -1426,11 +1410,9 @@ class \nodoc\ iso _TestInterceptorSegmentBoundaryMiss is UnitTest
 
 class \nodoc\ iso _TestInterceptorSegmentBoundaryNestedGroups is UnitTest
   """
-
   App-level interceptors propagate everywhere. Group interceptors at /api
   propagate to /api/admin/users but not to /api-docs.
   """
-
   fun name(): String => "router/interceptor segment boundary nested groups"
 
   fun apply(h: TestHelper) =>
@@ -1494,7 +1476,6 @@ class \nodoc\ iso _TestInterceptorSegmentBoundaryNestedGroups is UnitTest
 
 class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
   """
-
   When static and param children both miss, the miss with richer interceptors
   wins.
 
@@ -1503,7 +1484,6 @@ class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
   /api/users/new/nonexistent — static child reaches depth with [A, B] but
   misses, param child :id misses with only [A]. The 404 must carry [A, B].
   """
-
   fun name(): String => "router/deepest miss preserves richer interceptors"
 
   fun apply(h: TestHelper) =>
@@ -1541,13 +1521,11 @@ class \nodoc\ iso _TestDeepestMissPreservesRicherInterceptors is UnitTest
 
 class \nodoc\ iso _TestSharedParamNameConsistent is UnitTest
   """
-
   Multiple methods at the same param position with the same name works.
 
   GET /users/:id and POST /users/:id share a param child — the name must
   match. Mismatched names (e.g., :userId vs :id) would panic at startup.
   """
-
   fun name(): String => "router/shared param name consistent"
 
   fun apply(h: TestHelper) =>
@@ -1580,11 +1558,9 @@ class \nodoc\ iso _TestSharedParamNameConsistent is UnitTest
 
 class \nodoc\ iso _TestDoubleSlashNormalization is UnitTest
   """
-
   Double slashes are normalized: `/users//42/details` matches
   `/users/:id/details` with `id` = `"42"`.
   """
-
   fun name(): String => "router/double slash normalization"
 
   fun apply(h: TestHelper) =>
@@ -1628,14 +1604,12 @@ class \nodoc\ iso _TestDoubleSlashNormalization is UnitTest
 
 class \nodoc\ iso _TestWildcardDoubleSlashNormalization is UnitTest
   """
-
   Wildcard captures normalize double slashes in the captured value.
 
   A request for `/files/a//b/c` produces a wildcard value of `"a/b/c"`,
   not `"a//b/c"`, because `_SplitSegments` skips empty segments before
   the wildcard remainder is reconstructed.
   """
-
   fun name(): String => "router/wildcard double slash normalization"
 
   fun apply(h: TestHelper) =>
@@ -1820,11 +1794,9 @@ class \nodoc\ iso _TestWildcardHeadFallback is UnitTest
 // --- _SplitSegments / _JoinRemainingSegments tests ---
 class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
   """
-
   `_SplitSegments` edge cases: root, empty, single segment, double slashes,
   triple slashes, param/wildcard markers, and registration-path normalization.
   """
-
   fun name(): String => "router/split segments edge cases"
 
   fun apply(h: TestHelper) =>
@@ -1894,11 +1866,9 @@ class \nodoc\ iso _TestSplitSegmentsEdgeCases is UnitTest
 
 class \nodoc\ iso _PropertySplitJoinRoundTrip is Property1[String]
   """
-
   Splitting a static path into segments and joining them all back produces
   the original path without the leading slash.
   """
-
   fun name(): String => "router/property/split join round-trip"
 
   fun gen(): Generator[String] => _GenStaticPath()
@@ -1912,11 +1882,9 @@ class \nodoc\ iso _PropertySplitJoinRoundTrip is Property1[String]
 
 class \nodoc\ iso _TestJoinRemainingSegments is UnitTest
   """
-
   `_JoinRemainingSegments` edge cases: past-end index, single segment,
   multiple segments, and mid-array start.
   """
-
   fun name(): String => "router/join remaining segments"
 
   fun apply(h: TestHelper) =>
@@ -1961,13 +1929,11 @@ class \nodoc\ iso _TestJoinRemainingSegments is UnitTest
 
 class \nodoc\ iso _TestRoutesBeforeInterceptors is UnitTest
   """
-
   Routes registered before interceptors still get the interceptors.
 
   `add_interceptors` may be called after `add` — the tree traversal in
   `_ensure_path` must work on a tree that already has route nodes.
   """
-
   fun name(): String => "router/routes before interceptors"
 
   fun apply(h: TestHelper) =>
@@ -2115,14 +2081,12 @@ class \nodoc\ iso _TestWildcardNameConflictReturnsError is UnitTest
 
 class \nodoc\ iso _TestSharedWildcardNameConsistent is UnitTest
   """
-
   Multiple methods at the same wildcard position with the same name works.
 
   GET /files/*path and POST /files/*path share a wildcard node — the name
   must match. Verifies no error is produced and both methods route correctly
   with correct wildcard param extraction.
   """
-
   fun name(): String => "router/shared wildcard name consistent"
 
   fun apply(h: TestHelper) =>

--- a/hobby/_test_serve_files.pony
+++ b/hobby/_test_serve_files.pony
@@ -38,11 +38,9 @@ primitive \nodoc\ _TestServeFilesList
 // --- Test setup ---
 primitive \nodoc\ _ServeFilesTestSetup
   """
-
   Create a temporary directory with test files for ServeFiles integration
   tests. Idempotent — safe to call multiple times.
   """
-
   fun apply(env: Env): FilePath ? =>
     let file_auth = FileAuth(env.root)
     let root = FilePath(file_auth, "/tmp/hobby-test-serve")
@@ -555,11 +553,9 @@ class \nodoc\ iso _TestServeFilesCacheControlDisabled is UnitTest
 
 primitive \nodoc\ _ServeFilesCacheControlDisabledHelper
   """
-
   Run a test that checks for a required string AND verifies a forbidden
   string is absent.
   """
-
   fun run_test(
     h: TestHelper,
     router: _Router val,
@@ -596,11 +592,9 @@ actor \nodoc\ _TestNoCacheControlClient is
   (lori.TCPConnectionActor &
     lori.ClientLifecycleEventReceiver)
   """
-
   TCP client that checks a required string is present and a forbidden
   string is absent.
   """
-
   var _tcp_connection: lori.TCPConnection =
     lori.TCPConnection.none()
   let _h: TestHelper
@@ -686,11 +680,9 @@ class \nodoc\ iso _TestServeFilesLargeFileCacheHeaders is UnitTest
 
 class \nodoc\ iso _TestServeFilesLargeFileETag304 is UnitTest
   """
-
   Large file with matching If-None-Match returns 304 (conditional check
   happens before size branch).
   """
-
   fun name(): String => "integration/serve-files/large file ETag 304"
 
   fun label(): String => "integration"
@@ -717,11 +709,9 @@ class \nodoc\ iso _TestServeFilesLargeFileETag304 is UnitTest
 
 class \nodoc\ iso _TestServeFilesETagPrecedence is UnitTest
   """
-
   If-None-Match takes precedence over If-Modified-Since per RFC 7232 section 3.
   Matching ETag + non-matching If-Modified-Since still returns 304.
   """
-
   fun name(): String => "integration/serve-files/ETag precedence"
 
   fun label(): String => "integration"
@@ -939,11 +929,9 @@ class \nodoc\ iso _TestFileStreamerPauseResume is UnitTest
 
 actor \nodoc\ _PauseResumeTarget is _FileTarget
   """
-
   On first chunk, pauses the streamer. A short timer resumes it.
   Verifies that _file_done arrives after the pause/resume cycle.
   """
-
   let _h: TestHelper
   var _streamer: (_FileStreamer | None) = None
   let _timers: Timers
@@ -1046,11 +1034,9 @@ class \nodoc\ iso _TestServeFilesHandlerBackpressure is UnitTest
 
 actor \nodoc\ _BackpressureMockConnection is _ConnectionProtocol
   """
-
   Mock connection that throttles on first chunk and unthrottles after a timer.
   Verifies that chunks continue to arrive after unthrottling.
   """
-
   let _h: TestHelper
   let _path: FilePath
   let _timers: Timers

--- a/hobby/_test_signed_cookie.pony
+++ b/hobby/_test_signed_cookie.pony
@@ -169,11 +169,9 @@ class \nodoc\ iso _TestSignedCookieInvalidBase64 is UnitTest
 
 class \nodoc\ iso _TestSignedCookieKeyBoundary is UnitTest
   """
-
   The minimum key length is 32 bytes. A 31-byte key must be rejected;
   a 32-byte key must be accepted.
   """
-
 
   fun name(): String => "SignedCookie/key-boundary"
 
@@ -195,11 +193,9 @@ class \nodoc\ iso _TestSignedCookieKeyBoundary is UnitTest
 
 class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
   """
-
   RFC 4231 Test Case 2: HMAC-SHA256 with "Jefe" key and "what do ya want
   for nothing?" data. Verifies our HMAC matches the known digest.
   """
-
 
   fun name(): String => "SignedCookie/rfc-4231-vector"
 
@@ -223,7 +219,6 @@ class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
 
 class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
   """
-
   Cross-language test vector: a known key, value, and expected signed
   output verified against `openssl dgst -sha256 -hmac`.
 
@@ -243,7 +238,6 @@ class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
   Expected signed output: "hello.7GT0SrIsQCeVHsMIKW5wg_p2huSb8nTFCUeO-QsJ_Ak=
   """
 
-
   fun name(): String => "SignedCookie/cross-language-vector"
 
   fun apply(h: TestHelper) ? =>
@@ -262,10 +256,8 @@ class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
 
 class \nodoc\ iso _PropSignedCookieRoundTrip is Property1[String]
   """
-
   For any printable ASCII value, sign then verify returns the original.
   """
-
 
   fun name(): String => "SignedCookie/prop-round-trip"
 
@@ -285,10 +277,8 @@ class \nodoc\ iso _PropSignedCookieRoundTrip is Property1[String]
 
 class \nodoc\ iso _PropSignedCookieDeterministic is Property1[String]
   """
-
   Signing the same value with the same key always produces the same output.
   """
-
 
   fun name(): String => "SignedCookie/prop-deterministic"
 
@@ -307,10 +297,8 @@ class \nodoc\ iso _PropSignedCookieDeterministic is Property1[String]
 class \nodoc\ iso _PropSignedCookieTamperDetection is
   Property1[(String, USize)]
   """
-
   Flipping any byte in a signed value causes verification to fail.
   """
-
 
   fun name(): String => "SignedCookie/prop-tamper-detection"
 
@@ -352,10 +340,8 @@ class \nodoc\ iso _PropSignedCookieTamperDetection is
 
 class \nodoc\ iso _PropSignedCookieKeyIndependence is Property1[String]
   """
-
   A value signed with one key does not verify with a different key.
   """
-
 
   fun name(): String => "SignedCookie/prop-key-independence"
 
@@ -377,13 +363,11 @@ class \nodoc\ iso _PropSignedCookieKeyIndependence is Property1[String]
 
 class \nodoc\ iso _PropSignedCookieCookieOctetValidity is Property1[String]
   """
-
   The separator and signature portion of a signed cookie contain only
   valid cookie-octet bytes (RFC 6265 section 4.1.1): US-ASCII excluding
   control characters, whitespace, double quote, comma, semicolon, and
   backslash. The value portion is the caller's responsibility.
   """
-
 
   fun name(): String => "SignedCookie/prop-cookie-octet-validity"
 
@@ -421,11 +405,9 @@ class \nodoc\ iso _PropSignedCookieCookieOctetValidity is Property1[String]
 
 class \nodoc\ iso _PropSignedCookieSignatureLength is Property1[String]
   """
-
   The signature portion (after the last `.`) is always 44 characters —
   the Base64-URL encoding of a 32-byte HMAC with padding.
   """
-
 
   fun name(): String => "SignedCookie/prop-signature-length"
 

--- a/hobby/_unreachable.pony
+++ b/hobby/_unreachable.pony
@@ -4,11 +4,9 @@ use @pony_os_stderr[Pointer[None]]()
 
 primitive _Unreachable
   """
-
   To be used in places that the compiler can't prove is unreachable but we are
   certain is unreachable and if we reach it, we'd be silently hiding a bug.
   """
-
   fun apply(loc: SourceLoc = __loc) =>
     @fprintf(
       @pony_os_stderr(),

--- a/hobby/application.pony
+++ b/hobby/application.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 class ref Application
   """
-
   Mutable route builder for the Hobby web framework.
 
   Register routes via `.>` method chaining (`get`, `post`, etc.), then
@@ -45,7 +44,6 @@ class ref Application
   can build routes, call `build()` to freeze a snapshot, add more
   routes, and build again. Each `BuiltApplication` is independent.
   """
-
   embed _routes: Array[_RouteDefinition]
   embed _app_interceptors: Array[RequestInterceptor val]
   embed _app_response_interceptors: Array[ResponseInterceptor val]
@@ -212,7 +210,6 @@ class ref Application
 
   fun ref add_request_interceptor(interceptor: RequestInterceptor val) =>
     """
-
     Add an application-level request interceptor.
 
     Request interceptors run before the handler on every request. Application
@@ -222,12 +219,10 @@ class ref Application
 
     App-level interceptors also run on 404 responses where no route matched.
     """
-
     _app_interceptors.push(interceptor)
 
   fun ref add_response_interceptor(interceptor: ResponseInterceptor val) =>
     """
-
     Add an application-level response interceptor.
 
     Response interceptors run after the handler responds, before the response
@@ -238,12 +233,10 @@ class ref Application
     App-level response interceptors also run on 404 responses where no route
     matched.
     """
-
     _app_response_interceptors.push(interceptor)
 
   fun ref group(g: RouteGroup iso) =>
     """
-
     Consume a route group, flattening its routes into this application.
 
     The group's prefix is applied to each of its routes. Group-level
@@ -251,14 +244,12 @@ class ref Application
     registered on path nodes, not concatenated onto routes. The group is
     consumed — no further registration on it is possible.
     """
-
     (consume g)
       .> _collect_group_infos(_group_infos)
       .> _flatten_routes_into(_routes)
 
   fun ref build(): BuildResult =>
     """
-
     Validate routes and freeze them into a `BuiltApplication`.
 
     Returns `BuiltApplication` on success or `ConfigError` if a
@@ -270,7 +261,6 @@ class ref Application
     `build()` again. Each `BuiltApplication` is an independent
     snapshot.
     """
-
     // Validate group configuration before building
     match _ValidateGroups(_group_infos)
     | let err: ConfigError => return err

--- a/hobby/body_not_needed.pony
+++ b/hobby/body_not_needed.pony
@@ -1,6 +1,5 @@
 primitive BodyNotNeeded
   """
-
   Returned by `RequestHandler.start_streaming()` when streaming cannot begin.
 
   This happens in two cases: the request is HEAD (the framework sends a

--- a/hobby/built_application.pony
+++ b/hobby/built_application.pony
@@ -11,7 +11,6 @@ class val BuiltApplication
   prove that route configuration is valid. The routing tree is accessed
   internally by `Server`.
   """
-
   let _router: _Router val
 
   new val _create(router: _Router val) =>

--- a/hobby/content_types.pony
+++ b/hobby/content_types.pony
@@ -2,10 +2,8 @@ use "collections"
 
 primitive _ContentTypeDefaults
   """
-
   Build the default content-type map with 17 common file extensions.
   """
-
   fun apply(): Map[String, String] ref^ =>
     let m = Map[String, String](24)
     m("html") = "text/html"
@@ -29,7 +27,6 @@ primitive _ContentTypeDefaults
 
 class val ContentTypes
   """
-
   Map file extensions to MIME content types.
 
   Ships with 17 common defaults (html, css, js, json, xml, txt, png, jpg,
@@ -47,34 +44,27 @@ class val ContentTypes
   Lookups are case-insensitive — both the default keys and user-provided keys
   are lowercased. Unknown extensions return `application/octet-stream`.
   """
-
   let _map: Map[String, String] val
 
   new val create() =>
     """
-
     Create a `ContentTypes` with the 17 standard defaults.
     """
-
     _map = recover val _ContentTypeDefaults() end
 
   new val _from_map(map: Map[String, String] val) =>
     """
-
     Create a `ContentTypes` from a pre-built map.
     """
-
     _map = map
 
   fun val add(ext: String, mime: String): ContentTypes val =>
     """
-
     Return a new `ContentTypes` with the given mapping added. If `ext`
     already exists, the new MIME type replaces the previous one. The
     extension is lowercased before insertion so lookups are always
     case-insensitive.
     """
-
     let new_map =
       recover val
         let m = Map[String, String](_map.size() + 1)
@@ -88,11 +78,9 @@ class val ContentTypes
 
   fun apply(ext: String): String =>
     """
-
     Look up the MIME type for `ext`. Returns `application/octet-stream` when
     the extension is not in the map.
     """
-
     try
       _map(ext.lower())?
     else

--- a/hobby/cookie_signing_key.pony
+++ b/hobby/cookie_signing_key.pony
@@ -2,38 +2,30 @@ use crypto = "ssl/crypto"
 
 class val CookieSigningKey
   """
-
   An HMAC-SHA256 signing key for use with `SignedCookie`.
 
   Keys must be at least 32 bytes. Use `generate` to create a random key
   or `create` to wrap an existing one.
   """
 
-
   let _key: Array[U8] val
 
   new val create(key: Array[U8] val) ? =>
     """
-
     Wrap an existing key. Errors if `key` is shorter than 32 bytes.
     """
-
     if key.size() < 32 then error end
     _key = key
 
   new val generate() ? =>
     """
-
     Generate a 32-byte key from a cryptographically secure random source.
     Errors if the runtime cannot produce secure random bytes.
     """
-
     _key = crypto.RandBytes(32)?
 
   fun _bytes(): Array[U8] val =>
     """
-
     Return the raw key bytes.
     """
-
     _key

--- a/hobby/handler_context.pony
+++ b/hobby/handler_context.pony
@@ -3,7 +3,6 @@ use stallion = "stallion"
 
 class iso HandlerContext
   """
-
   Request context consumed by a handler factory to create a handler.
 
   Carries the HTTP request, route parameters, and request body. Created by
@@ -14,7 +13,6 @@ class iso HandlerContext
   package-private and used by `RequestHandler` to communicate with the
   connection.
   """
-
   let request: stallion.Request val
   let params: Map[String, String] val
   let body: Array[U8] val

--- a/hobby/handler_factory.pony
+++ b/hobby/handler_factory.pony
@@ -1,7 +1,6 @@
 type HandlerFactory is
   {(HandlerContext iso): (HandlerReceiver tag | None)} val
   """
-
   A handler factory creates request handlers for incoming HTTP requests.
 
   `HandlerFactory` is a `val` lambda that receives an iso handler context and

--- a/hobby/handler_receiver.pony
+++ b/hobby/handler_receiver.pony
@@ -9,7 +9,6 @@ interface tag HandlerReceiver
   - `throttled()`: TCP send buffer is full; pause chunk production.
   - `unthrottled()`: TCP send buffer drained; resume chunk production.
   """
-
   be dispose()
 
   be throttled()

--- a/hobby/handler_timeout.pony
+++ b/hobby/handler_timeout.pony
@@ -57,7 +57,6 @@ primitive DefaultHandlerTimeout
   """
   Returns the default handler timeout of 30 seconds (30,000 ms).
   """
-
   fun apply(): (HandlerTimeout | None) =>
     match MakeHandlerTimeout(30_000)
     | let t: HandlerTimeout => t

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -1,5 +1,4 @@
 """
-
 # Hobby
 
 A simple HTTP web framework for Pony, powered by

--- a/hobby/intercept_response.pony
+++ b/hobby/intercept_response.pony
@@ -7,7 +7,6 @@ primitive InterceptPass
 
 class ref InterceptRespond
   """
-
   Returned by a request interceptor to short-circuit with an HTTP response.
 
   The handler is not created — the interceptor's response goes directly to
@@ -26,7 +25,6 @@ class ref InterceptRespond
     .> set_header("retry-after", "60")
   ```
   """
-
   let _status: stallion.Status
   let _body: ByteSeq
   embed _headers: Array[(String, String)]
@@ -38,13 +36,11 @@ class ref InterceptRespond
 
   fun ref set_header(name: String, value: String) =>
     """
-
     Set a response header, replacing any existing header with the same name.
 
     The name is lowercased for consistency with HTTP's case-insensitive
     header names.
     """
-
     let lower_name: String val = name.lower()
     var i: USize = 0
     while i < _headers.size() do
@@ -62,13 +58,11 @@ class ref InterceptRespond
 
   fun ref add_header(name: String, value: String) =>
     """
-
     Add a response header without removing existing entries.
 
     The name is lowercased for consistency. Use for multi-value headers like
     `Set-Cookie`.
     """
-
     _headers.push((name.lower(), value))
 
   // --- Package-private accessors for _Connection ---
@@ -82,7 +76,6 @@ class ref InterceptRespond
 
 type InterceptResult is (InterceptPass | InterceptRespond)
   """
-
   The result of a request interceptor: either pass the request through or
   short-circuit with a response.
   """

--- a/hobby/request_handler.pony
+++ b/hobby/request_handler.pony
@@ -3,7 +3,6 @@ use stallion = "stallion"
 
 class ref RequestHandler
   """
-
   The handler's interface to the connection.
 
   Embedded in a user's handler actor (or used inline). Hides the connection
@@ -36,7 +35,6 @@ class ref RequestHandler
     be unthrottled() => None
   ```
   """
-
   let _conn: _ConnectionProtocol tag
   let _token: U64
   let _request: stallion.Request val
@@ -48,12 +46,10 @@ class ref RequestHandler
 
   new create(ctx: HandlerContext iso) =>
     """
-
     Create a handler from a consumed handler context.
 
     Extracts all request data and protocol references from the context.
     """
-
     _request = ctx.request
     _params = ctx.params
     _body = ctx.body
@@ -63,14 +59,12 @@ class ref RequestHandler
 
   fun ref respond(status: stallion.Status, body': ByteSeq) =>
     """
-
     Send a complete response with the given status and body.
 
     Idempotent — the first call sends the response, subsequent calls are
     silently ignored. `Content-Length` is set automatically by the connection.
     For HEAD requests, the body is suppressed but `Content-Length` is preserved.
     """
-
     if not _responded then
       _responded = true
       _conn._handler_respond(_token, status, None, body')
@@ -82,14 +76,12 @@ class ref RequestHandler
     body': ByteSeq)
   =>
     """
-
     Send a complete response with explicit headers and body.
 
     The caller is responsible for including `Content-Length` or any other
     required headers. For HEAD requests, the body is suppressed but all
     headers are preserved.
     """
-
     if not _responded then
       _responded = true
       _conn._handler_respond(_token, status, headers, body')
@@ -100,7 +92,6 @@ class ref RequestHandler
     : (StreamingStarted | stallion.ChunkedNotSupported | BodyNotNeeded)
   =>
     """
-
     Begin a streaming response using chunked transfer encoding.
 
     Returns `StreamingStarted` on success, `ChunkedNotSupported` for
@@ -112,7 +103,6 @@ class ref RequestHandler
 
     For `ChunkedNotSupported`, `respond()` can still be called as a fallback.
     """
-
     if _responded then
       return BodyNotNeeded
     end
@@ -131,26 +121,22 @@ class ref RequestHandler
 
   fun ref send_chunk(data: ByteSeq) =>
     """
-
     Send a streaming chunk.
 
     Only effective after `start_streaming()` returned `StreamingStarted`.
     Silently ignored otherwise.
     """
-
     if _streaming then
       _conn._handler_send_chunk(_token, data)
     end
 
   fun ref finish() =>
     """
-
     End the streaming response.
 
     Sends the terminal chunk and signals completion. Only effective after
     `start_streaming()` returned `StreamingStarted`.
     """
-
     if _streaming then
       _streaming = false
       _conn._handler_finish(_token)
@@ -158,13 +144,11 @@ class ref RequestHandler
 
   fun box param(key: String): String ? =>
     """
-
     Get a route parameter by name.
 
     Errors if the parameter does not exist. Parameter names come from route
     definitions — `:id` in `/users/:id` is accessed as `param("id")`.
     """
-
     _params(key)?
 
   fun box body(): Array[U8] val =>

--- a/hobby/request_interceptor.pony
+++ b/hobby/request_interceptor.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 interface val RequestInterceptor
   """
-
   Synchronous request interceptor that runs before the handler is created.
 
   Interceptors inspect the request and return `InterceptPass` to let it
@@ -15,10 +14,8 @@ interface val RequestInterceptor
   should do only cheap work (header checks, size limits). Expensive or
   async work belongs in the handler.
   """
-
   fun apply(request: stallion.Request box): InterceptResult
     """
-
     Evaluate the request. Return `InterceptPass` to continue to the handler,
     or `InterceptRespond` to short-circuit with a response.
     """

--- a/hobby/response_context.pony
+++ b/hobby/response_context.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 class ref ResponseContext
   """
-
   Context for response interceptors.
 
   Provides read access to the response status, body, streaming state, and the
@@ -14,7 +13,6 @@ class ref ResponseContext
   silently ignored — headers and status are already on the wire, and body
   chunks have already been sent.
   """
-
   let _buf: _BufferedResponse ref
   let _request: stallion.Request val
 
@@ -48,26 +46,22 @@ class ref ResponseContext
 
   fun ref set_status(status': stallion.Status) =>
     """
-
     Replace the response status.
 
     No-op for streaming responses (status already on wire).
     """
-
     if not _buf.is_streaming then
       _buf.status = status'
     end
 
   fun ref set_header(name: String, value: String) =>
     """
-
     Set or replace a response header.
 
     Removes any existing entries with the same name (case-insensitive per
     RFC 7230 section 3.2) and adds a new one with the name lowercased.
     No-op for streaming responses (headers already on wire).
     """
-
     if not _buf.is_streaming then
       let lower_name: String val = name.lower()
       var i: USize = 0
@@ -87,26 +81,22 @@ class ref ResponseContext
 
   fun ref add_header(name: String, value: String) =>
     """
-
     Add a response header without removing existing entries.
 
     The name is lowercased for consistency. Use for multi-value headers like
     `Set-Cookie`. No-op for streaming responses.
     """
-
     if not _buf.is_streaming then
       _buf.headers.push((name.lower(), value))
     end
 
   fun ref set_body(body': ByteSeq) =>
     """
-
     Replace the response body.
 
     Content-Length is recalculated automatically at serialization time.
     No-op for streaming responses (chunks already sent).
     """
-
     if not _buf.is_streaming then
       _buf.body = body'
     end

--- a/hobby/response_interceptor.pony
+++ b/hobby/response_interceptor.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 interface val ResponseInterceptor
   """
-
   Synchronous response interceptor that runs after the handler responds but
   before the response goes to the wire.
 
@@ -19,10 +18,8 @@ interface val ResponseInterceptor
   are already on the wire. The interceptor still runs for logging and
   metrics; check `ctx.is_streaming()` to branch on streaming state.
   """
-
   fun apply(ctx: ResponseContext ref)
     """
-
     Process the response. Inspect or modify status, headers, and body
     via the provided `ResponseContext`.
     """

--- a/hobby/route_group.pony
+++ b/hobby/route_group.pony
@@ -2,7 +2,6 @@ use stallion = "stallion"
 
 class iso RouteGroup
   """
-
   A group of routes sharing a common path prefix and optional interceptors.
 
   Route groups let you factor out repeated prefixes and interceptors instead of
@@ -25,7 +24,6 @@ class iso RouteGroup
   `RouteGroup.group()` when done — this consumes the group and flattens its
   routes.
   """
-
   let _prefix: String
   let _interceptors: (Array[RequestInterceptor val] val | None)
   let _response_interceptors: (Array[ResponseInterceptor val] val | None)
@@ -40,7 +38,6 @@ class iso RouteGroup
       (Array[ResponseInterceptor val] val | None) = None)
   =>
     """
-
     Create a route group with a path prefix and optional interceptors.
 
     The prefix must be a static path segment — no `:param` or `*wildcard`
@@ -50,7 +47,6 @@ class iso RouteGroup
     interceptors. Response interceptors, if provided, run before each
     route's own response interceptors.
     """
-
     _prefix = prefix
     _interceptors = interceptors
     _response_interceptors = response_interceptors
@@ -212,14 +208,12 @@ class iso RouteGroup
 
   fun ref group(inner: RouteGroup iso) =>
     """
-
     Consume a nested route group, flattening its routes into this group.
 
     The inner group's prefix is appended to this group's prefix, and the inner
     group's interceptors are preserved separately for tree building. The inner
     group is consumed — no further registration on it is possible.
     """
-
     (consume inner)
       .> _collect_group_infos(_group_infos, _prefix)
       .> _flatten_routes_into(_routes, _prefix)
@@ -229,14 +223,12 @@ class iso RouteGroup
     outer_prefix: String = "")
   =>
     """
-
     Flatten routes into target, joining paths with outer prefix.
 
     Per-route interceptors are passed through unchanged — no concatenation
     with group interceptors. Group interceptors are handled separately via
     `_collect_group_infos()` and registered on tree nodes.
     """
-
     let full_prefix = _JoinPath(outer_prefix, _prefix)
     for r in _routes.values() do
       let joined_path = _JoinPath(full_prefix, r.path)
@@ -254,13 +246,11 @@ class iso RouteGroup
     outer_prefix: String = "")
   =>
     """
-
     Collect this group's info and any nested group infos into target.
 
     Prefixes are joined through all nesting levels. Only emits a `_GroupInfo`
     if this group has interceptors.
     """
-
     let full_prefix = _JoinPath(outer_prefix, _prefix)
     if (_interceptors isnt None) or (_response_interceptors isnt None) then
       target.push(

--- a/hobby/serve_files.pony
+++ b/hobby/serve_files.pony
@@ -4,7 +4,6 @@ use stallion = "stallion"
 
 class val ServeFiles
   """
-
   Serve files from a directory on disk.
 
   Structurally matches `HandlerFactory` — pass directly to route methods.
@@ -85,7 +84,6 @@ class val ServeFiles
   correct `text/html` content type and caching headers. If no `index.html`
   exists, the directory request returns 404.
   """
-
   let _root: FilePath
   let _chunk_threshold: USize
   let _cache_control: (String | None)
@@ -98,7 +96,6 @@ class val ServeFiles
     content_types: ContentTypes = ContentTypes)
   =>
     """
-
     Create a handler factory that serves files under `root`.
 
     `root` must have `FileLookup`, `FileStat`, and `FileRead` capabilities.
@@ -116,7 +113,6 @@ class val ServeFiles
     If the route uses a wildcard name other than `*filepath`, param lookup
     will fail and the handler will return 500. Always use `*filepath`.
     """
-
     _root = root
     _chunk_threshold = chunk_threshold * 1024
     _cache_control = cache_control

--- a/hobby/server.pony
+++ b/hobby/server.pony
@@ -42,7 +42,6 @@ actor Server is lori.TCPListenerActor
 
   Call `dispose()` to shut down. In-flight connections drain naturally.
   """
-
   var _tcp_listener: lori.TCPListener =
     lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth

--- a/hobby/server_notify.pony
+++ b/hobby/server_notify.pony
@@ -8,7 +8,6 @@ interface tag ServerNotify
 
   Modeled after the notify pattern in ponylang/postgres.
   """
-
   be listening(server: Server, host: String, service: String) =>
     """
     The server is bound and accepting connections.

--- a/hobby/signed_cookie.pony
+++ b/hobby/signed_cookie.pony
@@ -3,20 +3,16 @@ use "encode/base64"
 
 primitive SignedCookie
   """
-
   Signs and verifies cookie values using HMAC-SHA256.
 
   The signed format is `value.base64url(hmac)`. The value is readable
   (not encrypted); the signature proves integrity.
   """
 
-
   fun sign(key: CookieSigningKey, value: String val): String val =>
     """
-
     Sign `value` and return the signed string `value.signature`.
     """
-
     let hmac: Array[U8] val = crypto.HmacSha256(key._bytes(), value)
     let sig: String val =
       Base64.encode_url[String iso](hmac where pad = true)
@@ -33,11 +29,9 @@ primitive SignedCookie
     : (String val | SignedCookieError)
   =>
     """
-
     Verify the signature on `signed_value`. Returns the original value
     on success, or a `SignedCookieError` describing the failure.
     """
-
     let pos: ISize =
       try
         signed_value.rfind(".")?

--- a/hobby/signed_cookie_error.pony
+++ b/hobby/signed_cookie_error.pony
@@ -1,29 +1,24 @@
 primitive MalformedSignedValue
   """
-
   The signed cookie value is structurally invalid: it is missing the `.`
   separator between the value and signature, or the signature portion is
   empty or not valid Base64.
   """
-
 
   fun string(): String iso^ =>
     "malformed signed value".clone()
 
 primitive InvalidSignature
   """
-
   The signature did not match the value. The cookie was tampered with or
   signed with a different key.
   """
-
 
   fun string(): String iso^ =>
     "invalid signature".clone()
 
 type SignedCookieError is (MalformedSignedValue | InvalidSignature)
   """
-
   Errors that can occur when verifying a signed cookie value.
   """
 

--- a/hobby/streaming_started.pony
+++ b/hobby/streaming_started.pony
@@ -1,6 +1,5 @@
 primitive StreamingStarted
   """
-
   Returned by `RequestHandler.start_streaming()` on success.
 
   Indicates that chunked streaming has begun. The handler should proceed to


### PR DESCRIPTION
Removes blank lines after opening `"""` in docstrings across all 68 source files (hobby/ and examples/) to satisfy the new `style/docstring-leading-blank` lint rule. Also fixes 4 `style/blank-lines` violations (missing blank lines between entities/methods).