### PR TITLE
Update stallion to 0.9.0 and ssl to 4.0.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,77 @@
+## Fix streaming responses stalling under several conditions
+
+A streaming response could stall and never complete. The callback that tracks when a chunk's bytes reach the operating system fired once per write-queue drain instead of once per chunk, and when the connection closed, pending callbacks were discarded entirely. A handler driving the next chunk from the previous one's completion would stop sending when a callback it waited on never arrived.
+
+Each chunk now gets its own callback, in send order, and callbacks for bytes already delivered to the operating system are no longer discarded when the connection closes.
+
+## Fix a hang when a handler closes the server from a request callback
+
+Calling `server.dispose()` from inside a handler could leave a stray read outstanding on the closed socket. Under connection churn that read could block a scheduler thread and prevent the program from exiting.
+
+## Fix a connection wedging under sustained write backpressure
+
+A connection could permanently stop making progress under sustained write backpressure while the client was still sending. The connection did not recover on its own, staying wedged until something closed it. Most likely on a multi-threaded runtime.
+
+## Fix HTTPS connections receiving more requests after throttling
+
+On an HTTPS connection, `throttled()` did not stop request delivery. Data already decrypted from the same TLS record was parsed, so a handler that had just received `throttled()` could still be handed more requests. Plaintext connections were not affected. HTTPS connections now stop delivering requests as soon as throttling is applied.
+
+## Fix a possible write hang under load
+
+Sending response data could hang the program when the send buffer filled on a descriptor that the operating system had reused for a blocking socket. Fixed on Linux, FreeBSD, OpenBSD, and DragonFly.
+
+## Fix several SSL connection bugs
+
+Fixed multiple bugs affecting SSL connections: handshake failures being reported as authentication failures, data being silently dropped on large writes and when encryption fails, and one connection's SSL failure closing a different connection.
+
+## Send TLS close_notify on graceful close
+
+Closing a TLS connection now sends a `close_notify` alert before the TCP shutdown. Without it, the peer could not distinguish a clean close from a truncated stream.
+
+## SignedCookie.sign() returns a result instead of a plain String
+
+`SignedCookie.sign()` previously returned `String val`. It now returns `(String val | SignedCookieError)` and can return `CryptoFailure` when the HMAC operation fails. The old return type masked a silent failure: the HMAC could produce an all-zero code when the operation failed, yielding a signed cookie with an invalid signature.
+
+```pony
+// Before
+let signed: String val = SignedCookie.sign(key, value)
+
+// After
+match SignedCookie.sign(key, value)
+| let signed: String => // use signed
+| let err: SignedCookieError => // handle failure
+end
+```
+
+`CryptoFailure` is also a new member of `SignedCookieError`, so exhaustive matches on `SignedCookie.verify()` results that list error primitives individually need the new arm:
+
+```pony
+// Before
+match \exhaustive\ SignedCookie.verify(key, raw)
+| let v: String => v
+| InvalidSignature => "bad"
+| MalformedSignedValue => "bad"
+end
+
+// After
+match \exhaustive\ SignedCookie.verify(key, raw)
+| let v: String => v
+| InvalidSignature => "bad"
+| MalformedSignedValue => "bad"
+| CryptoFailure => "bad"
+end
+```
+
+Matches that use `let _: SignedCookieError` are unaffected.
+
+## Require ponyc 0.67.0 or later
+
+The previous minimum was 0.64.0. The write-hang fix depends on a socket call added in ponyc 0.67.0.
+
+## Move to ssl 4.0.0
+
+Hobby now uses ssl 4.0.0, where it used 2.0.1. Hobby's own SSL API is unchanged: pass an `SSLContext val` to `Server.ssl()` exactly as before.
+
+Code that uses `ssl/net` or `ssl/crypto` directly can break. If your application does not declare ssl in its own `corral.json`, it gets 4.0.0 through hobby.
+
+The most common breaks: the twelve protocol-version primitives spell their acronyms in full (`Tls1u2Version` is now `TLS1u2Version`), `SSLContext.alpn_set_resolver` takes a `val` resolver instead of `box`, `SSLState` has a new `SSLDisposed` member that breaks exhaustive matches, and `Digest`/`HmacSha256` now raise on failure. See the ssl 3.0.0 and 4.0.0 changelogs for the full list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix streaming responses stalling under several conditions ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Fix a hang when a handler closes the server from a request callback ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Fix a connection wedging under sustained write backpressure ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Fix HTTPS connections receiving more requests after throttling ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Fix a possible write hang under load ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Fix several SSL connection bugs ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Send TLS close_notify on graceful close ([PR #114](https://github.com/ponylang/hobby/pull/114))
 
 ### Added
 
 
 ### Changed
+
+- SignedCookie.sign() returns a result instead of a plain String ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Require ponyc 0.67.0 or later ([PR #114](https://github.com/ponylang/hobby/pull/114))
+- Move to ssl 4.0.0 ([PR #114](https://github.com/ponylang/hobby/pull/114))
 
 
 ## [0.9.0] - 2026-06-30

--- a/corral.json
+++ b/corral.json
@@ -13,11 +13,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/stallion.git",
-      "version": "0.8.0"
+      "version": "0.9.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.1"
+      "version": "4.0.0"
     }
   ]
 }

--- a/examples/signed-cookie/main.pony
+++ b/examples/signed-cookie/main.pony
@@ -54,7 +54,14 @@ actor Main is hobby.ServerNotify
           let new_count: String val =
             (count + 1).string()
           let signed =
-            hobby.SignedCookie.sign(key, new_count)
+            match \exhaustive\ hobby.SignedCookie.sign(key, new_count)
+            | let s: String => s
+            | let e: hobby.SignedCookieError =>
+              handler.respond(
+                stallion.StatusInternalServerError,
+                "Signing failed")
+              return
+            end
           // Build response headers with signed cookie.
           // Secure=false for localhost testing; use the
           // default (true) in production.

--- a/hobby/_connection.pony
+++ b/hobby/_connection.pony
@@ -298,6 +298,19 @@ actor _Connection is (stallion.HTTPServerActor & _ConnectionProtocol)
       | stallion.AlreadyResponded =>
         // Shouldn't happen — token validated
         None
+      | stallion.ConnectionClosed =>
+        _cancel_timer()
+        match _handler
+        | let h: HandlerReceiver tag => h.dispose()
+        end
+        _handler = None
+        _current_request = None
+        _current_responder = None
+        _current_response_interceptors = None
+        _streaming_status = None
+        _is_head = false
+        _state = _Idle
+        _pending_requests.clear()
       end
     end
 

--- a/hobby/_test_integration.pony
+++ b/hobby/_test_integration.pony
@@ -83,7 +83,7 @@ actor \nodoc\ _TestClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expected) then
@@ -91,6 +91,7 @@ actor \nodoc\ _TestClient is
       _server.dispose()
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 
@@ -585,7 +586,7 @@ actor \nodoc\ _TestHeadClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expect_header) then
@@ -597,6 +598,7 @@ actor \nodoc\ _TestHeadClient is
       _server.dispose()
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 
@@ -861,7 +863,7 @@ actor \nodoc\ _TestTimeoutClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains("504") or
@@ -871,6 +873,7 @@ actor \nodoc\ _TestTimeoutClient is
       _server.dispose()
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 
@@ -966,12 +969,13 @@ actor \nodoc\ _TestStreamTimeoutClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains("stream-timeout-chunk") then
       _got_chunk = true
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _got_chunk then
@@ -1104,7 +1108,9 @@ actor \nodoc\ _DisconnectAfterSendClient is
   be _disconnect_now() =>
     _tcp_connection.close()
 
-  fun ref _on_received(data: Array[U8] iso) => None
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    lori.KeepReading
+
   fun ref _on_closed() => None
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
@@ -1338,7 +1344,7 @@ actor \nodoc\ _TestTimeoutNormalClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains("Hello from Hobby!") then
@@ -1353,6 +1359,7 @@ actor \nodoc\ _TestTimeoutNormalClient is
       _server.dispose()
       _h.complete(false)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 
@@ -1537,7 +1544,7 @@ actor \nodoc\ _TestSSLClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expected) then
@@ -1545,6 +1552,7 @@ actor \nodoc\ _TestSSLClient is
       _server.dispose()
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 
@@ -1735,9 +1743,8 @@ actor \nodoc\ _PlainTCPThenSSLClient is
     _tcp_connection.send(
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    // SSL listener will likely close us — ignore data
-    None
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    lori.KeepReading
 
   fun ref _on_closed() =>
     // Plain connection was closed (expected). Now connect
@@ -1879,8 +1886,8 @@ actor \nodoc\ _PlainTCPClient is
     _tcp_connection.send(
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
-    None
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    lori.KeepReading
 
   fun ref _on_closed() =>
     _notify.plain_client_done()

--- a/hobby/_test_response_interceptor.pony
+++ b/hobby/_test_response_interceptor.pony
@@ -579,7 +579,7 @@ actor \nodoc\ _TestStreamingNoOpClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expect) then
@@ -591,6 +591,7 @@ actor \nodoc\ _TestStreamingNoOpClient is
       _server.dispose()
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 

--- a/hobby/_test_serve_files.pony
+++ b/hobby/_test_serve_files.pony
@@ -629,7 +629,7 @@ actor \nodoc\ _TestNoCacheControlClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let response_str: String val = _response.clone()
     if response_str.contains(_expected) then
@@ -641,6 +641,7 @@ actor \nodoc\ _TestNoCacheControlClient is
       _server.dispose()
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_closed() => None
 

--- a/hobby/_test_signed_cookie.pony
+++ b/hobby/_test_signed_cookie.pony
@@ -30,7 +30,11 @@ class \nodoc\ iso _TestSignedCookieRoundTrip is UnitTest
   fun apply(h: TestHelper) ? =>
     let key = CookieSigningKey.generate()?
     let value = "user=alice"
-    let signed = SignedCookie.sign(key, value)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, value)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     match \exhaustive\ SignedCookie.verify(key, signed)
     | let v: String => h.assert_eq[String](value, v)
     | let e: SignedCookieError => h.fail(e.string())
