### PR TITLE
Recover from idle timer subscription failures

### DIFF
--- a/.release-notes/recover-from-idle-timer-failures.md
+++ b/.release-notes/recover-from-idle-timer-failures.md
@@ -1,0 +1,5 @@
+## Recover from idle timer subscription failures
+
+Under sustained kernel resource pressure, the idle timer's ASIO event subscription could fail (for example, `ENOMEM` from `kevent` or `epoll_ctl`). When that happened, the timer was silently cancelled — idle connections stopped being reaped for the rest of that connection's lifetime, letting stale connections accumulate.
+
+The idle timer now automatically re-arms after an ASIO subscription failure using the originally configured duration, so idle-timeout protection resumes on the next ASIO turn. If the re-armed subscription also fails, re-arm attempts continue until one succeeds.

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/stallion.git",
-      "version": "0.6.0"
+      "version": "0.6.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -128,6 +128,12 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
       _server._connection_failed("SSL handshake")
     end
 
+  fun ref on_timer_failure() =>
+    // Hobby does not call `HTTPServer.set_timer()`, so Stallion will never
+    // fire this callback. If this ever fires, a future change has started
+    // using `set_timer()` without wiring up real handling here.
+    _Unreachable()
+
   // --- Request processing ---
   fun ref _process_request(
     request': stallion.Request val,


### PR DESCRIPTION
Bumps Stallion to 0.6.1 so the idle timer auto-rearms after an ASIO subscription failure instead of being silently cancelled.

Stallion 0.6.1 also adds an `on_timer_failure()` callback for user timers created via `HTTPServer.set_timer()`. Hobby does not call `set_timer()`, so the callback can never fire in practice. It is implemented as `_Unreachable()` to enforce that invariant — if a future change starts using `set_timer()` without wiring up real handling, the program will crash loudly with a clear location. Exposing the user-level timer API on `RequestHandler` is tracked separately.