### PR TITLE
Run the breakage test against ponyc main

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
The workflow exists to find out about a ponyc change before it lands in a release, and it posts to Zulip when it fails. It was using the `release` image tag, which is the ponyc `pr.yml` already builds against, so it never built against main and could not tell us anything the PR build had not.

Closes #110