@@ -41,7 +45,11 @@ class \nodoc\ iso _TestSignedCookieTamperedValue is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let key = CookieSigningKey.generate()?
-    let signed = SignedCookie.sign(key, "user=alice")
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, "user=alice")
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     // Replace "alice" with "mallory"
     let sig_part = signed.trim(signed.rfind(".")?.usize())
     let tampered =
@@ -54,6 +62,7 @@ class \nodoc\ iso _TestSignedCookieTamperedValue is UnitTest
     | let _: String => h.fail("accepted tampered value")
     | InvalidSignature => None
     | MalformedSignedValue => h.fail("wrong error type")
+    | CryptoFailure => h.fail("crypto failure")
     end
 
 class \nodoc\ iso _TestSignedCookieTamperedSig is UnitTest
@@ -61,7 +70,11 @@ class \nodoc\ iso _TestSignedCookieTamperedSig is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let key = CookieSigningKey.generate()?
-    let signed = SignedCookie.sign(key, "user=alice")
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, "user=alice")
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     let pos = signed.rfind(".")?.usize()
     let value = signed.trim(0, pos)
     // Replace the signature with a different valid Base64 string
@@ -76,6 +89,7 @@ class \nodoc\ iso _TestSignedCookieTamperedSig is UnitTest
     | let _: String => h.fail("accepted tampered signature")
     | InvalidSignature => None
     | MalformedSignedValue => h.fail("wrong error type")
+    | CryptoFailure => h.fail("crypto failure")
     end
 
 class \nodoc\ iso _TestSignedCookieNoSeparator is UnitTest
@@ -90,6 +104,7 @@ class \nodoc\ iso _TestSignedCookieNoSeparator is UnitTest
     | let _: String => h.fail("accepted value without separator")
     | MalformedSignedValue => None
     | InvalidSignature => h.fail("wrong error type")
+    | CryptoFailure => h.fail("crypto failure")
     end
 
 class \nodoc\ iso _TestSignedCookieEmptySig is UnitTest
@@ -104,6 +119,7 @@ class \nodoc\ iso _TestSignedCookieEmptySig is UnitTest
     | let _: String => h.fail("accepted empty signature")
     | MalformedSignedValue => None
     | InvalidSignature => h.fail("wrong error type")
+    | CryptoFailure => h.fail("crypto failure")
     end
 
 class \nodoc\ iso _TestSignedCookieWrongKey is UnitTest
@@ -116,11 +132,16 @@ class \nodoc\ iso _TestSignedCookieWrongKey is UnitTest
       else
         h.fail("key generation failed"); return
       end
-    let signed = SignedCookie.sign(key1, "secret")
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key1, "secret")
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     match \exhaustive\ SignedCookie.verify(key2, signed)
     | let _: String => h.fail("accepted wrong key")
     | InvalidSignature => None
     | MalformedSignedValue => h.fail("wrong error type")
+    | CryptoFailure => h.fail("crypto failure")
     end
 
 class \nodoc\ iso _TestSignedCookieValueWithDots is UnitTest
@@ -132,7 +153,11 @@ class \nodoc\ iso _TestSignedCookieValueWithDots is UnitTest
       else h.fail("key generation failed"); return
       end
     let value = "a.b.c.d"
-    let signed = SignedCookie.sign(key, value)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, value)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     match \exhaustive\ SignedCookie.verify(key, signed)
     | let v: String => h.assert_eq[String](value, v)
     | let e: SignedCookieError => h.fail(e.string())
@@ -147,7 +172,11 @@ class \nodoc\ iso _TestSignedCookieEmptyValue is UnitTest
       else h.fail("key generation failed"); return
       end
     let value = ""
-    let signed = SignedCookie.sign(key, value)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, value)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     match \exhaustive\ SignedCookie.verify(key, signed)
     | let v: String => h.assert_eq[String](value, v)
     | let e: SignedCookieError => h.fail(e.string())
@@ -165,6 +194,7 @@ class \nodoc\ iso _TestSignedCookieInvalidBase64 is UnitTest
     | let _: String => h.fail("accepted invalid base64")
     | MalformedSignedValue => None
     | InvalidSignature => h.fail("wrong error type")
+    | CryptoFailure => h.fail("crypto failure")
     end
 
 class \nodoc\ iso _TestSignedCookieKeyBoundary is UnitTest
@@ -199,7 +229,7 @@ class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
 
   fun name(): String => "SignedCookie/rfc-4231-vector"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     // RFC 4231 Test Case 2 key: "Jefe" (4 bytes) — too short for
     // CookieSigningKey, so test the HMAC primitive directly.
     let key: Array[U8] val = [as U8: 0x4a; 0x65; 0x66; 0x65]
@@ -211,7 +241,7 @@ class \nodoc\ iso _TestSignedCookieRfc4231Vector is UnitTest
         0x5a; 0x00; 0x3f; 0x08; 0x9d; 0x27; 0x39; 0x83
         0x9d; 0xec; 0x58; 0xb9; 0x64; 0xec; 0x38; 0x43
       ]
-    let actual = crypto.HmacSha256(key, data)
+    let actual = crypto.HmacSha256(key, data)?
     h.assert_eq[USize](32, actual.size())
     h.assert_true(
       crypto.ConstantTimeCompare(expected, actual),
@@ -246,7 +276,11 @@ class \nodoc\ iso _TestSignedCookieCrossLanguageVector is UnitTest
     let key = CookieSigningKey(key_bytes)?
 
     let expected = "hello.7GT0SrIsQCeVHsMIKW5wg_p2huSb8nTFCUeO-QsJ_Ak="
-    let signed = SignedCookie.sign(key, "hello")
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, "hello")
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     h.assert_eq[String](expected, signed)
 
     match \exhaustive\ SignedCookie.verify(key, signed)
@@ -269,7 +303,11 @@ class \nodoc\ iso _PropSignedCookieRoundTrip is Property1[String]
       try CookieSigningKey.generate()?
       else h.fail("key generation failed"); return
       end
-    let signed = SignedCookie.sign(key, sample)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, sample)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     match \exhaustive\ SignedCookie.verify(key, signed)
     | let v: String => h.assert_eq[String](sample, v)
     | let e: SignedCookieError => h.fail(e.string())
@@ -290,8 +328,16 @@ class \nodoc\ iso _PropSignedCookieDeterministic is Property1[String]
       try CookieSigningKey.generate()?
       else h.fail("key generation failed"); return
       end
-    let a = SignedCookie.sign(key, sample)
-    let b = SignedCookie.sign(key, sample)
+    let a =
+      match \exhaustive\ SignedCookie.sign(key, sample)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
+    let b =
+      match \exhaustive\ SignedCookie.sign(key, sample)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     h.assert_eq[String](a, b)
 
 class \nodoc\ iso _PropSignedCookieTamperDetection is
@@ -314,7 +360,11 @@ class \nodoc\ iso _PropSignedCookieTamperDetection is
       try CookieSigningKey.generate()?
       else h.fail("key generation failed"); return
       end
-    let signed = SignedCookie.sign(key, value)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, value)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
 
     if signed.size() == 0 then return end
     let flip_pos = flip_hint % signed.size()
@@ -355,7 +405,11 @@ class \nodoc\ iso _PropSignedCookieKeyIndependence is Property1[String]
       else
         h.fail("key generation failed"); return
       end
-    let signed = SignedCookie.sign(key1, sample)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key1, sample)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     match \exhaustive\ SignedCookie.verify(key2, signed)
     | let _: String => h.fail("different key accepted")
     | let _: SignedCookieError => None
@@ -379,7 +433,11 @@ class \nodoc\ iso _PropSignedCookieCookieOctetValidity is Property1[String]
       try CookieSigningKey.generate()?
       else h.fail("key generation failed"); return
       end
-    let signed = SignedCookie.sign(key, sample)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, sample)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     // Check only the dot separator and signature, not the user-supplied value
     let pos =
       try signed.rfind(".")?.usize()
@@ -419,7 +477,11 @@ class \nodoc\ iso _PropSignedCookieSignatureLength is Property1[String]
       try CookieSigningKey.generate()?
       else h.fail("key generation failed"); return
       end
-    let signed = SignedCookie.sign(key, sample)
+    let signed =
+      match \exhaustive\ SignedCookie.sign(key, sample)
+      | let s: String => s
+      | let e: SignedCookieError => h.fail(e.string()); return
+      end
     let pos =
       try signed.rfind(".")?.usize()
       else h.fail("no separator in signed output"); return

--- a/hobby/hobby.pony
+++ b/hobby/hobby.pony
@@ -309,7 +309,8 @@ resolves to a directory, `ServeFiles` automatically serves `index.html`.
 Users import up to five packages:
 
 - **`hobby`**: Application, BodyNotNeeded, BuildResult, BuiltApplication,
-  ConfigError, ContentTypes, CookieSigningKey, DefaultHandlerTimeout,
+  ConfigError, ContentTypes, CookieSigningKey, CryptoFailure,
+  DefaultHandlerTimeout,
   HandlerContext, HandlerFactory, HandlerReceiver, HandlerTimeout,
   HandlerTimeoutValidator, InterceptPass, InterceptRespond, InterceptResult,
   InvalidSignature, MakeHandlerTimeout, MalformedSignedValue,

--- a/hobby/signed_cookie.pony
+++ b/hobby/signed_cookie.pony
@@ -9,11 +9,20 @@ primitive SignedCookie
   (not encrypted); the signature proves integrity.
   """
 
-  fun sign(key: CookieSigningKey, value: String val): String val =>
+  fun sign(key: CookieSigningKey, value: String val)
+    : (String val | SignedCookieError)
+  =>
     """
     Sign `value` and return the signed string `value.signature`.
+
+    Returns `CryptoFailure` if the HMAC operation fails.
     """
-    let hmac: Array[U8] val = crypto.HmacSha256(key._bytes(), value)
+    let hmac: Array[U8] val =
+      try
+        crypto.HmacSha256(key._bytes(), value)?
+      else
+        return CryptoFailure
+      end
     let sig: String val =
       Base64.encode_url[String iso](hmac where pad = true)
     recover val
@@ -53,7 +62,12 @@ primitive SignedCookie
         return MalformedSignedValue
       end
 
-    let expected: Array[U8] val = crypto.HmacSha256(key._bytes(), value)
+    let expected: Array[U8] val =
+      try
+        crypto.HmacSha256(key._bytes(), value)?
+      else
+        return CryptoFailure
+      end
 
     if crypto.ConstantTimeCompare(expected, decoded) then
       value

--- a/hobby/signed_cookie_error.pony
+++ b/hobby/signed_cookie_error.pony
@@ -17,8 +17,18 @@ primitive InvalidSignature
   fun string(): String iso^ =>
     "invalid signature".clone()
 
-type SignedCookieError is (MalformedSignedValue | InvalidSignature)
+primitive CryptoFailure
   """
-  Errors that can occur when verifying a signed cookie value.
+  The underlying HMAC operation failed — an extremely rare condition
+  caused by a broken or misconfigured OpenSSL installation.
+  """
+
+  fun string(): String iso^ =>
+    "crypto failure".clone()
+
+type SignedCookieError is
+  (MalformedSignedValue | InvalidSignature | CryptoFailure)
+  """
+  Errors from signing or verifying a signed cookie value.
   """
 


### PR DESCRIPTION
Updates stallion to 0.9.0 and ssl to 4.0.0 (which pulls in lori 0.18.1 transitively).

Stallion 0.9.0 brings fixes for streaming stalls, connection hangs, backpressure wedging, HTTPS throttling, write hangs, and SSL connection bugs, plus TLS close_notify on graceful close. It also adds `ConnectionClosed` to `StartChunkedResponseResult`, which hobby now handles with full cleanup.

ssl 4.0.0 makes `HmacSha256` partial. Rather than swallowing the error, `sign()` now returns `(String val | SignedCookieError)` with a new `CryptoFailure` error primitive, matching the pattern `verify()` already uses.

Lori 0.18.1 changes `_on_received` to return `ReadAction` — all test clients updated.

Minimum ponyc bumped from 0.64.0 to 0.67.0 (required by stallion's write-hang fix).
